### PR TITLE
Improvements to timer logic.

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IViewProperties.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IViewProperties.cs
@@ -39,6 +39,7 @@ namespace Silk.NET.Windowing
         /// <summary>
         /// The number of rendering operations to run every second.
         /// </summary>
+        /// <remarks>This value is ignored if <see cref="VSync">VSync</see> is set to <see langref="true"/>.</remarks>
         double FramesPerSecond { get; set; }
 
         /// <summary>
@@ -54,6 +55,8 @@ namespace Silk.NET.Windowing
         /// <summary>
         /// Whether or not VSync is enabled for this view.
         /// </summary>
+        /// <remarks>This value will set the SwapInterval for OpenGL, but on other frameworks (e.g. Vulkan) you will need to turn on
+        /// VSync manually.  Whilst <see langref="true"/>, the value of <see cref="FramesPerSecond"/> is ignored, to prevent frame skipping.</remarks>
         bool VSync { get; set; }
 
         /// <summary>

--- a/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
@@ -165,13 +165,14 @@ namespace Silk.NET.Windowing.Internals
                     _swapIntervalChanged = false;
                 }
 
-                Render?.Invoke(_renderStopwatch.Elapsed.TotalSeconds);
+                delta = _renderStopwatch.Elapsed.TotalSeconds;
+                _renderStopwatch.Restart();
+                Render?.Invoke(delta);
+
                 if (ShouldSwapAutomatically)
                 {
                     GLContext?.SwapBuffers();
                 }
-
-                _renderStopwatch.Restart();
             }
         }
 
@@ -180,8 +181,8 @@ namespace Silk.NET.Windowing.Internals
             var delta = _updateStopwatch.Elapsed.TotalSeconds;
             if (delta >= _updatePeriod)
             {
-                Update?.Invoke(_updateStopwatch.Elapsed.TotalSeconds);
                 _updateStopwatch.Restart();
+                Update?.Invoke(delta);
             }
         }
 

--- a/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
@@ -150,7 +150,7 @@ namespace Silk.NET.Windowing.Internals
         {
             DoInvokes();
             // Check elapsed time
-            if (((Stopwatch.GetTimestamp() - _renderTimestamp) >= _renderPeriod) || VSync)
+            if (VSync || ((Stopwatch.GetTimestamp() - _renderTimestamp) >= _renderPeriod))
             {
                 if (!(GLContext is null) && !GLContext.IsCurrent)
                 {

--- a/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
@@ -164,9 +164,9 @@ namespace Silk.NET.Windowing.Internals
                 }
 
                 // Re-calculte the elapsed time, resetting the current timestamp
-                var newTimeStamp = Stopwatch.GetTimestamp();
-                var delta = (newTimeStamp - _renderTimestamp) / Frequency;
-                _renderTimestamp = newTimeStamp;
+                var newTimestamp = Stopwatch.GetTimestamp();
+                var delta = (newTimestamp - _renderTimestamp) / Frequency;
+                _renderTimestamp = newTimestamp;
                 Render?.Invoke(delta);
 
                 if (ShouldSwapAutomatically)
@@ -179,12 +179,12 @@ namespace Silk.NET.Windowing.Internals
         public void DoUpdate()
         {
             // Check elapsed time
-            var newTimeStamp = Stopwatch.GetTimestamp();
-            if ((newTimeStamp - _updateTimestamp) >= _updatePeriod)
+            var newTimestamp = Stopwatch.GetTimestamp();
+            if ((newTimestamp - _updateTimestamp) >= _updatePeriod)
             {
                 // Re-calculte the elapsed time, resetting the current timestamp
-                var delta = (newTimeStamp - _updateTimestamp) / Frequency;
-                _updateTimestamp = newTimeStamp;
+                var delta = (newTimestamp - _updateTimestamp) / Frequency;
+                _updateTimestamp = newTimestamp;
                 Update?.Invoke(delta);
             }
         }

--- a/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
@@ -124,7 +124,7 @@ namespace Silk.NET.Windowing.Internals
 
         public double UpdatesPerSecond
         {
-            get => _updatePeriod < 1 ? 0 : Frequency / _renderPeriod;
+            get => _updatePeriod < 1 ? 0 : Frequency / _updatePeriod;
             set => _updatePeriod = value <= double.Epsilon ? 0 : (long) (Frequency / value);
         }
 

--- a/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
@@ -164,7 +164,10 @@ namespace Silk.NET.Windowing.Internals
                 }
 
                 // Re-calculte the elapsed time, resetting the current timestamp
-                Render?.Invoke((-Interlocked.Exchange(ref _renderTimestamp, Stopwatch.GetTimestamp()) + _renderTimestamp) / Frequency);
+                var newTimeStamp = Stopwatch.GetTimestamp();
+                var delta = (newTimeStamp - _renderTimestamp) / Frequency;
+                _renderTimestamp = newTimeStamp;
+                Render?.Invoke(delta);
 
                 if (ShouldSwapAutomatically)
                 {
@@ -176,10 +179,13 @@ namespace Silk.NET.Windowing.Internals
         public void DoUpdate()
         {
             // Check elapsed time
-            if ((Stopwatch.GetTimestamp() - _updateTimestamp) >= _updatePeriod)
+            var newTimeStamp = Stopwatch.GetTimestamp();
+            if ((newTimeStamp - _updateTimestamp) >= _updatePeriod)
             {
                 // Re-calculte the elapsed time, resetting the current timestamp
-                Update?.Invoke((-Interlocked.Exchange(ref _updateTimestamp, Stopwatch.GetTimestamp()) + _updateTimestamp) / Frequency);
+                var delta = (newTimeStamp - _updateTimestamp) / Frequency;
+                _updateTimestamp = newTimeStamp;
+                Update?.Invoke(delta);
             }
         }
 


### PR DESCRIPTION
# Summary of the PR
This is a minor improvement to the timer logic on view, following a discussion of #395, and utilises the underlying system timestamps more efficiently.

# Related issues, Discord discussions, or proposals
This was discussed on discord.

The initial timer check is now reduced to simple `long` arithmetic for optimum speed with a single call to `Stopwatch.GetTimestamp()`, as this can be called repeatedly.  When calculating the elapsed seconds as a `double` the timestamp is retrieved once again as well as 'restarting the clock' immediately before invoking the user code, giving the most accurate (and non-drifting) time delta.
