### PR TITLE
Check for sdl errors only when failed

### DIFF
--- a/src/Windowing/Silk.NET.SDL/SdlContext.cs
+++ b/src/Windowing/Silk.NET.SDL/SdlContext.cs
@@ -66,12 +66,17 @@ namespace Silk.NET.SDL
         {
             foreach (var (attribute, value) in attributes)
             {
-                _sdl.GLSetAttribute(attribute, value);
-                _sdl.ThrowError();
+                if (_sdl.GLSetAttribute(attribute, value) != 0)
+                {
+                    _sdl.ThrowError();
+                }
             }
 
             _ctx = _sdl.GLCreateContext(Window);
-            _sdl.ThrowError();
+            if (_ctx == null)
+            {
+                _sdl.ThrowError();
+            }
         }
 
         private void AssertCreated()

--- a/src/Windowing/Silk.NET.SDL/SdlNativeWindow.cs
+++ b/src/Windowing/Silk.NET.SDL/SdlNativeWindow.cs
@@ -13,6 +13,7 @@ namespace Silk.NET.SDL
             Kind = NativeWindowFlags.Sdl;
             Sdl = (nint) window;
             SysWMInfo info;
+            api.GetVersion(&info.Version);
             api.GetWindowWMInfo(window, &info);
             // ReSharper disable once SwitchStatementHandlesSomeKnownEnumValuesWithDefault
             switch (info.Subsystem)

--- a/src/Windowing/Silk.NET.SDL/SdlProvider.cs
+++ b/src/Windowing/Silk.NET.SDL/SdlProvider.cs
@@ -48,8 +48,10 @@ namespace Silk.NET.SDL
             #if DEBUG
             Console.WriteLine("SDL initialized.");
             #endif
-            sdl.Init(InitFlags);
-            sdl.ThrowError();
+            if (sdl.Init(InitFlags) != 0)
+            {
+                sdl.ThrowError();
+            }
 
             return sdl;
         }

--- a/src/Windowing/Silk.NET.Windowing.Sdl/SdlView.cs
+++ b/src/Windowing/Silk.NET.Windowing.Sdl/SdlView.cs
@@ -154,7 +154,10 @@ namespace Silk.NET.Windowing.Sdl
                 h ?? 720,
                 (uint) flags
             );
-            Sdl.ThrowError();
+            if (SdlWindow == null)
+            {
+                Sdl.ThrowError();
+            }
             
             sharedContext?.MakeCurrent();
             (GLContext as SdlContext)?.Create

--- a/src/Windowing/Silk.NET.Windowing.Sdl/SdlWindowing.cs
+++ b/src/Windowing/Silk.NET.Windowing.Sdl/SdlWindowing.cs
@@ -58,6 +58,7 @@ namespace Silk.NET.Windowing.Sdl
             if (view is SdlView sdlView)
             {
                 SysWMInfo ret;
+                sdlView.Sdl.GetVersion(&ret.Version);
                 if (sdlView.Sdl.GetWindowWMInfo(sdlView.SdlWindow, &ret))
                 {
                     return ret;


### PR DESCRIPTION
# Summary of the PR
Only call:
https://github.com/dotnet/Silk.NET/blob/3bd07365dde27da14d64e7f1db8fc3797a55ec4a/src/Windowing/Silk.NET.SDL/SDL.cs#L898
When preceding call reports failure(when possible).

# Further Comments
This PR fixes:
`Silk.NET.SDL.SdlException: Failed loading udev_device_get_action: /home/dinolek/Desktop/Silk.NET/src/Lab/VulkanTriangle/bin/Debug/netcoreapp3.1/runtimes/linux-x64/native/libSDL2-2.0.so: undefined symbol: _udev_device_get_action`