### PR TITLE
apply deadzone to sdl gamepad

### DIFF
--- a/src/Input/Silk.NET.Input.Sdl/SdlGamepad.cs
+++ b/src/Input/Silk.NET.Input.Sdl/SdlGamepad.cs
@@ -80,7 +80,10 @@ namespace Silk.NET.Input.Sdl
                                 Deadzone.Apply((float) @event.Caxis.Value / short.MaxValue), 
                                 Deadzone.Apply(_thumbsticks[0].Y));
 
-                            if(thumbstick0.X != _thumbsticks[0].X) _thumbsticksChanged[0] = true;
+                            if (thumbstick0.X != _thumbsticks[0].X)
+                            {
+                                _thumbsticksChanged[0] = true;
+                            }
                             _thumbsticks[0] = thumbstick0;
                             break;
                         }
@@ -90,7 +93,10 @@ namespace Silk.NET.Input.Sdl
                                 Deadzone.Apply(_thumbsticks[0].X),
                                 Deadzone.Apply((float) @event.Caxis.Value / short.MaxValue));
 
-                            if (thumbstick0.Y != _thumbsticks[0].Y) _thumbsticksChanged[0] = true;
+                            if (thumbstick0.Y != _thumbsticks[0].Y)
+                            {
+                                _thumbsticksChanged[0] = true;
+                            }
                             _thumbsticks[0] = thumbstick0;
                             break;
                         }
@@ -100,7 +106,10 @@ namespace Silk.NET.Input.Sdl
                                 Deadzone.Apply((float) @event.Caxis.Value / short.MaxValue),
                                 Deadzone.Apply(_thumbsticks[1].Y));
 
-                            if (thumbstick1.X != _thumbsticks[1].X) _thumbsticksChanged[1] = true;
+                            if (thumbstick1.X != _thumbsticks[1].X)
+                            {
+                                _thumbsticksChanged[1] = true;
+                            }
                             _thumbsticks[1] = thumbstick1;
                             break;
                         }
@@ -110,7 +119,10 @@ namespace Silk.NET.Input.Sdl
                                 Deadzone.Apply(_thumbsticks[1].X),
                                 Deadzone.Apply((float) @event.Caxis.Value / short.MaxValue));
 
-                            if (thumbstick1.Y != _thumbsticks[1].Y) _thumbsticksChanged[1] = true;
+                            if (thumbstick1.Y != _thumbsticks[1].Y)
+                            {
+                                _thumbsticksChanged[1] = true;
+                            }
                             _thumbsticks[1] = thumbstick1;
                             break;
                         }

--- a/src/Input/Silk.NET.Input.Sdl/SdlGamepad.cs
+++ b/src/Input/Silk.NET.Input.Sdl/SdlGamepad.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Silk.NET.SDL;
 
@@ -76,30 +76,42 @@ namespace Silk.NET.Input.Sdl
                     {
                         case GameControllerAxis.ControllerAxisLeftx:
                         {
-                            _thumbsticksChanged[0] = true;
-                            _thumbsticks[0] = new Thumbstick
-                                (0, (float) @event.Caxis.Value / short.MaxValue, _thumbsticks[0].Y);
+                            var thumbstick0 = new Thumbstick(0, 
+                                Deadzone.Apply((float) @event.Caxis.Value / short.MaxValue), 
+                                Deadzone.Apply(_thumbsticks[0].Y));
+
+                            if(thumbstick0.X != _thumbsticks[0].X) _thumbsticksChanged[0] = true;
+                            _thumbsticks[0] = thumbstick0;
                             break;
                         }
                         case GameControllerAxis.ControllerAxisLefty:
                         {
-                            _thumbsticksChanged[0] = true;
-                            _thumbsticks[0] = new Thumbstick
-                                (0, _thumbsticks[0].X, (float) @event.Caxis.Value / short.MaxValue);
+                            var thumbstick0 = new Thumbstick(0,
+                                Deadzone.Apply(_thumbsticks[0].X),
+                                Deadzone.Apply((float) @event.Caxis.Value / short.MaxValue));
+
+                            if (thumbstick0.Y != _thumbsticks[0].Y) _thumbsticksChanged[0] = true;
+                            _thumbsticks[0] = thumbstick0;
                             break;
                         }
                         case GameControllerAxis.ControllerAxisRightx:
                         {
-                            _thumbsticksChanged[1] = true;
-                            _thumbsticks[1] = new Thumbstick
-                                (1, (float) @event.Caxis.Value / short.MaxValue, _thumbsticks[1].Y);
+                            var thumbstick1 = new Thumbstick(1,
+                                Deadzone.Apply((float) @event.Caxis.Value / short.MaxValue),
+                                Deadzone.Apply(_thumbsticks[1].Y));
+
+                            if (thumbstick1.X != _thumbsticks[1].X) _thumbsticksChanged[1] = true;
+                            _thumbsticks[1] = thumbstick1;
                             break;
                         }
                         case GameControllerAxis.ControllerAxisRighty:
                         {
-                            _thumbsticksChanged[1] = true;
-                            _thumbsticks[1] = new Thumbstick
-                                (1, _thumbsticks[1].X, (float) @event.Caxis.Value / short.MaxValue);
+                            var thumbstick1 = new Thumbstick(1,
+                                Deadzone.Apply(_thumbsticks[1].X),
+                                Deadzone.Apply((float) @event.Caxis.Value / short.MaxValue));
+
+                            if (thumbstick1.Y != _thumbsticks[1].Y) _thumbsticksChanged[1] = true;
+                            _thumbsticks[1] = thumbstick1;
                             break;
                         }
                         case GameControllerAxis.ControllerAxisTriggerleft:


### PR DESCRIPTION
# Summary of the PR

## Purpose
Support the deadzone feature in Silk.NET.Input.Sdl
Specifically, application of the Deadzone object to SdlGamepad

## Background
SdlGamepad has a Deadzone object, however the deadzone is not applied in SdlGamepad DoEvent method.
This prevents the SdlGamepad DoEvent method from filtering out superfluous ThumbstickMoved events on idle.
This may also cause unwanted thumbstick drift.

## Considerations
~**This fix is untested!**~
~Due to environmental factors and my general unfamiliarity with the project dependency tree, I was unable to run this fix to verify its suitability. It does, however, compile.~
Edit: Testing done after creating sister PR here: https://github.com/dotnet/Silk.NET/pull/452

## Assumptions made
1) I have made the assumption the SdlGamepad._thumbsticks array is not modified elsewhere, since it is private. This means that it should now always hold a value with the deadzone applied.

2) I have assumed the ThumbstickMoved event is driven directly off the _thumbsticksChanged bool array, and that it is correct to compare the previous state (with deadzone applied) to the current state (with deadzone applied) and only trigger the Thumbstick moved event if they are not equal.
