### PR TITLE
Hotfix/tutorial tweaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'src/**/*'
       - 'build/nuke/*'
+      - 'examples/**/*'
     branches:
       - 'main'
       - 'release/*'
@@ -12,6 +13,7 @@ on:
     paths:
       - 'src/**/*'
       - 'build/nuke/*'
+      - 'examples/**/*'
 
 jobs:
   Build:

--- a/examples/CSharp/Tutorial 1.3 - Abstractions/Shader.cs
+++ b/examples/CSharp/Tutorial 1.3 - Abstractions/Shader.cs
@@ -73,7 +73,7 @@ namespace Tutorial
 
         private uint LoadShader(ShaderType type, string path)
         {
-            //To load a single shader we need to load
+            //To load a single shader we need to:
             //1) Load the shader from a file.
             //2) Create the handle.
             //3) Upload the source to opengl.

--- a/examples/CSharp/Tutorial 1.3 - Abstractions/Shader.cs
+++ b/examples/CSharp/Tutorial 1.3 - Abstractions/Shader.cs
@@ -52,7 +52,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -63,7 +62,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 

--- a/examples/CSharp/Tutorial 1.3 - Abstractions/shader.frag
+++ b/examples/CSharp/Tutorial 1.3 - Abstractions/shader.frag
@@ -1,7 +1,7 @@
 //Specifying the version like in our vertex shader.
 #version 330 core
 //The input variables, again prefixed with an f as they are the input variables of our fragment shader.
-//These have to share name for now even tho there is a way around this later on.
+//These have to share name for now even though there is a way around this later on.
 in vec4 fColor;
   
 //The output of our fragment shader, this just has to be a vec3 or a vec4, containing the color information about

--- a/examples/CSharp/Tutorial 1.3 - Abstractions/shader.vert
+++ b/examples/CSharp/Tutorial 1.3 - Abstractions/shader.vert
@@ -2,20 +2,20 @@
 #version 330 core
 //These lines specify the location and type of our attributes,
 //the attributes here are prefixed with a "v" as they are our inputs to the vertex shader
-//this isnt strictly necessary tho, but a good habbit.
+//this isn't strictly necessary though, but a good habit.
 layout (location = 0) in vec3 vPos;
 layout (location = 1) in vec4 vColor;
 
 //This is how we declare a uniform, they can be used in all our shaders and share the same name.
-//This is prefixed with a u as its our uniform.
+//This is prefixed with a u as it's our uniform.
 uniform float uBlue;
 
-//This is our output variables, notice that this is prefixed with an f as its the input of our fragment shader.
+//This is our output variable, notice that this is prefixed with an f as it's the input of our fragment shader.
 out vec4 fColor;
 
 void main()
 {
-    //gl_Position, is a builting variable on all vertex shaders that will specify the position of our vertex.
+    //gl_Position, is a built-in variable on all vertex shaders that will specify the position of our vertex.
     gl_Position = vec4(vPos, 1.0);
     //The rest of this code looks like plain old c (almost c#)
     vec4 color = vec4(vColor.rb / 2, uBlue, vColor.a); //Swizzling and constructors in glsl.

--- a/examples/CSharp/Tutorial 1.4 - Textures/Shader.cs
+++ b/examples/CSharp/Tutorial 1.4 - Textures/Shader.cs
@@ -42,7 +42,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -53,7 +52,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 

--- a/examples/CSharp/Tutorial 1.4 - Textures/Texture.cs
+++ b/examples/CSharp/Tutorial 1.4 - Textures/Texture.cs
@@ -17,7 +17,7 @@ namespace Tutorial
             //Loading an image using imagesharp.
             Image<Rgba32> img = (Image<Rgba32>) Image.Load(path);
             //We need to flip our image as image sharps coordinates has origin (0, 0) in the top-left corner,
-            //where as openGL has origin in the bottom-left corner.
+            //whereas openGL has origin in the bottom-left corner.
             img.Mutate(x => x.Flip(FlipMode.Vertical));
 
             fixed (void* data = &MemoryMarshal.GetReference(img.GetPixelRowSpan(0)))

--- a/examples/CSharp/Tutorial 1.5 - Transformations/Program.cs
+++ b/examples/CSharp/Tutorial 1.5 - Transformations/Program.cs
@@ -72,7 +72,7 @@ namespace Tutorial
 
             Texture = new Texture(Gl, "silk.png");
 
-            //Unlike in the transformation, because of our abstraction order dosent matter here.
+            //Unlike in the transformation, because of our abstraction, order doesn't matter here.
             //Translation.
             Transforms[0] = new Transform();
             Transforms[0].Position = new Vector3(0.5f, 0.5f, 0f);

--- a/examples/CSharp/Tutorial 1.5 - Transformations/Shader.cs
+++ b/examples/CSharp/Tutorial 1.5 - Transformations/Shader.cs
@@ -43,7 +43,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -55,7 +54,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.UniformMatrix4(location, 1, false, (float*) &value);
         }
 
@@ -66,7 +64,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 

--- a/examples/CSharp/Tutorial 1.5 - Transformations/Transform.cs
+++ b/examples/CSharp/Tutorial 1.5 - Transformations/Transform.cs
@@ -6,7 +6,7 @@ namespace Tutorial
     {
         //A transform abstraction.
         //For a transform we need to have a position a scale and a rotation,
-        //depending on what application you are creating the type for these may vary.
+        //depending on what application you are creating, the type for these may vary.
 
         //Here we have chosen a vec3 for position, float for scale and quaternion for rotation,
         //as that is the most normal to go with.

--- a/examples/CSharp/Tutorial 2.1 - Co-ordinate Systems/Program.cs
+++ b/examples/CSharp/Tutorial 2.1 - Co-ordinate Systems/Program.cs
@@ -21,7 +21,7 @@ namespace Tutorial
         private static Texture Texture;
         private static Shader Shader;
 
-        //Setup the cameras location, and relative up and right directions
+        //Setup the camera's location, and relative up and right directions
         private static Vector3 CameraPosition = new Vector3(0.0f, 0.0f, 3.0f);
         private static Vector3 CameraTarget = Vector3.Zero;
         private static Vector3 CameraDirection = Vector3.Normalize(CameraPosition - CameraTarget);

--- a/examples/CSharp/Tutorial 2.1 - Co-ordinate Systems/Shader.cs
+++ b/examples/CSharp/Tutorial 2.1 - Co-ordinate Systems/Shader.cs
@@ -43,7 +43,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -55,7 +54,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.UniformMatrix4(location, 1, false, (float*) &value);
         }
 
@@ -66,7 +64,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 

--- a/examples/CSharp/Tutorial 2.1 - Co-ordinate Systems/Transform.cs
+++ b/examples/CSharp/Tutorial 2.1 - Co-ordinate Systems/Transform.cs
@@ -5,8 +5,8 @@ namespace Tutorial
     public class Transform
     {
         //A transform abstraction.
-        //For a transform we need to have a position a scale and a rotation,
-        //depending on what application you are creating the type for these may vary.
+        //For a transform we need to have a position, a scale, and a rotation,
+        //depending on what application you are creating, the type for these may vary.
 
         //Here we have chosen a vec3 for position, float for scale and quaternion for rotation,
         //as that is the most normal to go with.

--- a/examples/CSharp/Tutorial 2.2 - Camera/Program.cs
+++ b/examples/CSharp/Tutorial 2.2 - Camera/Program.cs
@@ -24,7 +24,7 @@ namespace Tutorial
         private static Texture Texture;
         private static Shader Shader;
 
-        //Setup the cameras location, directions, and movement speed
+        //Setup the camera's location, directions, and movement speed
         private static Vector3 CameraPosition = new Vector3(0.0f, 0.0f, 3.0f);
         private static Vector3 CameraFront = new Vector3(0.0f, 0.0f, -1.0f);
         private static Vector3 CameraUp = Vector3.UnitY;

--- a/examples/CSharp/Tutorial 2.2 - Camera/Shader.cs
+++ b/examples/CSharp/Tutorial 2.2 - Camera/Shader.cs
@@ -43,7 +43,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -55,7 +54,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.UniformMatrix4(location, 1, false, (float*) &value);
         }
 
@@ -66,7 +64,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 

--- a/examples/CSharp/Tutorial 2.2 - Camera/Transform.cs
+++ b/examples/CSharp/Tutorial 2.2 - Camera/Transform.cs
@@ -5,8 +5,8 @@ namespace Tutorial
     public class Transform
     {
         //A transform abstraction.
-        //For a transform we need to have a position a scale and a rotation,
-        //depending on what application you are creating the type for these may vary.
+        //For a transform we need to have a position, a scale, and a rotation,
+        //depending on what application you are creating, the type for these may vary.
 
         //Here we have chosen a vec3 for position, float for scale and quaternion for rotation,
         //as that is the most normal to go with.

--- a/examples/CSharp/Tutorial 3.1 - Ambient Lighting/Program.cs
+++ b/examples/CSharp/Tutorial 3.1 - Ambient Lighting/Program.cs
@@ -118,7 +118,7 @@ namespace Tutorial
 
             VaoCube.VertexAttributePointer(0, 3, VertexAttribPointerType.Float, 3, 0);
 
-            //The lighting shader will give our main cube its colour multiplied by the lights intensity
+            //The lighting shader will give our main cube it's colour multiplied by the lights intensity
             LightingShader = new Shader(Gl, "shader.vert", "lighting.frag");
             //The Lamp shader uses a fragment shader that just colours it solid white so that we know it is the light source
             LampShader = new Shader(Gl, "shader.vert", "shader.frag");

--- a/examples/CSharp/Tutorial 3.1 - Ambient Lighting/Shader.cs
+++ b/examples/CSharp/Tutorial 3.1 - Ambient Lighting/Shader.cs
@@ -43,7 +43,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -55,7 +54,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.UniformMatrix4(location, 1, false, (float*) &value);
         }
 
@@ -66,7 +64,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -77,7 +74,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform3(location, value.X, value.Y, value.Z);
         }
 

--- a/examples/CSharp/Tutorial 3.1 - Ambient Lighting/Transform.cs
+++ b/examples/CSharp/Tutorial 3.1 - Ambient Lighting/Transform.cs
@@ -5,8 +5,8 @@ namespace Tutorial
     public class Transform
     {
         //A transform abstraction.
-        //For a transform we need to have a position a scale and a rotation,
-        //depending on what application you are creating the type for these may vary.
+        //For a transform we need to have a position, a scale, and a rotation,
+        //depending on what application you are creating, the type for these may vary.
 
         //Here we have chosen a vec3 for position, float for scale and quaternion for rotation,
         //as that is the most normal to go with.

--- a/examples/CSharp/Tutorial 3.2 - Diffuse Lighting/Program.cs
+++ b/examples/CSharp/Tutorial 3.2 - Diffuse Lighting/Program.cs
@@ -120,7 +120,7 @@ namespace Tutorial
             VaoCube.VertexAttributePointer(0, 3, VertexAttribPointerType.Float, 6, 0);
             VaoCube.VertexAttributePointer(1, 3, VertexAttribPointerType.Float, 6, 3);
 
-            //The lighting shader will give our main cube its colour multiplied by the lights intensity
+            //The lighting shader will give our main cube it's colour multiplied by the lights intensity
             LightingShader = new Shader(Gl, "shader.vert", "lighting.frag");
             //The Lamp shader uses a fragment shader that just colours it solid white so that we know it is the light source
             LampShader = new Shader(Gl, "shader.vert", "shader.frag");
@@ -135,12 +135,12 @@ namespace Tutorial
 
             if (primaryKeyboard.IsKeyPressed(Key.W))
             {
-                //Move forwards by adding a movement amount in the Cameras Front direction
+                //Move forwards by adding a movement amount in the Camera's Front direction
                 Camera.Position += moveSpeed * Camera.Front;
             }
             if (primaryKeyboard.IsKeyPressed(Key.S))
             {
-                //Move backwards by subtracting a movement amount in the Cameras Front direction
+                //Move backwards by subtracting a movement amount in the Camera's Front direction
                 Camera.Position -= moveSpeed * Camera.Front;
             }
             if (primaryKeyboard.IsKeyPressed(Key.A))

--- a/examples/CSharp/Tutorial 3.2 - Diffuse Lighting/Shader.cs
+++ b/examples/CSharp/Tutorial 3.2 - Diffuse Lighting/Shader.cs
@@ -44,7 +44,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -56,7 +55,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.UniformMatrix4(location, 1, false, (float*) &value);
         }
 
@@ -67,7 +65,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -78,7 +75,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform3(location, value.X, value.Y, value.Z);
         }
 

--- a/examples/CSharp/Tutorial 3.2 - Diffuse Lighting/Transform.cs
+++ b/examples/CSharp/Tutorial 3.2 - Diffuse Lighting/Transform.cs
@@ -5,8 +5,8 @@ namespace Tutorial
     public class Transform
     {
         //A transform abstraction.
-        //For a transform we need to have a position a scale and a rotation,
-        //depending on what application you are creating the type for these may vary.
+        //For a transform we need to have a position, a scale, and a rotation,
+        //depending on what application you are creating, the type for these may vary.
 
         //Here we have chosen a vec3 for position, float for scale and quaternion for rotation,
         //as that is the most normal to go with.

--- a/examples/CSharp/Tutorial 3.2 - Diffuse Lighting/shader.vert
+++ b/examples/CSharp/Tutorial 3.2 - Diffuse Lighting/shader.vert
@@ -13,7 +13,7 @@ void main()
 {
     //Multiplying our uniform with the vertex position, the multiplication order here does matter.
     gl_Position = uProjection * uView * uModel * vec4(vPos, 1.0);
-    //We want to know the fragments position in World space, so we multiply ONLY by uModel and not uView or uProjection
+    //We want to know the fragment's position in World space, so we multiply ONLY by uModel and not uView or uProjection
     fPos = vec3(uModel * vec4(vPos, 1.0));
     //The Normal needs to be in World space too, but needs to account for Scaling of the object
     fNormal = mat3(transpose(inverse(uModel))) * vPos;

--- a/examples/CSharp/Tutorial 3.3 - Specular Lighting/Program.cs
+++ b/examples/CSharp/Tutorial 3.3 - Specular Lighting/Program.cs
@@ -120,7 +120,7 @@ namespace Tutorial
             VaoCube.VertexAttributePointer(0, 3, VertexAttribPointerType.Float, 6, 0);
             VaoCube.VertexAttributePointer(1, 3, VertexAttribPointerType.Float, 6, 3);
 
-            //The lighting shader will give our main cube its colour multiplied by the lights intensity
+            //The lighting shader will give our main cube it's colour multiplied by the light's intensity
             LightingShader = new Shader(Gl, "shader.vert", "lighting.frag");
             //The Lamp shader uses a fragment shader that just colours it solid white so that we know it is the light source
             LampShader = new Shader(Gl, "shader.vert", "shader.frag");

--- a/examples/CSharp/Tutorial 3.3 - Specular Lighting/Shader.cs
+++ b/examples/CSharp/Tutorial 3.3 - Specular Lighting/Shader.cs
@@ -43,7 +43,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -55,7 +54,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.UniformMatrix4(location, 1, false, (float*) &value);
         }
 
@@ -66,7 +64,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -77,7 +74,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform3(location, value.X, value.Y, value.Z);
         }
 

--- a/examples/CSharp/Tutorial 3.3 - Specular Lighting/Transform.cs
+++ b/examples/CSharp/Tutorial 3.3 - Specular Lighting/Transform.cs
@@ -5,8 +5,8 @@ namespace Tutorial
     public class Transform
     {
         //A transform abstraction.
-        //For a transform we need to have a position a scale and a rotation,
-        //depending on what application you are creating the type for these may vary.
+        //For a transform we need to have a position, a scale, and a rotation,
+        //depending on what application you are creating, the type for these may vary.
 
         //Here we have chosen a vec3 for position, float for scale and quaternion for rotation,
         //as that is the most normal to go with.

--- a/examples/CSharp/Tutorial 3.3 - Specular Lighting/shader.vert
+++ b/examples/CSharp/Tutorial 3.3 - Specular Lighting/shader.vert
@@ -13,7 +13,7 @@ void main()
 {
     //Multiplying our uniform with the vertex position, the multiplication order here does matter.
     gl_Position = uProjection * uView * uModel * vec4(vPos, 1.0);
-    //We want to know the fragments position in World space, so we multiply ONLY by uModel and not uView or uProjection
+    //We want to know the fragment's position in World space, so we multiply ONLY by uModel and not uView or uProjection
     fPos = vec3(uModel * vec4(vPos, 1.0));
     //The Normal needs to be in World space too, but needs to account for Scaling of the object
     fNormal = mat3(transpose(inverse(uModel))) * vPos;

--- a/examples/CSharp/Tutorial 3.4 - Materials/Program.cs
+++ b/examples/CSharp/Tutorial 3.4 - Materials/Program.cs
@@ -125,7 +125,7 @@ namespace Tutorial
             VaoCube.VertexAttributePointer(0, 3, VertexAttribPointerType.Float, 6, 0);
             VaoCube.VertexAttributePointer(1, 3, VertexAttribPointerType.Float, 6, 3);
 
-            //The lighting shader will give our main cube its colour multiplied by the lights intensity
+            //The lighting shader will give our main cube it's colour multiplied by the light's intensity
             LightingShader = new Shader(Gl, "shader.vert", "lighting.frag");
             //The Lamp shader uses a fragment shader that just colours it solid white so that we know it is the light source
             LampShader = new Shader(Gl, "shader.vert", "shader.frag");

--- a/examples/CSharp/Tutorial 3.4 - Materials/Shader.cs
+++ b/examples/CSharp/Tutorial 3.4 - Materials/Shader.cs
@@ -43,7 +43,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -55,7 +54,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.UniformMatrix4(location, 1, false, (float*) &value);
         }
 
@@ -66,7 +64,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -77,7 +74,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform3(location, value.X, value.Y, value.Z);
         }
 

--- a/examples/CSharp/Tutorial 3.4 - Materials/shader.vert
+++ b/examples/CSharp/Tutorial 3.4 - Materials/shader.vert
@@ -13,7 +13,7 @@ void main()
 {
     //Multiplying our uniform with the vertex position, the multiplication order here does matter.
     gl_Position = uProjection * uView * uModel * vec4(vPos, 1.0);
-    //We want to know the fragments position in World space, so we multiply ONLY by uModel and not uView or uProjection
+    //We want to know the fragment's position in World space, so we multiply ONLY by uModel and not uView or uProjection
     fPos = vec3(uModel * vec4(vPos, 1.0));
     //The Normal needs to be in World space too, but needs to account for Scaling of the object
     fNormal = mat3(transpose(inverse(uModel))) * vPos;

--- a/examples/CSharp/Tutorial 3.5 - Lighting Maps/Program.cs
+++ b/examples/CSharp/Tutorial 3.5 - Lighting Maps/Program.cs
@@ -129,7 +129,7 @@ namespace Tutorial
             VaoCube.VertexAttributePointer(1, 3, VertexAttribPointerType.Float, 8, 3);
             VaoCube.VertexAttributePointer(2, 2, VertexAttribPointerType.Float, 8, 6);
 
-            //The lighting shader will give our main cube its colour multiplied by the lights intensity
+            //The lighting shader will give our main cube it's colour multiplied by the light's intensity
             LightingShader = new Shader(Gl, "shader.vert", "lighting.frag");
             //The Lamp shader uses a fragment shader that just colours it solid white so that we know it is the light source
             LampShader = new Shader(Gl, "shader.vert", "shader.frag");

--- a/examples/CSharp/Tutorial 3.5 - Lighting Maps/Shader.cs
+++ b/examples/CSharp/Tutorial 3.5 - Lighting Maps/Shader.cs
@@ -43,7 +43,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -55,7 +54,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.UniformMatrix4(location, 1, false, (float*) &value);
         }
 
@@ -66,7 +64,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform1(location, value);
         }
 
@@ -77,7 +74,6 @@ namespace Tutorial
             {
                 throw new Exception($"{name} uniform not found on shader.");
             }
-            Use();
             _gl.Uniform3(location, value.X, value.Y, value.Z);
         }
 

--- a/examples/CSharp/Tutorial 3.5 - Lighting Maps/Transform.cs
+++ b/examples/CSharp/Tutorial 3.5 - Lighting Maps/Transform.cs
@@ -5,8 +5,8 @@ namespace Tutorial
     public class Transform
     {
         //A transform abstraction.
-        //For a transform we need to have a position a scale and a rotation,
-        //depending on what application you are creating the type for these may vary.
+        //For a transform we need to have a position, a scale, and a rotation,
+        //depending on what application you are creating, the type for these may vary.
 
         //Here we have chosen a vec3 for position, float for scale and quaternion for rotation,
         //as that is the most normal to go with.

--- a/examples/CSharp/Tutorial 3.5 - Lighting Maps/shader.vert
+++ b/examples/CSharp/Tutorial 3.5 - Lighting Maps/shader.vert
@@ -15,7 +15,7 @@ void main()
 {
     //Multiplying our uniform with the vertex position, the multiplication order here does matter.
     gl_Position = uProjection * uView * uModel * vec4(vPos, 1.0);
-    //We want to know the fragments position in World space, so we multiply ONLY by uModel and not uView or uProjection
+    //We want to know the fragment's position in World space, so we multiply ONLY by uModel and not uView or uProjection
     fPos = vec3(uModel * vec4(vPos, 1.0));
     //The Normal needs to be in World space too, but needs to account for Scaling of the object
     fNormal = mat3(transpose(inverse(uModel))) * vPos;


### PR DESCRIPTION
# Summary of the PR
Two changes to the tutorial example code: 
The removal of superfluous Use() calls from the tutorial Shader SetUniform definitions. These can cause confusion when debugging. (Use calls the shaders UseProgram)

Assorted small spelling and grammar tweaks, primarily commas, apostrophes and the occasional "tho" -> "though" 

# Related issues, Discord discussions, or proposals
Perksey was happy for me to make this pull request. 
https://discord.com/channels/521092042781229087/607634593201520651/831162386195021845

# Further Comments
