### PR TITLE
Fix Vulkan validation layer errors when minimizing SDL window

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Sdl/SdlView.cs
+++ b/src/Windowing/Silk.NET.Windowing.Sdl/SdlView.cs
@@ -53,8 +53,12 @@ namespace Silk.NET.Windowing.Sdl
         public override event Action<bool>? FocusChanged;
 
         // Properties
-        protected override IGLContext? CoreGLContext => _ctx ??= new SdlContext(Sdl, SdlWindow, this);
-        protected override IVkSurface? CoreVkSurface => _vk ??= new SdlVkSurface(this);
+        protected override IGLContext? CoreGLContext => API.API == ContextAPI.OpenGL || API.API == ContextAPI.OpenGLES
+            ? _ctx ??= new SdlContext(Sdl, SdlWindow, this)
+            : null;
+        protected override IVkSurface? CoreVkSurface => API.API == ContextAPI.Vulkan
+            ? _vk ??= new SdlVkSurface(this)
+            : null;
         protected override nint CoreHandle => (nint) SdlWindow;
         internal SDL.Sdl Sdl { get; }
         internal SDL.Window* SdlWindow { get; private set; }


### PR DESCRIPTION
# Summary of the PR
Fix console error spam in the VulkanTriangle project due to an invalid swap chain being created when an SDL window is minimized. Closes #492 
Closes #499 