### PR TITLE
Fix `NU5127`, `NU5128`, and `NU1701` in relation to native packages.

### DIFF
--- a/src/Native/Directory.Build.targets
+++ b/src/Native/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)_._" PackagePath="lib/net461" />
+    <Content Include="$(MSBuildThisFileDirectory)_._" PackagePath="lib/netstandard2.0" />
+  </ItemGroup>
+</Project>

--- a/src/Native/Silk.NET.Assimp.Native/Silk.NET.Assimp.Native.csproj
+++ b/src/Native/Silk.NET.Assimp.Native/Silk.NET.Assimp.Native.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net4.6.1</TargetFrameworks>
     <PackageId>Ultz.Native.Assimp</PackageId> <!-- TODO change this in 3.0 -->
-    <PackageVersion>5.0.1.2</PackageVersion>
+    <PackageVersion>5.0.1.3</PackageVersion>
     <Authors>.NET Foundation and Contributors</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/src/Native/Silk.NET.GLFW.Native/Silk.NET.GLFW.Native.csproj
+++ b/src/Native/Silk.NET.GLFW.Native/Silk.NET.GLFW.Native.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net4.6.1</TargetFrameworks>
     <PackageId>Ultz.Native.GLFW</PackageId> <!-- TODO change this in 3.0 -->
-    <PackageVersion>3.3.3</PackageVersion>
+    <PackageVersion>3.3.3.1</PackageVersion>
     <Authors>.NET Foundation and Contributors</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>Zlib</PackageLicenseExpression>

--- a/src/Native/Silk.NET.OpenAL.Soft.Native/Silk.NET.OpenAL.Soft.Native.csproj
+++ b/src/Native/Silk.NET.OpenAL.Soft.Native/Silk.NET.OpenAL.Soft.Native.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net4.6.1</TargetFrameworks>
-    <PackageVersion>1.21.1</PackageVersion>
+    <PackageVersion>1.21.1.1</PackageVersion>
     <Authors>.NET Foundation and Contributors</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>LGPL-2.0-or-later</PackageLicenseExpression>

--- a/src/Native/Silk.NET.SDL.Native/Silk.NET.SDL.Native.csproj
+++ b/src/Native/Silk.NET.SDL.Native/Silk.NET.SDL.Native.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net4.6.1</TargetFrameworks>
     <PackageId>Ultz.Native.SDL</PackageId> <!-- TODO change this in 3.0 -->
-    <PackageVersion>2.0.14</PackageVersion>
+    <PackageVersion>2.0.14.1</PackageVersion>
     <Authors>.NET Foundation and Contributors</Authors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>Zlib</PackageLicenseExpression>


### PR DESCRIPTION
Fixes #514.

This resolves `NU5127` and `NU5128` at pack time. Also verified using a local package source that `NU1701` no longer occurs when consuming the package.

New versions of all the native packages should probably be pushed after this is merged.