### PR TITLE
Start of improving FileNotFound exceptions

### DIFF
--- a/src/Core/Silk.NET.Core/Loader/LibraryLoader.cs
+++ b/src/Core/Silk.NET.Core/Loader/LibraryLoader.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #if NETCOREAPP3_1 || NET5_0
@@ -31,7 +31,8 @@ namespace Silk.NET.Core.Loader
 
         private static void ThrowLibNotFound(string name, PathResolver resolver)
         {
-            throw new FileNotFoundException($"Could not find or load the native library: {name} Attempted: {string.Join(", ", resolver.EnumeratePossibleLibraryLoadTargets(name).Select(x => "\"" + x + "\""))}");
+            throw new FileNotFoundException($"Could not find or load the native library: {name} Attempted: {string.Join(", ", resolver.EnumeratePossibleLibraryLoadTargets(name).Select(x => "\"" + x + "\""))}",
+                name);
         }
 
         /// <summary>
@@ -60,7 +61,8 @@ namespace Silk.NET.Core.Loader
         private static void ThrowLibNotFoundAny(string[] names, PathResolver pathResolver)
         {
             throw new FileNotFoundException
-                ($"Could not find or load the native library from any name: [ {string.Join(", ", names.Select(x => x + " Attempted: (" + string.Join(", ", pathResolver.EnumeratePossibleLibraryLoadTargets(x).Select(x2 => "\"" + x2 + "\"")) + ")"))} ]");
+                ($"Could not find or load the native library from any name: [ {string.Join(", ", names.Select(x => x + " Attempted: (" + string.Join(", ", pathResolver.EnumeratePossibleLibraryLoadTargets(x).Select(x2 => "\"" + x2 + "\"")) + ")"))} ]",
+                names[0]);
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary of the PR
The FileNotFound exceptions only provide a message but it would be nice if they also provide the filename they couldn't found in the FileName property. This is nice for creating own error messages.

A recent usage was that OpenAL32.dll was missing because it wasn't installed. But as it happens inside a game with a graphical UI I prefer to show a very short notice about the missing DLL rather then the long message provided by Silk.NET.

Moreover the name can be better parsed if it is provided on its own and someone could create more user-friendly messages like "OpenAL is not installed" from such exception more easily.

The changes should be small and safe.