### PR TITLE
Fix lib open cl so linkname on linux

### DIFF
--- a/generator.json
+++ b/generator.json
@@ -153,7 +153,7 @@
             "namespace": "Silk.NET.OpenCL",
             "extensionsNamespace": "Silk.NET.OpenCL.Extensions",
             "nameContainer": {
-                "linux-x64": "libOpenCL.so",
+                "linux-x64": "libOpenCL.so.1",
                 "win-x64": "opencl.dll",
                 "win-x86": "opencl.dll",
                 "osx-x64": "/System/Library/Frameworks/OpenCL.framework/OpenCL",

--- a/src/OpenCL/Silk.NET.OpenCL/OpenCLLibraryNameContainer.cs
+++ b/src/OpenCL/Silk.NET.OpenCL/OpenCLLibraryNameContainer.cs
@@ -11,7 +11,7 @@ namespace Silk.NET.OpenCL
     internal class OpenCLLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libOpenCL.so";
+        public override string Linux => "libOpenCL.so.1";
 
         /// <inheritdoc />
         public override string MacOS => "/System/Library/Frameworks/OpenCL.framework/OpenCL";


### PR DESCRIPTION
# Summary of the PR
This fixes a problem on linux where I had to create a link named libOpenCL.so manually and point it to libOpenCL.so.1

Fixed as discussed here: https://discord.com/channels/521092042781229087/607634593201520651/854308234578755584