### PR TITLE
Upgrade to the latest AOT compiler

### DIFF
--- a/src/Lab/Experiments/CoreRTTest/CoreRTTest.csproj
+++ b/src/Lab/Experiments/CoreRTTest/CoreRTTest.csproj
@@ -49,11 +49,11 @@
     
     <!-- Reference the CoreRT toolchain -->
     <PropertyGroup>
-        <RestoreAdditionalProjectSources>https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;$(RestoreAdditionalProjectSources)</RestoreAdditionalProjectSources>
+        <RestoreAdditionalProjectSources>https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json;$(RestoreAdditionalProjectSources)</RestoreAdditionalProjectSources>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="1.0.0-alpha-*" />
+        <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="6.0.0-*" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Summary of the PR
Upgrade to the latest AOT compiler.

The native aot compiler has been greatly improved, also the 1.0.0-alpha version of CoreRT has been deprecated.
