### PR TITLE
Multi-Backend Input for Silk.NET 3.0

### DIFF
--- a/documentation/proposals/Proposal - Multi-Backend Input.md
+++ b/documentation/proposals/Proposal - Multi-Backend Input.md
@@ -139,11 +139,21 @@ namespace Silk.NET.Input
 +   /// <summary>
 +   /// Represents an input backend from which input devices can be retrieved.
 +   /// </summary>
++   /// <remarks>
++   /// This interface is not intended for general consumption. Consider <see cref="InputContext" /> instead.
++   /// </remarks>
 +   public interface IInputBackend : IDisposable
 +   {
 +       /// <summary>
 +       /// Gets all devices of the given type recognised by this backend.
 +       /// </summary>
++       /// <remarks>
++       /// The <typeparamref name="T" /> type parameter must be the last interface in the inheritance heirarchy (the "device type")
++       /// i.e. it must be a device type like <see cref="IJoystick" /> and not something like <see cref="IInputDevice" />.
++       /// The behaviour of using a T that isn't a device type recognised by the backend is undefined.<br />
++       /// <br />
++       /// This method is not intended for general consumption. Consider <see cref="InputContext" /> instead.
++       /// </remarks>
 +       IReadOnlyList<IInputDevice> GetDevices<T>() where T : IInputDevice;
 +
 +       /// <summary>

--- a/documentation/proposals/Proposal - Multi-Backend Input.md
+++ b/documentation/proposals/Proposal - Multi-Backend Input.md
@@ -48,6 +48,8 @@ The `CreateInput` method will use the surface, obtain its platform data (i.e. by
 
 The API surface for this is defined later in the Proposed API section.
 
+One instance of an `IInputBackend` can only belong to one input context at a time. If multiple input contexts are in use, multiple backend instances should also be used. An input context is set as active/in use by a context using the `Activate` and `Deactivate` methods. `Activate` should throw an exception if already activated, and `Deactivate` should throw an exception if not already activated.
+
 **KEY POINT FOR WORKING GROUP**: The Windowing-Input integration mandates the use of source generators. Is this ok?
 
 # Proposed API

--- a/documentation/proposals/Proposal - Multi-Backend Input.md
+++ b/documentation/proposals/Proposal - Multi-Backend Input.md
@@ -43,12 +43,10 @@ namespace Silk.NET.Input
 The `CreateInput` method will use the surface, obtain its platform data (i.e. by using something like `IGlfwPlatformData`), and then feed that into `InputBackend.Create`. The returned `InputContext` will be configured to have the returned `IInputBackend` as a backend. This method will also appropriately bind the `ISurface.Update` callback:
 - The `IInputBackend.Update` method is configured to run in the `ISurface.Update` callback.
 - The `IInputBackend.Disposing` event will be bound such that the `IInputBackend.Update` method is unbound from `ISurface.Update` event callback.
-- Once a `IInputBackend` is `Add`ed to an `InputContext`, the `InputContext` takes full ownership of the `IInputBackend` and, as a result, will `Dispose` the `IInputBackend` when it is `Remove`d or the context itself is `Dispose`d.
-    - This essentially means that you can count on `Disposing` being fired as an indicator that the `IInputBackend` will never be relevant again. 
 
 The API surface for this is defined later in the Proposed API section.
 
-One instance of an `IInputBackend` can only belong to one input context at a time. If multiple input contexts are in use, multiple backend instances should also be used. An input context is set as active/in use by a context using the `Activate` and `Deactivate` methods. `Activate` should throw an exception if already activated, and `Deactivate` should throw an exception if not already activated. Once deactivated, an input backend can be reactivated.
+One instance of an `IInputBackend` can only belong to one `InputContext` throughout the entirety of the `IInputBackend`'s lifetime. Once a `IInputBackend` is `Add`ed to an `InputContext`, the `InputContext` takes full ownership of the `IInputBackend` and, as a result, will `Dispose` the `IInputBackend` when it is `Remove`d or the context itself is `Dispose`d. If multiple `InputContext`s are in use, multiple `IInputBackend` instances must also be used. `IInputBackend` should throw an exception if its APIs are used after the backend has been disposed.
 
 **KEY POINT FOR WORKING GROUP**: The Windowing-Input integration mandates the use of source generators. Is this ok?
 

--- a/documentation/proposals/Proposal - Multi-Backend Input.md
+++ b/documentation/proposals/Proposal - Multi-Backend Input.md
@@ -68,7 +68,7 @@ namespace Silk.NET.Input
 +   /// Encapsulates input devices sourced from input backends.
 +   /// </summary>
 -   public interface IInputContext : IDisposable
-+   public class InputContext : IDisposable
++   public sealed class InputContext : IDisposable
     {
 -       nint Handle { get; }
         IReadOnlyList<IGamepad> Gamepads { get; }

--- a/documentation/proposals/Proposal - Multi-Backend Input.md
+++ b/documentation/proposals/Proposal - Multi-Backend Input.md
@@ -48,7 +48,7 @@ The `CreateInput` method will use the surface, obtain its platform data (i.e. by
 
 The API surface for this is defined later in the Proposed API section.
 
-One instance of an `IInputBackend` can only belong to one input context at a time. If multiple input contexts are in use, multiple backend instances should also be used. An input context is set as active/in use by a context using the `Activate` and `Deactivate` methods. `Activate` should throw an exception if already activated, and `Deactivate` should throw an exception if not already activated.
+One instance of an `IInputBackend` can only belong to one input context at a time. If multiple input contexts are in use, multiple backend instances should also be used. An input context is set as active/in use by a context using the `Activate` and `Deactivate` methods. `Activate` should throw an exception if already activated, and `Deactivate` should throw an exception if not already activated. Once deactivated, an input backend can be reactivated.
 
 **KEY POINT FOR WORKING GROUP**: The Windowing-Input integration mandates the use of source generators. Is this ok?
 
@@ -132,7 +132,7 @@ namespace Silk.NET.Input
 +       void Update();
 +
 +       /// <summary>
-+       /// Activates this input backend and runs any necessary prerequisites.
++       /// Activates this input backend and runs any necessary prerequisites to collecting input data.
 +       /// </summary>
 +       /// <remarks>
 +       /// Called by <see cref="InputContext.Add" />
@@ -140,7 +140,7 @@ namespace Silk.NET.Input
 +       void Activate();
 +
 +       /// <summary>
-+       /// Deactivates this input backend and tears down any resources created.
++       /// Deactivates this input backend and destroys/disables any resources responsible for collecting input data.
 +       /// </summary>
 +       /// <remarks>
 +       /// Called by <see cref="InputContext.Remove" />

--- a/documentation/proposals/Proposal - Multi-Backend Input.md
+++ b/documentation/proposals/Proposal - Multi-Backend Input.md
@@ -46,7 +46,7 @@ The `CreateInput` method will use the surface, obtain its platform data (i.e. by
 
 The API surface for this is defined later in the Proposed API section.
 
-One instance of an `IInputBackend` can only belong to one `InputContext` throughout the entirety of the `IInputBackend`'s lifetime. Once a `IInputBackend` is `Add`ed to an `InputContext`, the `InputContext` takes full ownership of the `IInputBackend` and, as a result, will `Dispose` the `IInputBackend` when it is `Remove`d or the context itself is `Dispose`d. If multiple `InputContext`s are in use, multiple `IInputBackend` instances must also be used. `IInputBackend` should throw an exception if its APIs are used after the backend has been disposed.
+One instance of an `IInputBackend` can only belong to one `InputContext` throughout the entirety of the `IInputBackend`'s lifetime. Once a `IInputBackend` is `Add`ed to an `InputContext`, the `InputContext` takes full ownership of the `IInputBackend` and, as a result, will `Dispose` the `IInputBackend` when it is `Remove`d or the context itself is `Dispose`d. If multiple `InputContext`s are in use, multiple `IInputBackend` instances must also be used. `IInputBackend` will throw an exception if its APIs are used after the backend has been disposed.
 
 **KEY POINT FOR WORKING GROUP**: The Windowing-Input integration mandates the use of source generators. Is this ok?
 

--- a/documentation/proposals/Proposal - Multi-Backend Input.md
+++ b/documentation/proposals/Proposal - Multi-Backend Input.md
@@ -124,6 +124,16 @@ namespace Silk.NET.Input
 +       event Action<IInputDevice, bool>? ConnectionChanged;
 +
 +       /// <summary>
++       /// Occurs when the backend is <see cref="Activate" />d.
++       /// </summary>
++       event Action Activated;
++
++       /// <summary>
++       /// Occurs when the backend is <see cref="Deactivate" />d.
++       /// </summary>
++       event Action Deactivated;
++
++       /// <summary>
 +       /// Updates this backend's input data.
 +       /// </summary>
 +       /// <remarks>

--- a/documentation/proposals/Proposal - Multi-Backend Input.md
+++ b/documentation/proposals/Proposal - Multi-Backend Input.md
@@ -46,6 +46,8 @@ The `CreateInput` method will use the surface, obtain its platform data (i.e. by
 - These delegates must be called by the reference implementation in its `IInputBackend.Activate` and `IInputBackend.Deactivate` methods (respectively)
 - The `IInputBackend.Activate` and `IInputBackend.Deactivate` methods must be called by the `InputContext.Add` and `InputContext.Remove` methods (respectively)
 
+The API surface for this is defined later in the Proposed API section.
+
 **KEY POINT FOR WORKING GROUP**: The Windowing-Input integration mandates the use of source generators. Is this ok?
 
 # Proposed API
@@ -176,7 +178,7 @@ namespace Silk.NET.Input
 +       /// <param name="onDeactivate">A delegate to be called when the context is deactivated. May be null.</param>
 +       /// <remarks>
 +       /// This method is implicitly called by the Windowing-Input integration. <br />
-+       /// On desktop, this uses GLFW.
++       /// On desktop, this uses GLFW. The handle refers to a <c>GLFWwindow*</c> if GLFW is in use.
 +       /// </remarks>
 +       public static unsafe IInputBackend Create(void* handle, Action? onActivate = null, Action? onDeactivate = null);
 +   }

--- a/documentation/proposals/Proposal - Multi-Backend Input.md
+++ b/documentation/proposals/Proposal - Multi-Backend Input.md
@@ -133,6 +133,7 @@ namespace Silk.NET.Input
 +
 +       /// <summary>
 +       /// Activates this input backend and runs any necessary prerequisites to collecting input data.
++       /// Once activated, <see cref="Deactivate" /> must be used before the backend can be activated again.
 +       /// </summary>
 +       /// <remarks>
 +       /// Called by <see cref="InputContext.Add" />
@@ -141,9 +142,10 @@ namespace Silk.NET.Input
 +
 +       /// <summary>
 +       /// Deactivates this input backend and destroys/disables any resources responsible for collecting input data.
++       /// Once deactivated, <see cref="Activate" /> can be used to activate the backend again.
 +       /// </summary>
 +       /// <remarks>
-+       /// Called by <see cref="InputContext.Remove" />
++       /// Called by <see cref="InputContext.Remove" />.
 +       /// </remarks>
 +       void Deactivate();
 +   }

--- a/documentation/proposals/Proposal - Multi-Backend Input.md
+++ b/documentation/proposals/Proposal - Multi-Backend Input.md
@@ -64,6 +64,9 @@ namespace Silk.NET.Input
 ```diff
 namespace Silk.NET.Input
 {
++   /// <summary>
++   /// Encapsulates input devices sourced from input backends.
++   /// </summary>
 -   public interface IInputContext : IDisposable
 +   public class InputContext : IDisposable
     {
@@ -73,10 +76,26 @@ namespace Silk.NET.Input
         IReadOnlyList<IKeyboard> Keyboards { get; }
         IReadOnlyList<IMouse> Mice { get; }
         IReadOnlyList<IInputDevice> OtherDevices { get; }
++
++       /// <summary>
++       /// Gets a list of backends from which all input devices on this input context are sourced.
++       /// </summary>
 +       IReadOnlyList<IInputBackend> Backends { get; }
         event Action<IInputDevice, bool>? ConnectionChanged;
++
++       /// <summary>
++       /// Adds the given backend to the list of <see cref="Backends" />.
++       /// </summary>
 +       void Add(IInputBackend backend);
++
++       /// <summary>
++       /// Removes the given backend from the list of <see cref="Backends" />.
++       /// </summary>
 +       void Remove(IInputBackend backend);
++
++       /// <summary>
++       /// Updates all input data on all backends.
++       /// </summary>
 +       void Update();
     }
 }
@@ -85,6 +104,9 @@ namespace Silk.NET.Input
 ```diff
 namespace Silk.NET.Input
 {
++   /// <summary>
++   /// Represents an input backend from which input devices can be retrieved.
++   /// </summary>
 +   public interface IInputBackend
 +   {
 +       /// <summary>
@@ -137,9 +159,26 @@ namespace Silk.NET.Input
 ```diff
 namespace Silk.NET.Input
 {
++   /// <summary>
++   /// Represents the out-of-the-box input backend, which uses a native API to retrieve input backends using a native handle.
++   /// </summary>
++   /// <remarks>
++   /// On desktop, this uses GLFW.
++   /// </remarks>
 +   public static class InputBackend
 +   {
-+       public static IInputBackend Create(void* handle, Action? onActivate = null, Action? onDeactivate = null);
++       /// <summary>
++       /// Creates an instance of the out-of-the-box input backend, which uses a native API to retrieve input backends using
++       /// the given native handle, optionally calling the given delegates when the input backend is activated and deactivated.
++       /// </summary>
++       /// <param name="handle">The native handle created/sourced from the underlying native API used by this input backend.</param>
++       /// <param name="onActivate">A delegate to be called when the context is activated. May be null.</param>
++       /// <param name="onDeactivate">A delegate to be called when the context is deactivated. May be null.</param>
++       /// <remarks>
++       /// This method is implicitly called by the Windowing-Input integration. <br />
++       /// On desktop, this uses GLFW.
++       /// </remarks>
++       public static unsafe IInputBackend Create(void* handle, Action? onActivate = null, Action? onDeactivate = null);
 +   }
 }
 ```

--- a/documentation/proposals/Proposal - Multi-Backend Input.md
+++ b/documentation/proposals/Proposal - Multi-Backend Input.md
@@ -1,0 +1,77 @@
+# Summary
+Proposal API for backend-agnostic, refactored Input via keyboards, mice, and controllers.
+
+# Contributors
+- Dylan Perks (@Perksey)
+
+# Current Status
+- [x] Proposed
+- [ ] Discussed with Working Group
+- [ ] Approved
+- [ ] Implemented
+
+# Design Decisions
+- This proposal refactors the internals of the Input API to be less tied to a single backend, and instead allow multiple backends to be added and removed from an input context at will.
+- This proposal aims to keep the look and feel of the Input APIs intended for general consumption similar to that of 2.0.
+- This proposal assumes knowledge of the following proposals:
+    - Windowing 3.0
+    - Input
+    - Enhanced Input Events
+- This proposal also assumes knowledge of 2.0's Input APIs as it is only a refactor and not a complete redesign of the API as in other proposals. The most noticable differences between the design of Input 2.0 and Input 3.0 are:
+    - Input no longer has a hard bond to Windowing. The integration will remain the same to the end user but will use Source Generators, more on that later. 
+    - Input contexts and the devices therein are no longer interfaces. They are instead structures containing a handle and a backend object. See the proposed API for details.
+    - They may now only be one mouse and one keyboard. This is because no supported operating system actually allows multiple mice or keyboards to be reported individually.
+    - There is now another layer to input: the LLAPI.
+
+## Input Low-Level API (LLAPI)
+
+In order to faciliate the goal of allowing multiple backends, we needed to remove the close tie between the platform and the high-level input API. To do this, this proposal adds a low-level API to be stored in the `Silk.NET.Input.Internals` namespace.
+
+**OPEN QUESTION:** what should we call this namespace? `Silk.NET.Input.Internals` is used as a placeholder.
+
+### Device Handles
+
+Each kind of device which allows multiple instances (i.e. everything but keyboard and mouse as discussed earlier) will have a handle specific to that backend. For example, there will be:
+- `JoystickHandle`
+- `GamepadHandle`
+
+Both of which containing a `ulong` handle allocated by the backend.
+
+
+# Proposed API
+- Here you do some code blocks, this is the heart and soul of the proposal. DON'T DO ANY IMPLEMENTATIONS! Just declarations.
+
+```cs
+namespace Silk.NET.Inout.Internals
+{
+    public interface IInputBackend
+    {
+        void QueryDevices<TDeviceHandle>(out int numDevices) where TDeviceHandle : unmanaged;
+        void QueryDevices<TDeviceHandle>(Span<TDeviceHandle> deviceHandles) where TDeviceHandle : unmanaged;
+        void QueryDevice<TDeviceHandle, TDataType>(TDeviceHandle device, DeviceDataKind key, out TDataType value) where TDeviceHandle : unmanaged where TDataType : unmanaged;
+        void QueryGlobal<TDataType>(GlobalDataKind key, out TDataType value) where TDataType : unmanaged;
+        void Update();
+    }
+}
+```
+
+```cs
+/// <summary>
+/// Represents a grenade.
+/// </summary>
+public class SilkGrenade
+{
+    /// <summary>
+    /// What does this do?!?
+    /// </summary>
+    public void RedButton();
+    /// <summary>
+    /// Detonates the grenade.
+    /// </summary>
+    protected void Kaboom();
+    /// <summary>
+    /// Gets or sets whether this grenade is disarmed or not.
+    /// </summary>
+    public bool Disarmed { get; set; }
+}
+```

--- a/documentation/proposals/Proposal - Multi-Backend Input.md
+++ b/documentation/proposals/Proposal - Multi-Backend Input.md
@@ -41,8 +41,8 @@ namespace Silk.NET.Input
 ```
 
 The `CreateInput` method will use the surface, obtain its platform data (i.e. by using something like `IGlfwPlatformData`), and then feed that into `InputBackend.Create`. The returned `InputContext` will be configured to have the returned `IInputBackend` as a backend. This method will also appropriately bind the `ISurface.Update` callback:
-- The delegate passed in the `onActivated` parameter of `InputBackend.Create` will bind the `IInputBackend.Update` method to run in the `ISurface.Update` callback.
-- The delegate passed in the `onDeactivated` parameter of `InputBackend.Create` will unbind the `ISurface.Update` callback.
+- The `IInputBackend.Activated` event will be bound such that the `IInputBackend.Update` method is configured to run in the `ISurface.Update` callback.
+- The `IInputBackend.Deactivated` event will be bound such that the `IInputBackend.Update` is unbound from `ISurface.Update`.
 - These delegates must be called by the reference implementation in its `IInputBackend.Activate` and `IInputBackend.Deactivate` methods (respectively)
 - The `IInputBackend.Activate` and `IInputBackend.Deactivate` methods must be called by the `InputContext.Add` and `InputContext.Remove` methods (respectively)
 
@@ -185,16 +185,14 @@ namespace Silk.NET.Input
 +   {
 +       /// <summary>
 +       /// Creates an instance of the out-of-the-box input backend, which uses a native API to retrieve input backends using
-+       /// the given native handle, optionally calling the given delegates when the input backend is activated and deactivated.
++       /// the given native handle.
 +       /// </summary>
 +       /// <param name="handle">The native handle created/sourced from the underlying native API used by this input backend.</param>
-+       /// <param name="onActivate">A delegate to be called when the context is activated. May be null.</param>
-+       /// <param name="onDeactivate">A delegate to be called when the context is deactivated. May be null.</param>
 +       /// <remarks>
 +       /// This method is implicitly called by the Windowing-Input integration. <br />
 +       /// On desktop, this uses GLFW. The handle refers to a <c>GLFWwindow*</c> if GLFW is in use.
 +       /// </remarks>
-+       public static unsafe IInputBackend Create(void* handle, Action? onActivate = null, Action? onDeactivate = null);
++       public static unsafe IInputBackend Create(void* handle);
 +   }
 }
 ```


### PR DESCRIPTION
This enables input to use multiple backends (i.e. so we can have windowing-based input as well as something like OpenXR) and contains other refactorings for 3.0.

Unlike previous 3.0 proposals this proposes only a minor change of the public API.