### PR TITLE
"Winapi" support on NS20 and .NET 5

### DIFF
--- a/src/Assimp/Silk.NET.Assimp/Assimp.cs
+++ b/src/Assimp/Silk.NET.Assimp/Assimp.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using Silk.NET.Core.Contexts;
 using Silk.NET.Core.Loader;
 using Silk.NET.Core.Native;
@@ -7,6 +8,7 @@ using Silk.NET.Core.Native;
 
 namespace Silk.NET.Assimp
 {
+    [NativeApi(Convention = CallingConvention.Winapi)]
     public partial class Assimp
     {
         public static Assimp GetApi()

--- a/src/Core/Silk.NET.Core/Native/NativeApiAttribute.cs
+++ b/src/Core/Silk.NET.Core/Native/NativeApiAttribute.cs
@@ -45,7 +45,7 @@ namespace Silk.NET.Core.Native
 
         public static CallingConvention GetCallingConvention(NativeApiAttribute attr, NativeApiAttribute parent)
         {
-            return attr?._actualConvention ?? parent?._actualConvention ?? CallingConvention.Winapi;
+            return attr?._actualConvention ?? parent?._actualConvention ?? CallingConvention.Cdecl;
         }
     }
 }

--- a/src/Core/Silk.NET.Core/Native/NativeApiAttribute.cs
+++ b/src/Core/Silk.NET.Core/Native/NativeApiAttribute.cs
@@ -45,7 +45,7 @@ namespace Silk.NET.Core.Native
 
         public static CallingConvention GetCallingConvention(NativeApiAttribute attr, NativeApiAttribute parent)
         {
-            return attr?._actualConvention ?? parent?._actualConvention ?? CallingConvention.Cdecl;
+            return attr?._actualConvention ?? parent?._actualConvention ?? CallingConvention.Winapi;
         }
     }
 }

--- a/src/Core/Silk.NET.Core/Native/SilkMarshal.cs
+++ b/src/Core/Silk.NET.Core/Native/SilkMarshal.cs
@@ -9,8 +9,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
-using Silk.NET.Core.Loader;
 
 namespace Silk.NET.Core.Native
 {
@@ -19,6 +17,25 @@ namespace Silk.NET.Core.Native
     /// </summary>
     public static class SilkMarshal
     {
+        /// <summary>
+        /// Gets a value indicating whether <see cref="CallingConvention.Winapi"/> is equivalent to
+        /// <see cref="CallingConvention.StdCall"/>.
+        /// </summary>
+        /// <remarks>
+        /// If false, <see cref="CallingConvention.Winapi"/> can be generally assumed to be equivalent to
+        /// <see cref="CallingConvention.Cdecl"/>.
+        /// </remarks>
+        public static readonly bool IsWinapiStdcall;
+
+        static SilkMarshal()
+        {
+#if NET5_0
+            IsWinapiStdcall = OperatingSystem.IsWindows();
+#else
+            IsWinapiStdcall = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#endif
+        }
+    
         /// <summary>
         /// Allocate a new BStr pointer.
         /// </summary>

--- a/src/Core/Silk.NET.SilkTouch/MarshalContext.cs
+++ b/src/Core/Silk.NET.SilkTouch/MarshalContext.cs
@@ -423,6 +423,7 @@ namespace Silk.NET.SilkTouch
 
         public BlockSyntax BuildFinalBlock()
         {
+            
             // add return
             if (!ReturnsVoid)
             {


### PR DESCRIPTION
2.7 is due today, to get this fix in we'll delay release to tomorrow.

This implements support for platform-default P/Invoke calling conventions instead of blindly using Cdecl (which is incorrect!) This is something that was pointed out when SilkTouch development first started, but was not implemented.

On .NET Standard 2.0, seeing as there's no true way to specify "platform default" we use a "best effort" implementation to cover known cases. Right now, this is just 32-bit Windows being not Cdecl - there are no other concerns we know of today.

Codegen:
- [Assimp.WinapiNET5.gen.txt](https://github.com/dotnet/Silk.NET/files/6948095/Assimp.WinapiNET5.gen.txt)
- [Assimp.WinapiNS20.gen.txt](https://github.com/dotnet/Silk.NET/files/6948096/Assimp.WinapiNS20.gen.txt)
