### PR TITLE
Code signing issues "workaround"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
         retention-days: 1
     - name: Push to NuGet
       run: nuke PushToNuGet --skip Clean Restore Pack --configuration Release --msbuild-properties ContinuousIntegrationBuild=true SilkEnableSourceLink=true --feature-sets Android iOS --nuget-api-key ${{ secrets.NUGET_TOKEN }} --sign-username "${{ secrets.SIGN_USERNAME }}" --sign-password "${{ secrets.SIGN_PASSWORD }}"
+      continue-on-error: true
     - name: Upload Signed Artifacts to Actions
       uses: actions/upload-artifact@v2.2.4
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,6 @@ jobs:
         retention-days: 1
     - name: Push to NuGet
       run: nuke PushToNuGet --skip Clean Restore Pack --configuration Release --msbuild-properties ContinuousIntegrationBuild=true SilkEnableSourceLink=true --feature-sets Android iOS --nuget-api-key ${{ secrets.NUGET_TOKEN }} --sign-username "${{ secrets.SIGN_USERNAME }}" --sign-password "${{ secrets.SIGN_PASSWORD }}"
-      continue-on-error: true
     - name: Upload Signed Artifacts to Actions
       uses: actions/upload-artifact@v2.2.4
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,6 @@ jobs:
     - name: Upload Signed Artifacts to Actions
       uses: actions/upload-artifact@v2.2.4
       with:
-        name: unsigned_nupkgs
+        name: signed_nupkgs
         path: "build/output_packages/*.nupkg"
         if-no-files-found: warn

--- a/build/nuke/Build.cs
+++ b/build/nuke/Build.cs
@@ -443,12 +443,13 @@ class Build : NukeBuild
                 DotNetToolInstall(s => s.SetToolInstallationPath(basePath / "tool").SetPackageName("SignClient"));
             }
 
+            foreach (var pkg in Packages)
             StartProcess
             (
                 execPath,
                 "sign " +
                 $"--baseDirectory {PackageDirectory} " +
-                "--input \"**/*.nupkg\" " +
+                $"--input \"{pkg}\" " +
                 $"--config \"{basePath / "config.json"}\" " +
                 $"--filelist \"{basePath / "filelist.txt"}\" " +
                 $"--user \"{SignUsername}\" " +

--- a/build/nuke/Build.cs
+++ b/build/nuke/Build.cs
@@ -444,20 +444,22 @@ class Build : NukeBuild
             }
 
             foreach (var pkg in Packages)
-            StartProcess
-            (
-                execPath,
-                "sign " +
-                $"--baseDirectory {PackageDirectory} " +
-                $"--input \"{pkg}\" " +
-                $"--config \"{basePath / "config.json"}\" " +
-                $"--filelist \"{basePath / "filelist.txt"}\" " +
-                $"--user \"{SignUsername}\" " +
-                $"--secret \"{SignPassword}\" " +
-                "--name \"Silk.NET\" " +
-                "--description \"Silk.NET\" " +
-                "--descriptionUrl \"https://github.com/dotnet/Silk.NET\""
-            ).AssertZeroExitCode();
+            {
+                StartProcess
+                (
+                    execPath,
+                    "sign " +
+                    $"--baseDirectory {PackageDirectory} " +
+                    $"--input \"{pkg}\" " +
+                    $"--config \"{basePath / "config.json"}\" " +
+                    $"--filelist \"{basePath / "filelist.txt"}\" " +
+                    $"--user \"{SignUsername}\" " +
+                    $"--secret \"{SignPassword}\" " +
+                    "--name \"Silk.NET\" " +
+                    "--description \"Silk.NET\" " +
+                    "--descriptionUrl \"https://github.com/dotnet/Silk.NET\""
+                ).AssertZeroExitCode();
+            }
         }
 
         var allFiles = Packages.Select((x, i) => new {Index = i, Value = x})


### PR DESCRIPTION
It looks like the .NET Foundation code signing service doesn't cope well under pressure, so I've now made it do things a lot more slowly by starting a process for each individual package rather than signing all packages at once (with a degree of parallelism) 