### PR TITLE
Fix calling SetWindowShouldClose if _glfwWindow is null

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -246,7 +246,13 @@ namespace Silk.NET.Windowing.Glfw
 
         protected override bool IsClosingSettable
         {
-            set => _glfw.SetWindowShouldClose(_glfwWindow, value);
+            set
+            {
+                if (_glfwWindow != null)
+                {
+                    _glfw.SetWindowShouldClose(_glfwWindow, value);
+                }
+            }
         }
 
         protected override Vector2D<int> SizeSettable


### PR DESCRIPTION
# Summary of the PR
Fixes Calling window.Close before window.Run causing an exception on GLFW.
Closes #565

