### PR TITLE
Fix incorrect documentation in Thumbstick.Direction

### DIFF
--- a/src/Input/Silk.NET.Input.Common/Structs/Thumbstick.cs
+++ b/src/Input/Silk.NET.Input.Common/Structs/Thumbstick.cs
@@ -31,7 +31,7 @@ namespace Silk.NET.Input
         public float Position => (float) Math.Sqrt(X * X + Y * Y);
 
         /// <summary>
-        /// The current direction of the stick, from 0.0 to 360.0.
+        /// The current direction of the stick, from -π to π.
         /// </summary>
         public float Direction => (float) Math.Atan2(Y, X);
 


### PR DESCRIPTION
# Summary of the PR
Math.Atan2 returns value in radians, not degrees.  

