### PR TITLE
fix Box2D.Center returns bogus values

### DIFF
--- a/src/Maths/Silk.NET.Maths/Box2D.cs
+++ b/src/Maths/Silk.NET.Maths/Box2D.cs
@@ -39,7 +39,7 @@ namespace Silk.NET.Maths
         /// The center of this box.
         /// </summary>
         [IgnoreDataMember]
-        public Vector2D<T> Center => Min + Max / Scalar<T>.Two;
+        public Vector2D<T> Center => (Min + Max) / Scalar<T>.Two;
 
         /// <summary>
         /// The size of this box.

--- a/src/Maths/Silk.NET.Maths/Box3D.cs
+++ b/src/Maths/Silk.NET.Maths/Box3D.cs
@@ -39,7 +39,7 @@ namespace Silk.NET.Maths
         /// The center of this box.
         /// </summary>
         [IgnoreDataMember]
-        public Vector3D<T> Center => Min + Max / Scalar<T>.Two;
+        public Vector3D<T> Center => (Min + Max) / Scalar<T>.Two;
 
         /// <summary>
         /// The size of this box.


### PR DESCRIPTION
`Box2D.Center` and `Box3D.Center` were calculated falsely. Fix that.
Also check other classes in Maths for similar problems.

The issue: https://github.com/dotnet/Silk.NET/issues/567
