### PR TITLE
Linux fix for Silk.NET Vulkan Triangle experiment.

### DIFF
--- a/src/Lab/Experiments/VulkanTriangle/HelloTriangleApplication.cs
+++ b/src/Lab/Experiments/VulkanTriangle/HelloTriangleApplication.cs
@@ -71,7 +71,7 @@ namespace VulkanTriangle
         private KhrSurface _vkSurface;
         private KhrSwapchain _vkSwapchain;
         private ExtDebugUtils _debugUtils;
-        private string[] _validationLayers = { "VK_LAYER_KHRONOS_validation" };
+        private string[] _validationLayers = { "VK_LAYER_LUNARG_standard_validation" };
         private string[] _instanceExtensions = { ExtDebugUtils.ExtensionName };
         private string[] _deviceExtensions = { KhrSwapchain.ExtensionName };
 


### PR DESCRIPTION
# Summary of the PR
The validation layer on all my computers is called `VK_LAYER_LUNARG_standard_validation` and not `VK_LAYER_KHRONOS_validation`. Changing this will allow the experiment application to run on my computers.

# Related issues, Discord discussions, or proposals


# Further Comments
As I understand from the Vulkan docs though, `VK_LAYER_LUNARG_standard_validation` is deprecated and `VK_LAYER_KHRONOS_validation` is recommended. However, this does not exist on any of my computers. Therefore the application will exit.
https://vulkan.lunarg.com/doc/view/1.1.114.0/windows/validation_layers.html