### PR TITLE
OpenGL Tutorial 3.5: Dispose SpecularMap

### DIFF
--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Program.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Program.cs
@@ -177,7 +177,7 @@ namespace Tutorial
 
             //Bind the diffuse map and and set to use texture0.
             DiffuseMap.Bind(TextureUnit.Texture0);
-            //Bind the diffuse map and and set to use texture10.
+            //Bind the diffuse map and and set to use texture1.
             SpecularMap.Bind(TextureUnit.Texture1);
 
             //Setup the coordinate systems for our view
@@ -245,6 +245,7 @@ namespace Tutorial
             LightingShader.Dispose();
             LampShader.Dispose();
             DiffuseMap.Dispose();
+            SpecularMap.Dispose();
         }
 
         private static void KeyDown(IKeyboard keyboard, Key key, int arg3)


### PR DESCRIPTION
Also fixing a comment to say texture 1 instead of texture 10