### PR TITLE
fix Scalar.Abs for double values

### DIFF
--- a/src/Maths/Silk.NET.Maths/Scalar.MathFPort.cs
+++ b/src/Maths/Silk.NET.Maths/Scalar.MathFPort.cs
@@ -124,8 +124,8 @@ namespace Silk.NET.Maths
                     else
 #endif
                     {
-                        var v = *(uint*) &x;
-                        v &= 0x7FFF_FFFF;
+                        var v = *(ulong*) &x;
+                        v &= 0x7FFF_FFFF_FFFF_FFFF;
                         return *(T*) &v;
                     }
                 }


### PR DESCRIPTION
# Summary of the PR
The PR fixes an issue with Scalar.Abs not working for double values.

For example `Scalar.Abs(-1.0)` evalutes to 0.0 for me in a unit test using .NET 5.0 on Windows.

# Related issues, Discord discussions, or proposals
N/A

# Further Comments
Actually I found this because the following returned false:
`Matrix4X4.Invert(Matrix4X4<double>.Identity, out var invertedMatrix);`
