### PR TITLE
Update doc comments for some Maths classes

### DIFF
--- a/src/Maths/Silk.NET.Maths/Matrix2X2.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix2X2.cs
@@ -105,29 +105,29 @@ namespace Silk.NET.Maths
             }
         }
 
-        /// <summary>Constructs a Matrix2X2 from the given components.</summary>
+        /// <summary>Constructs a <see cref="Matrix2X2{T}"/> from the given components.</summary>
         public Matrix2X2(T m11, T m12, T m21, T m22)
         {
             Row1 = new(m11, m12);
             Row2 = new(m21, m22);
         }
 
-        /// <summary>Constructs a Matrix2X2 from the given rows.</summary>
+        /// <summary>Constructs a <see cref="Matrix2X2{T}"/> from the given rows.</summary>
         public Matrix2X2(Vector2D<T> row1, Vector2D<T> row2)
         {
             Row1 = row1;
             Row2 = row2;
         }
 
-        /// <summary>Constructs a Matrix2X2 from the given Matrix3X2.</summary>
-        /// <param name="value">The source Matrix3X2.</param>
+        /// <summary>Constructs a <see cref="Matrix2X2{T}"/> from the given <see cref="Matrix3X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X2{T}"/>.</param>
         public Matrix2X2(Matrix3X2<T> value)
         {
             Row1 = new(value.M11, value.M12);
             Row2 = new(value.M21, value.M22);
         }
 
-        /// <summary>Constructs a Matrix2X2 from the given Matrix4x3.</summary>
+        /// <summary>Constructs a <see cref="Matrix2X2{T}"/> from the given Matrix4x3.</summary>
         /// <param name="value">The source Matrix4x3.</param>
         public Matrix2X2(Matrix4X3<T> value)
         {
@@ -135,24 +135,24 @@ namespace Silk.NET.Maths
             Row2 = new(value.M21, value.M22);
         }
 
-        /// <summary>Constructs a Matrix2X2 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a <see cref="Matrix2X2{T}"/> from the given <see cref="Matrix3X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X4{T}"/>.</param>
         public Matrix2X2(Matrix3X4<T> value)
         {
             Row1 = new(value.M11, value.M12);
             Row2 = new(value.M21, value.M22);
         }
 
-        /// <summary>Constructs a Matrix2x2 from the given Matrix2X4.</summary>
-        /// <param name="value">The source Matrix2X4.</param>
+        /// <summary>Constructs a <see cref="Matrix2X2{T}"/> from the given <see cref="Matrix2X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix2X4{T}"/>.</param>
         public Matrix2X2(Matrix2X4<T> value)
         {
             Row1 = new(value.M11, value.M12);
             Row2 = new(value.M21, value.M22);
         }
 
-        /// <summary>Constructs a Matrix2x2 from the given Matrix4X2.</summary>
-        /// <param name="value">The source Matrix4X2.</param>
+        /// <summary>Constructs a <see cref="Matrix2X2{T}"/> from the given <see cref="Matrix4X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X2{T}"/>.</param>
         public Matrix2X2(Matrix4X2<T> value)
         {
             Row1 = new(value.M11, value.M12);

--- a/src/Maths/Silk.NET.Maths/Matrix2X2.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix2X2.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 
 namespace Silk.NET.Maths
 {
-    /// <summary>A structure encapsulating a 4x4 matrix.</summary>
+    /// <summary>A structure encapsulating a 2x2 matrix.</summary>
     [Serializable]
     [DataContract]
     public struct Matrix2X2<T> : IEquatable<Matrix2X2<T>>
@@ -143,16 +143,16 @@ namespace Silk.NET.Maths
             Row2 = new(value.M21, value.M22);
         }
 
-        /// <summary>Constructs a Matrix4x4 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a Matrix2x2 from the given Matrix2X4.</summary>
+        /// <param name="value">The source Matrix2X4.</param>
         public Matrix2X2(Matrix2X4<T> value)
         {
             Row1 = new(value.M11, value.M12);
             Row2 = new(value.M21, value.M22);
         }
 
-        /// <summary>Constructs a Matrix4x4 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a Matrix2x2 from the given Matrix4X2.</summary>
+        /// <param name="value">The source Matrix4X2.</param>
         public Matrix2X2(Matrix4X2<T> value)
         {
             Row1 = new(value.M11, value.M12);

--- a/src/Maths/Silk.NET.Maths/Matrix2X3.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix2X3.cs
@@ -130,7 +130,7 @@ namespace Silk.NET.Maths
             }
         }
 
-        /// <summary>Constructs a Matrix2X3 from the given components.</summary>
+        /// <summary>Constructs a <see cref="Matrix2X3{T}"/> from the given components.</summary>
         public Matrix2X3(T m11, T m12, T m13,
                          T m21, T m22, T m23)
         {
@@ -139,7 +139,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>
-        /// Constructs a Matrix2X3 from the given rows.
+        /// Constructs a <see cref="Matrix2X3{T}"/> from the given rows.
         /// </summary>
         public Matrix2X3(Vector3D<T> row1, Vector3D<T> row2)
         {
@@ -147,40 +147,40 @@ namespace Silk.NET.Maths
             Row2 = row2;
         }
 
-        /// <summary>Constructs a Matrix2X3 from the given Matrix3X2.</summary>
-        /// <param name="value">The source Matrix3X2.</param>
+        /// <summary>Constructs a <see cref="Matrix2X3{T}"/> from the given <see cref="Matrix3X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X2{T}"/>.</param>
         public Matrix2X3(Matrix3X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default);
             Row2 = new(value.M21, value.M22, default);
         }
 
-        /// <summary>Constructs a Matrix2X3 from the given Matrix4X3.</summary>
-        /// <param name="value">The source Matrix4X3.</param>
+        /// <summary>Constructs a <see cref="Matrix2X3{T}"/> from the given <see cref="Matrix4X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X3{T}"/>.</param>
         public Matrix2X3(Matrix4X3<T> value)
         {
             Row1 = new Vector3D<T>(value.M11, value.M12, value.M13);
             Row2 = new Vector3D<T>(value.M21, value.M22, value.M23);
         }
 
-        /// <summary>Constructs a Matrix2X3 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a <see cref="Matrix2X3{T}"/> from the given <see cref="Matrix3X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X4{T}"/>.</param>
         public Matrix2X3(Matrix3X4<T> value)
         {
             Row1 = new Vector3D<T>(value.M11, value.M12, value.M13);
             Row2 = new Vector3D<T>(value.M21, value.M22, value.M23);
         }
 
-        /// <summary>Constructs a Matrix2X3 from the given Matrix2X4.</summary>
-        /// <param name="value">The source Matrix2X4.</param>
+        /// <summary>Constructs a <see cref="Matrix2X3{T}"/> from the given <see cref="Matrix2X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix2X4{T}"/>.</param>
         public Matrix2X3(Matrix2X4<T> value)
         {
             Row1 = new Vector3D<T>(value.M11, value.M12, value.M13);
             Row2 = new Vector3D<T>(value.M21, value.M22, value.M23);
         }
 
-        /// <summary>Constructs a Matrix2X3 from the given Matrix4X2.</summary>
-        /// <param name="value">The source Matrix4X2.</param>
+        /// <summary>Constructs a <see cref="Matrix2X3{T}"/> from the given <see cref="Matrix4X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X2{T}"/>.</param>
         public Matrix2X3(Matrix4X2<T> value)
         {
             Row1 = new Vector3D<T>(value.M11, value.M12, default);

--- a/src/Maths/Silk.NET.Maths/Matrix2X3.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix2X3.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 
 namespace Silk.NET.Maths
 {
-    /// <summary>A structure encapsulating a 4x4 matrix.</summary>
+    /// <summary>A structure encapsulating a 2x3 matrix.</summary>
     [Serializable]
     [DataContract]
     public struct Matrix2X3<T> : IEquatable<Matrix2X3<T>>
@@ -171,16 +171,16 @@ namespace Silk.NET.Maths
             Row2 = new Vector3D<T>(value.M21, value.M22, value.M23);
         }
 
-        /// <summary>Constructs a Matrix4X4 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a Matrix2X3 from the given Matrix2X4.</summary>
+        /// <param name="value">The source Matrix2X4.</param>
         public Matrix2X3(Matrix2X4<T> value)
         {
             Row1 = new Vector3D<T>(value.M11, value.M12, value.M13);
             Row2 = new Vector3D<T>(value.M21, value.M22, value.M23);
         }
 
-        /// <summary>Constructs a Matrix4X4 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a Matrix2X3 from the given Matrix4X2.</summary>
+        /// <param name="value">The source Matrix4X2.</param>
         public Matrix2X3(Matrix4X2<T> value)
         {
             Row1 = new Vector3D<T>(value.M11, value.M12, default);

--- a/src/Maths/Silk.NET.Maths/Matrix2X4.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix2X4.cs
@@ -153,7 +153,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>
-        /// Constructs a Matrix2X4 from the given rows
+        /// Constructs a <see cref="Matrix2X4{T}"/> from the given rows
         /// </summary>
         public Matrix2X4(Vector4D<T> row1, Vector4D<T> row2)
         {
@@ -161,22 +161,22 @@ namespace Silk.NET.Maths
             Row2 = row2;
         }
 
-        /// <summary>Constructs a Matrix2X4 from the given components.</summary>
+        /// <summary>Constructs a <see cref="Matrix2X4{T}"/> from the given components.</summary>
         public Matrix2X4(T m11, T m12, T m13, T m14, T m21, T m22, T m23, T m24)
         {
             Row1 = new(m11, m12, m13, m14);
             Row2 = new(m21, m22, m23, m24);
         }
 
-        /// <summary>Constructs a Matrix2X4 from the given Matrix3X2.</summary>
-        /// <param name="value">The source Matrix3X2.</param>
+        /// <summary>Constructs a <see cref="Matrix2X4{T}"/> from the given <see cref="Matrix3X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X2{T}"/>.</param>
         public Matrix2X4(Matrix3X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default, default);
             Row2 = new(value.M21, value.M22, default, default);
         }
 
-        /// <summary>Constructs a Matrix2X4 from the given Matrix4x3.</summary>
+        /// <summary>Constructs a <see cref="Matrix2X4{T}"/> from the given Matrix4x3.</summary>
         /// <param name="value">The source Matrix4x3.</param>
         public Matrix2X4(Matrix4X3<T> value)
         {
@@ -184,24 +184,24 @@ namespace Silk.NET.Maths
             Row2 = new(value.M21, value.M22, value.M23, default);
         }
 
-        /// <summary>Constructs a Matrix2X4 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a <see cref="Matrix2X4{T}"/> from the given <see cref="Matrix3X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X4{T}"/>.</param>
         public Matrix2X4(Matrix3X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13, value.M14);
             Row2 = new(value.M21, value.M22, value.M23, value.M24);
         }
 
-        /// <summary>Constructs a Matrix2X4 from the given Matrix3X3.</summary>
-        /// <param name="value">The source Matrix3X3.</param>
+        /// <summary>Constructs a <see cref="Matrix2X4{T}"/> from the given <see cref="Matrix3X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X3{T}"/>.</param>
         public Matrix2X4(Matrix3X3<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13, default);
             Row2 = new(value.M21, value.M22, value.M23, default);
         }
 
-        /// <summary>Constructs a Matrix2x4 from the given Matrix4X2.</summary>
-        /// <param name="value">The source Matrix4X2.</param>
+        /// <summary>Constructs a Matrix2x4 from the given <see cref="Matrix4X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X2{T}"/>.</param>
         public Matrix2X4(Matrix4X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default, default);

--- a/src/Maths/Silk.NET.Maths/Matrix2X4.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix2X4.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 
 namespace Silk.NET.Maths
 {
-    /// <summary>A structure encapsulating a 4x4 matrix.</summary>
+    /// <summary>A structure encapsulating a 2x4 matrix.</summary>
     [Serializable]
     [DataContract]
     public struct Matrix2X4<T> : IEquatable<Matrix2X4<T>>
@@ -200,8 +200,8 @@ namespace Silk.NET.Maths
             Row2 = new(value.M21, value.M22, value.M23, default);
         }
 
-        /// <summary>Constructs a Matrix4x4 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a Matrix2x4 from the given Matrix4X2.</summary>
+        /// <param name="value">The source Matrix4X2.</param>
         public Matrix2X4(Matrix4X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default, default);

--- a/src/Maths/Silk.NET.Maths/Matrix3X2.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix3X2.cs
@@ -178,8 +178,8 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32);
         }
 
-        /// <summary>Constructs a Matrix4X4 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a Matrix3X2 from the given Matrix2X4.</summary>
+        /// <param name="value">The source Matrix2X4.</param>
         public Matrix3X2(Matrix2X4<T> value)
         {
             Row1 = new(value.M11, value.M12);
@@ -187,8 +187,8 @@ namespace Silk.NET.Maths
             Row3 = Vector2D<T>.Zero;
         }
 
-        /// <summary>Constructs a Matrix4X4 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a Matrix3X2 from the given Matrix4X2.</summary>
+        /// <param name="value">The source Matrix4X2.</param>
         public Matrix3X2(Matrix4X2<T> value)
         {
             Row1 = new(value.M11, value.M12);

--- a/src/Maths/Silk.NET.Maths/Matrix3X2.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix3X2.cs
@@ -131,7 +131,7 @@ namespace Silk.NET.Maths
             }
         }
 
-        /// <summary>Constructs a Matrix3X2 from the given components.</summary>
+        /// <summary>Constructs a <see cref="Matrix3X2{T}"/> from the given components.</summary>
         public Matrix3X2(T m11, T m12,
             T m21, T m22,
             T m31, T m32)
@@ -142,7 +142,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>
-        /// Constructs a Matrix3X2 from the given rows.
+        /// Constructs a <see cref="Matrix3X2{T}"/> from the given rows.
         /// </summary>
         public Matrix3X2(Vector2D<T> row1, Vector2D<T> row2, Vector2D<T> row3)
         {
@@ -151,7 +151,7 @@ namespace Silk.NET.Maths
             Row3 = row3;
         }
 
-        /// <summary>Constructs a Matrix3X2 from the given Matrix4x3.</summary>
+        /// <summary>Constructs a <see cref="Matrix3X2{T}"/> from the given Matrix4x3.</summary>
         /// <param name="value">The source Matrix4x3.</param>
         public Matrix3X2(Matrix4X3<T> value)
         {
@@ -160,8 +160,8 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32);
         }
 
-        /// <summary>Constructs a Matrix3X2 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a <see cref="Matrix3X2{T}"/> from the given <see cref="Matrix3X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X4{T}"/>.</param>
         public Matrix3X2(Matrix3X4<T> value)
         {
             Row1 = new(value.M11, value.M12);
@@ -169,8 +169,8 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32);
         }
 
-        /// <summary>Constructs a Matrix3X2 from the given Matrix3X3.</summary>
-        /// <param name="value">The source Matrix3X3.</param>
+        /// <summary>Constructs a <see cref="Matrix3X2{T}"/> from the given <see cref="Matrix3X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X3{T}"/>.</param>
         public Matrix3X2(Matrix3X3<T> value)
         {
             Row1 = new(value.M11, value.M12);
@@ -178,8 +178,8 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32);
         }
 
-        /// <summary>Constructs a Matrix3X2 from the given Matrix2X4.</summary>
-        /// <param name="value">The source Matrix2X4.</param>
+        /// <summary>Constructs a <see cref="Matrix3X2{T}"/> from the given <see cref="Matrix2X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix2X4{T}"/>.</param>
         public Matrix3X2(Matrix2X4<T> value)
         {
             Row1 = new(value.M11, value.M12);
@@ -187,8 +187,8 @@ namespace Silk.NET.Maths
             Row3 = Vector2D<T>.Zero;
         }
 
-        /// <summary>Constructs a Matrix3X2 from the given Matrix4X2.</summary>
-        /// <param name="value">The source Matrix4X2.</param>
+        /// <summary>Constructs a <see cref="Matrix3X2{T}"/> from the given <see cref="Matrix4X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X2{T}"/>.</param>
         public Matrix3X2(Matrix4X2<T> value)
         {
             Row1 = new(value.M11, value.M12);

--- a/src/Maths/Silk.NET.Maths/Matrix3X3.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix3X3.cs
@@ -164,7 +164,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>
-        /// Constructs a Matrix3X3 from the given rows.
+        /// Constructs a <see cref="Matrix3X3{T}"/> from the given rows.
         /// </summary>
         public Matrix3X3(Vector3D<T> row1, Vector3D<T> row2, Vector3D<T> row3)
         {
@@ -173,7 +173,7 @@ namespace Silk.NET.Maths
             Row3 = row3;
         }
 
-        /// <summary>Constructs a Matrix3X3 from the given components.</summary>
+        /// <summary>Constructs a <see cref="Matrix3X3{T}"/> from the given components.</summary>
         public Matrix3X3(T m11, T m12, T m13, T m21, T m22, T m23, T m31, T m32, T m33)
         {
             Row1 = new(m11, m12, m13);
@@ -181,8 +181,8 @@ namespace Silk.NET.Maths
             Row3 = new(m31, m32, m33);
         }
 
-        /// <summary>Constructs a Matrix3X3 from the given Matrix3X2.</summary>
-        /// <param name="value">The source Matrix3X2.</param>
+        /// <summary>Constructs a <see cref="Matrix3X3{T}"/> from the given <see cref="Matrix3X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X2{T}"/>.</param>
         public Matrix3X3(Matrix3X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default);
@@ -190,8 +190,8 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32, Scalar<T>.One);
         }
 
-        /// <summary>Constructs a Matrix3X3 from the given Matrix4X3.</summary>
-        /// <param name="value">The source Matrix4X3.</param>
+        /// <summary>Constructs a <see cref="Matrix3X3{T}"/> from the given <see cref="Matrix4X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X3{T}"/>.</param>
         public Matrix3X3(Matrix4X3<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);
@@ -199,8 +199,8 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32, value.M33);
         }
 
-        /// <summary>Constructs a Matrix3X3 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a <see cref="Matrix3X3{T}"/> from the given <see cref="Matrix3X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X4{T}"/>.</param>
         public Matrix3X3(Matrix3X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);
@@ -208,8 +208,8 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32, value.M33);
         }
 
-        /// <summary>Constructs a Matrix3X3 from the given Matrix3X3.</summary>
-        /// <param name="value">The source Matrix3X3.</param>
+        /// <summary>Constructs a <see cref="Matrix3X3{T}"/> from the given <see cref="Matrix3X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X3{T}"/>.</param>
         public Matrix3X3(Matrix3X3<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);
@@ -217,8 +217,8 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32, value.M33);
         }
 
-        /// <summary>Constructs a Matrix3X3 from the given Matrix2X4.</summary>
-        /// <param name="value">The source Matrix2X4.</param>
+        /// <summary>Constructs a <see cref="Matrix3X3{T}"/> from the given <see cref="Matrix2X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix2X4{T}"/>.</param>
         public Matrix3X3(Matrix2X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);
@@ -226,8 +226,8 @@ namespace Silk.NET.Maths
             Row3 = Vector3D<T>.UnitZ;
         }
 
-        /// <summary>Constructs a Matrix3X3 from the given Matrix4X2.</summary>
-        /// <param name="value">The source Matrix4X2.</param>
+        /// <summary>Constructs a <see cref="Matrix3X3{T}"/> from the given <see cref="Matrix4X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X2{T}"/>.</param>
         public Matrix3X3(Matrix4X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default);
@@ -235,8 +235,8 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32, Scalar<T>.One);
         }
 
-        /// <summary>Constructs a Matrix3X3 from the given Matrix4X4.</summary>
-        /// <param name="value">The source Matrix4X4.</param>
+        /// <summary>Constructs a <see cref="Matrix3X3{T}"/> from the given <see cref="Matrix4X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X4{T}"/>.</param>
         public Matrix3X3(Matrix4X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);

--- a/src/Maths/Silk.NET.Maths/Matrix3X3.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix3X3.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 
 namespace Silk.NET.Maths
 {
-    /// <summary>A structure encapsulating a 4x4 matrix.</summary>
+    /// <summary>A structure encapsulating a 3x3 matrix.</summary>
     [Serializable]
     [DataContract]
     public struct Matrix3X3<T> : IEquatable<Matrix3X3<T>>
@@ -218,7 +218,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>Constructs a Matrix3X3 from the given Matrix2X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <param name="value">The source Matrix2X4.</param>
         public Matrix3X3(Matrix2X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);
@@ -227,7 +227,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>Constructs a Matrix3X3 from the given Matrix4X2.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <param name="value">The source Matrix4X2.</param>
         public Matrix3X3(Matrix4X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default);
@@ -236,7 +236,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>Constructs a Matrix3X3 from the given Matrix4X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <param name="value">The source Matrix4X4.</param>
         public Matrix3X3(Matrix4X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);

--- a/src/Maths/Silk.NET.Maths/Matrix3X4.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix3X4.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 
 namespace Silk.NET.Maths
 {
-    /// <summary>A structure encapsulating a 4x4 matrix.</summary>
+    /// <summary>A structure encapsulating a 3x4 matrix.</summary>
     [Serializable]
     [DataContract]
     public struct Matrix3X4<T> : IEquatable<Matrix3X4<T>>
@@ -239,7 +239,7 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32, value.M33, value.M34);
         }
 
-        /// <summary>Constructs a Matrix4X4 from the given Matrix3X3.</summary>
+        /// <summary>Constructs a Matrix3X4 from the given Matrix3X3.</summary>
         /// <param name="value">The source Matrix3X3.</param>
         public Matrix3X4(Matrix3X3<T> value)
         {
@@ -248,8 +248,8 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32, value.M33, default);
         }
 
-        /// <summary>Constructs a Matrix4X4 from the given Matrix2X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a Matrix3X4 from the given Matrix2X4.</summary>
+        /// <param name="value">The source Matrix2X4.</param>
         public Matrix3X4(Matrix2X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13, value.M14);
@@ -257,8 +257,8 @@ namespace Silk.NET.Maths
             Row3 = Vector4D<T>.UnitZ;
         }
 
-        /// <summary>Constructs a Matrix4X4 from the given Matrix4X2.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a Matrix3X4 from the given Matrix4X2.</summary>
+        /// <param name="value">The source Matrix4X2.</param>
         public Matrix3X4(Matrix4X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default, default);

--- a/src/Maths/Silk.NET.Maths/Matrix3X4.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix3X4.cs
@@ -192,7 +192,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>
-        /// Constructs a Matrix3X4 from the given rows.
+        /// Constructs a <see cref="Matrix3X4{T}"/> from the given rows.
         /// </summary>
         /// <param name="row1"></param>
         /// <param name="row2"></param>
@@ -204,7 +204,7 @@ namespace Silk.NET.Maths
             Row3 = row3;
         }
 
-        /// <summary>Constructs a Matrix3X4 from the given components.</summary>
+        /// <summary>Constructs a <see cref="Matrix3X4{T}"/> from the given components.</summary>
         public Matrix3X4(T m11, T m12, T m13, T m14, T m21, T m22, T m23, T m24, T m31, T m32, T m33, T m34)
         {
             Row1 = new(m11, m12, m13, m14);
@@ -212,8 +212,8 @@ namespace Silk.NET.Maths
             Row3 = new(m31, m32, m33, m34);
         }
 
-        /// <summary>Constructs a Matrix3X4 from the given Matrix3X2.</summary>
-        /// <param name="value">The source Matrix3X2.</param>
+        /// <summary>Constructs a <see cref="Matrix3X4{T}"/> from the given <see cref="Matrix3X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X2{T}"/>.</param>
         public Matrix3X4(Matrix3X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default, default);
@@ -221,8 +221,8 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32, Scalar<T>.One, default);
         }
 
-        /// <summary>Constructs a Matrix3X4 from the given Matrix4X3.</summary>
-        /// <param name="value">The source Matrix4X3.</param>
+        /// <summary>Constructs a <see cref="Matrix3X4{T}"/> from the given <see cref="Matrix4X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X3{T}"/>.</param>
         public Matrix3X4(Matrix4X3<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13, default);
@@ -230,8 +230,8 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32, value.M33, default);
         }
 
-        /// <summary>Constructs a Matrix3X4 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a <see cref="Matrix3X4{T}"/> from the given <see cref="Matrix3X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X4{T}"/>.</param>
         public Matrix3X4(Matrix3X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13, value.M14);
@@ -239,8 +239,8 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32, value.M33, value.M34);
         }
 
-        /// <summary>Constructs a Matrix3X4 from the given Matrix3X3.</summary>
-        /// <param name="value">The source Matrix3X3.</param>
+        /// <summary>Constructs a <see cref="Matrix3X4{T}"/> from the given <see cref="Matrix3X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X3{T}"/>.</param>
         public Matrix3X4(Matrix3X3<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13, default);
@@ -248,8 +248,8 @@ namespace Silk.NET.Maths
             Row3 = new(value.M31, value.M32, value.M33, default);
         }
 
-        /// <summary>Constructs a Matrix3X4 from the given Matrix2X4.</summary>
-        /// <param name="value">The source Matrix2X4.</param>
+        /// <summary>Constructs a <see cref="Matrix3X4{T}"/> from the given <see cref="Matrix2X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix2X4{T}"/>.</param>
         public Matrix3X4(Matrix2X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13, value.M14);
@@ -257,8 +257,8 @@ namespace Silk.NET.Maths
             Row3 = Vector4D<T>.UnitZ;
         }
 
-        /// <summary>Constructs a Matrix3X4 from the given Matrix4X2.</summary>
-        /// <param name="value">The source Matrix4X2.</param>
+        /// <summary>Constructs a <see cref="Matrix3X4{T}"/> from the given <see cref="Matrix4X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X2{T}"/>.</param>
         public Matrix3X4(Matrix4X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default, default);

--- a/src/Maths/Silk.NET.Maths/Matrix4X2.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix4X2.cs
@@ -158,7 +158,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>
-        /// Constructs a Matrix4X2 from the given rows.
+        /// Constructs a <see cref="Matrix4X2{T}"/> from the given rows.
         /// </summary>
         public Matrix4X2(Vector2D<T> row1, Vector2D<T> row2, Vector2D<T> row3, Vector2D<T> row4)
         {
@@ -168,7 +168,7 @@ namespace Silk.NET.Maths
             Row4 = row4;
         }
 
-        /// <summary>Constructs a Matrix4X2 from the given components.</summary>
+        /// <summary>Constructs a <see cref="Matrix4X2{T}"/> from the given components.</summary>
         public Matrix4X2(T m11, T m12, T m21, T m22, T m31, T m32, T m41, T m42)
         {
             Row1 = new(m11, m12);
@@ -177,8 +177,8 @@ namespace Silk.NET.Maths
             Row4 = new(m41, m42);
         }
 
-        /// <summary>Constructs a Matrix4X2 from the given Matrix3X2.</summary>
-        /// <param name="value">The source Matrix3X2.</param>
+        /// <summary>Constructs a <see cref="Matrix4X2{T}"/> from the given <see cref="Matrix3X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X2{T}"/>.</param>
         public Matrix4X2(Matrix3X2<T> value)
         {
             Row1 = new(value.M11, value.M12);
@@ -187,8 +187,8 @@ namespace Silk.NET.Maths
             Row4 = new(value.M31, value.M32);
         }
 
-        /// <summary>Constructs a Matrix4X2 from the given Matrix4X3.</summary>
-        /// <param name="value">The source Matrix4X3.</param>
+        /// <summary>Constructs a <see cref="Matrix4X2{T}"/> from the given <see cref="Matrix4X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X3{T}"/>.</param>
         public Matrix4X2(Matrix4X3<T> value)
         {
             Row1 = new(value.M11, value.M12);
@@ -197,8 +197,8 @@ namespace Silk.NET.Maths
             Row4 = new(value.M41, value.M42);
         }
 
-        /// <summary>Constructs a Matrix4X2 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a <see cref="Matrix4X2{T}"/> from the given <see cref="Matrix3X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X4{T}"/>.</param>
         public Matrix4X2(Matrix3X4<T> value)
         {
             Row1 = new(value.M11, value.M12);
@@ -207,8 +207,8 @@ namespace Silk.NET.Maths
             Row4 = default;
         }
 
-        /// <summary>Constructs a Matrix4X2 from the given Matrix3X3.</summary>
-        /// <param name="value">The source Matrix3X3.</param>
+        /// <summary>Constructs a <see cref="Matrix4X2{T}"/> from the given <see cref="Matrix3X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X3{T}"/>.</param>
         public Matrix4X2(Matrix3X3<T> value)
         {
             Row1 = new(value.M11, value.M12);
@@ -217,8 +217,8 @@ namespace Silk.NET.Maths
             Row4 = new(value.M31, value.M32);
         }
 
-        /// <summary>Constructs a Matrix4X2 from the given Matrix2X4.</summary>
-        /// <param name="value">The source Matrix2X4.</param>
+        /// <summary>Constructs a <see cref="Matrix4X2{T}"/> from the given <see cref="Matrix2X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix2X4{T}"/>.</param>
         public Matrix4X2(Matrix2X4<T> value)
         {
             Row1 = new(value.M11, value.M12);

--- a/src/Maths/Silk.NET.Maths/Matrix4X2.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix4X2.cs
@@ -6,7 +6,7 @@ using System.Runtime.Serialization;
 
 namespace Silk.NET.Maths
 {
-    /// <summary>A structure encapsulating a 4x4 matrix.</summary>
+    /// <summary>A structure encapsulating a 4x2 matrix.</summary>
     [Serializable]
     [DataContract]
     public struct Matrix4X2<T> : IEquatable<Matrix4X2<T>>
@@ -218,7 +218,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>Constructs a Matrix4X2 from the given Matrix2X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <param name="value">The source Matrix2X4.</param>
         public Matrix4X2(Matrix2X4<T> value)
         {
             Row1 = new(value.M11, value.M12);

--- a/src/Maths/Silk.NET.Maths/Matrix4X3.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix4X3.cs
@@ -193,7 +193,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>
-        /// Constructs a Matrix4X3 from the given rows.
+        /// Constructs a <see cref="Matrix4X3{T}"/> from the given rows.
         /// </summary>
         public Matrix4X3(Vector3D<T> row1, Vector3D<T> row2, Vector3D<T> row3, Vector3D<T> row4)
         {
@@ -203,7 +203,7 @@ namespace Silk.NET.Maths
             Row4 = row4;
         }
 
-        /// <summary>Constructs a Matrix4X3 from the given components.</summary>
+        /// <summary>Constructs a <see cref="Matrix4X3{T}"/> from the given components.</summary>
         public Matrix4X3(T m11, T m12, T m13, T m21, T m22, T m23, T m31, T m32, T m33, T m41, T m42, T m43)
         {
             Row1 = new(m11, m12, m13);
@@ -212,8 +212,8 @@ namespace Silk.NET.Maths
             Row4 = new(m41, m42, m43);
         }
 
-        /// <summary>Constructs a Matrix4X3 from the given Matrix3X2.</summary>
-        /// <param name="value">The source Matrix3X2.</param>
+        /// <summary>Constructs a <see cref="Matrix4X3{T}"/> from the given <see cref="Matrix3X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X2{T}"/>.</param>
         public Matrix4X3(Matrix3X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default);
@@ -222,8 +222,8 @@ namespace Silk.NET.Maths
             Row4 = new(value.M31, value.M32, default);
         }
 
-        /// <summary>Constructs a Matrix4X3 from the given Matrix4X3.</summary>
-        /// <param name="value">The source Matrix4X3.</param>
+        /// <summary>Constructs a <see cref="Matrix4X3{T}"/> from the given <see cref="Matrix4X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X3{T}"/>.</param>
         public Matrix4X3(Matrix4X3<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);
@@ -232,8 +232,8 @@ namespace Silk.NET.Maths
             Row4 = new(value.M41, value.M42, value.M43);
         }
 
-        /// <summary>Constructs a Matrix4X3 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a <see cref="Matrix4X3{T}"/> from the given <see cref="Matrix3X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X4{T}"/>.</param>
         public Matrix4X3(Matrix3X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);
@@ -242,8 +242,8 @@ namespace Silk.NET.Maths
             Row4 = default;
         }
 
-        /// <summary>Constructs a Matrix4X3 from the given Matrix3X3.</summary>
-        /// <param name="value">The source Matrix3X3.</param>
+        /// <summary>Constructs a <see cref="Matrix4X3{T}"/> from the given <see cref="Matrix3X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X3{T}"/>.</param>
         public Matrix4X3(Matrix3X3<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);
@@ -252,8 +252,8 @@ namespace Silk.NET.Maths
             Row4 = new(value.M31, value.M32, value.M33);
         }
 
-        /// <summary>Constructs a Matrix4X3 from the given Matrix2X4.</summary>
-        /// <param name="value">The source Matrix2X4.</param>
+        /// <summary>Constructs a <see cref="Matrix4X3{T}"/> from the given <see cref="Matrix2X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix2X4{T}"/>.</param>
         public Matrix4X3(Matrix2X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);
@@ -262,8 +262,8 @@ namespace Silk.NET.Maths
             Row4 = default;
         }
 
-        /// <summary>Constructs a Matrix4X3 from the given Matrix4X2.</summary>
-        /// <param name="value">The source Matrix4X2.</param>
+        /// <summary>Constructs a <see cref="Matrix4X3{T}"/> from the given <see cref="Matrix4X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X2{T}"/>.</param>
         public Matrix4X3(Matrix4X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default);
@@ -272,8 +272,8 @@ namespace Silk.NET.Maths
             Row4 = new(value.M41, value.M42, Scalar<T>.One);
         }
 
-        /// <summary>Constructs a Matrix4X3 from the given Matrix4X4.</summary>
-        /// <param name="value">The source Matrix4X4.</param>
+        /// <summary>Constructs a <see cref="Matrix4X3{T}"/> from the given <see cref="Matrix4X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X4{T}"/>.</param>
         public Matrix4X3(Matrix4X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);

--- a/src/Maths/Silk.NET.Maths/Matrix4X3.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix4X3.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 
 namespace Silk.NET.Maths
 {
-    /// <summary>A structure encapsulating a 4x4 matrix.</summary>
+    /// <summary>A structure encapsulating a 4x3 matrix.</summary>
     [Serializable]
     [DataContract]
     public struct Matrix4X3<T> : IEquatable<Matrix4X3<T>>
@@ -253,7 +253,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>Constructs a Matrix4X3 from the given Matrix2X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <param name="value">The source Matrix2X4.</param>
         public Matrix4X3(Matrix2X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);
@@ -263,7 +263,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>Constructs a Matrix4X3 from the given Matrix4X2.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <param name="value">The source Matrix4X2.</param>
         public Matrix4X3(Matrix4X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default);
@@ -273,7 +273,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>Constructs a Matrix4X3 from the given Matrix4X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <param name="value">The source Matrix4X4.</param>
         public Matrix4X3(Matrix4X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);

--- a/src/Maths/Silk.NET.Maths/Matrix4X4.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix4X4.cs
@@ -309,7 +309,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>Constructs a Matrix4X4 from the given Matrix2X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <param name="value">The source Matrix2X4.</param>
         public Matrix4X4(Matrix2X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13, value.M14);
@@ -319,7 +319,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>Constructs a Matrix4X4 from the given Matrix4X2.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <param name="value">The source Matrix4X2.</param>
         public Matrix4X4(Matrix4X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default, default);

--- a/src/Maths/Silk.NET.Maths/Matrix4X4.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix4X4.cs
@@ -231,7 +231,7 @@ namespace Silk.NET.Maths
         }
 
         /// <summary>
-        /// Constructs a Matrix4X4 from the given rows
+        /// Constructs a <see cref="Matrix4X4{T}"/> from the given rows
         /// </summary>
         public Matrix4X4(Vector4D<T> row1, Vector4D<T> row2, Vector4D<T> row3, Vector4D<T> row4)
         {
@@ -241,7 +241,7 @@ namespace Silk.NET.Maths
             Row4 = row4;
         }
 
-        /// <summary>Constructs a Matrix4X4 from the given components.</summary>
+        /// <summary>Constructs a <see cref="Matrix4X4{T}"/> from the given components.</summary>
         public Matrix4X4
         (
             T m11,
@@ -268,8 +268,8 @@ namespace Silk.NET.Maths
             Row4 = new(m41, m42, m43, m44);
         }
 
-        /// <summary>Constructs a Matrix4X4 from the given Matrix3X2.</summary>
-        /// <param name="value">The source Matrix3X2.</param>
+        /// <summary>Constructs a <see cref="Matrix4X4{T}"/> from the given <see cref="Matrix3X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X2{T}"/>.</param>
         public Matrix4X4(Matrix3X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default, default);
@@ -278,8 +278,8 @@ namespace Silk.NET.Maths
             Row3 = new(default, default, Scalar<T>.One, default);
         }
 
-        /// <summary>Constructs a Matrix4X4 from the given Matrix4X3.</summary>
-        /// <param name="value">The source Matrix4X3.</param>
+        /// <summary>Constructs a <see cref="Matrix4X4{T}"/> from the given <see cref="Matrix4X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X3{T}"/>.</param>
         public Matrix4X4(Matrix4X3<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13, default);
@@ -288,8 +288,8 @@ namespace Silk.NET.Maths
             Row4 = new(value.M41, value.M42, value.M43, Scalar<T>.One);
         }
 
-        /// <summary>Constructs a Matrix4X4 from the given Matrix3X4.</summary>
-        /// <param name="value">The source Matrix3X4.</param>
+        /// <summary>Constructs a <see cref="Matrix4X4{T}"/> from the given <see cref="Matrix3X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X4{T}"/>.</param>
         public Matrix4X4(Matrix3X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13, value.M14);
@@ -298,8 +298,8 @@ namespace Silk.NET.Maths
             Row4 = default;
         }
 
-        /// <summary>Constructs a Matrix4X4 from the given Matrix3X3.</summary>
-        /// <param name="value">The source Matrix3X3.</param>
+        /// <summary>Constructs a <see cref="Matrix4X4{T}"/> from the given <see cref="Matrix3X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix3X3{T}"/>.</param>
         public Matrix4X4(Matrix3X3<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13, default);
@@ -308,8 +308,8 @@ namespace Silk.NET.Maths
             Row3 = new(default, default, Scalar<T>.One, default);
         }
 
-        /// <summary>Constructs a Matrix4X4 from the given Matrix2X4.</summary>
-        /// <param name="value">The source Matrix2X4.</param>
+        /// <summary>Constructs a <see cref="Matrix4X4{T}"/> from the given <see cref="Matrix2X4{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix2X4{T}"/>.</param>
         public Matrix4X4(Matrix2X4<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13, value.M14);
@@ -318,8 +318,8 @@ namespace Silk.NET.Maths
             Row4 = Vector4D<T>.UnitW;
         }
 
-        /// <summary>Constructs a Matrix4X4 from the given Matrix4X2.</summary>
-        /// <param name="value">The source Matrix4X2.</param>
+        /// <summary>Constructs a <see cref="Matrix4X4{T}"/> from the given <see cref="Matrix4X2{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X2{T}"/>.</param>
         public Matrix4X4(Matrix4X2<T> value)
         {
             Row1 = new(value.M11, value.M12, default, default);

--- a/src/Maths/Silk.NET.Maths/Scalar.MathFPort.cs
+++ b/src/Maths/Silk.NET.Maths/Scalar.MathFPort.cs
@@ -124,8 +124,8 @@ namespace Silk.NET.Maths
                     else
 #endif
                     {
-                        var v = *(uint*) &x;
-                        v &= 0x7FFF_FFFF;
+                        var v = *(ulong*) &x;
+                        v &= 0x7FFF_FFFF_FFFF_FFFF;
                         return *(T*) &v;
                     }
                 }

--- a/src/Maths/Silk.NET.Maths/Vector2D.cs
+++ b/src/Maths/Silk.NET.Maths/Vector2D.cs
@@ -103,12 +103,12 @@ namespace Silk.NET.Maths
             array[index + 1] = Y;
         }
 
-        /// <summary>Returns a boolean indicating whether the given Vector2D is equal to this Vector2D instance.</summary>
-        /// <param name="other">The Vector2D to compare this instance to.</param>
-        /// <returns>True if the other Vector2D is equal to this instance; False otherwise.</returns>
+        /// <summary>Returns a boolean indicating whether the given <see cref="Vector2D{T}"/> is equal to this <see cref="Vector2D{T}"/> instance.</summary>
+        /// <param name="other">The <see cref="Vector2D{T}"/> to compare this instance to.</param>
+        /// <returns>True if the other <see cref="Vector2D{T}"/> is equal to this instance; False otherwise.</returns>
         public readonly bool Equals(Vector2D<T> other) => this == other;
 
-        /// <summary>Returns a boolean indicating whether the given Object is equal to this Vector2D instance.</summary>
+        /// <summary>Returns a boolean indicating whether the given Object is equal to this <see cref="Vector2D{T}"/> instance.</summary>
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this Vector2D; False otherwise.</returns>
         [MethodImpl((MethodImplOptions) 768)]
@@ -210,16 +210,16 @@ namespace Silk.NET.Maths
         [MethodImpl((MethodImplOptions) 768)]
         public static Vector2D<T> operator -(Vector2D<T> value) => Zero - value;
 
-        /// <summary>Returns a String representing this Vector2D instance.</summary>
+        /// <summary>Returns a String representing this <see cref="Vector2D{T}"/> instance.</summary>
         /// <returns>The string representation.</returns>
         public override readonly string ToString() => ToString("G", CultureInfo.CurrentCulture);
 
-        /// <summary>Returns a String representing this Vector2D instance, using the specified format to format individual elements.</summary>
+        /// <summary>Returns a String representing this <see cref="Vector2D{T}"/> instance, using the specified format to format individual elements.</summary>
         /// <param name="format">The format of individual elements.</param>
         /// <returns>The string representation.</returns>
         public readonly string ToString(string? format) => ToString(format, CultureInfo.CurrentCulture);
 
-        /// <summary>Returns a String representing this Vector2D instance, using the specified format to format individual elements and the given IFormatProvider.</summary>
+        /// <summary>Returns a String representing this <see cref="Vector2D{T}"/> instance, using the specified format to format individual elements and the given IFormatProvider.</summary>
         /// <param name="format">The format of individual elements.</param>
         /// <param name="formatProvider">The format provider to use when formatting elements.</param>
         /// <returns>The string representation.</returns>

--- a/src/Maths/Silk.NET.Maths/Vector3D.cs
+++ b/src/Maths/Silk.NET.Maths/Vector3D.cs
@@ -29,7 +29,7 @@ namespace Silk.NET.Maths
         /// <param name="value">The element to fill the vector with.</param>
         public Vector3D(T value) => (X, Y, Z) = (value, value, value);
 
-        /// <summary>Constructs a Vector3D from the given Vector2D and a third value.</summary>
+        /// <summary>Constructs a <see cref="Vector3D{T}"/> from the given <see cref="Vector2D{T}"/> and a third value.</summary>
         /// <param name="value">The Vector to extract X and Y components from.</param>
         /// <param name="z">The Z component.</param>
         public Vector3D(Vector2D<T> value, T z) => (X, Y, Z) = (value.X, value.Y, z);
@@ -194,7 +194,7 @@ namespace Silk.NET.Maths
             array[index + 2] = Z;
         }
 
-        /// <summary>Returns a boolean indicating whether the given Object is equal to this Vector3D instance.</summary>
+        /// <summary>Returns a boolean indicating whether the given Object is equal to this <see cref="Vector3D{T}"/> instance.</summary>
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this Vector3D; False otherwise.</returns>
         [MethodImpl((MethodImplOptions) 768)]
@@ -203,9 +203,9 @@ namespace Silk.NET.Maths
             return (obj is Vector3D<T> other) && Equals(other);
         }
 
-        /// <summary>Returns a boolean indicating whether the given Vector3D is equal to this Vector3D instance.</summary>
-        /// <param name="other">The Vector3D to compare this instance to.</param>
-        /// <returns>True if the other Vector3D is equal to this instance; False otherwise.</returns>
+        /// <summary>Returns a boolean indicating whether the given <see cref="Vector3D{T}"/> is equal to this <see cref="Vector3D{T}"/> instance.</summary>
+        /// <param name="other">The <see cref="Vector3D{T}"/> to compare this instance to.</param>
+        /// <returns>True if the other <see cref="Vector3D{T}"/> is equal to this instance; False otherwise.</returns>
         public readonly bool Equals(Vector3D<T> other)
         {
             return this == other;
@@ -234,16 +234,16 @@ namespace Silk.NET.Maths
             get => Vector3D.Dot(this, this);
         }
 
-        /// <summary>Returns a String representing this Vector3D instance.</summary>
+        /// <summary>Returns a String representing this <see cref="Vector3D{T}"/> instance.</summary>
         /// <returns>The string representation.</returns>
         public override readonly string ToString() => ToString("G", CultureInfo.CurrentCulture);
 
-        /// <summary>Returns a String representing this Vector3D instance, using the specified format to format individual elements.</summary>
+        /// <summary>Returns a String representing this <see cref="Vector3D{T}"/> instance, using the specified format to format individual elements.</summary>
         /// <param name="format">The format of individual elements.</param>
         /// <returns>The string representation.</returns>
         public readonly string ToString(string? format) => ToString(format, CultureInfo.CurrentCulture);
 
-        /// <summary>Returns a String representing this Vector3D instance, using the specified format to format individual elements and the given IFormatProvider.</summary>
+        /// <summary>Returns a String representing this <see cref="Vector3D{T}"/> instance, using the specified format to format individual elements and the given IFormatProvider.</summary>
         /// <param name="format">The format of individual elements.</param>
         /// <param name="formatProvider">The format provider to use when formatting elements.</param>
         /// <returns>The string representation.</returns>

--- a/src/Maths/Silk.NET.Maths/Vector4D.cs
+++ b/src/Maths/Silk.NET.Maths/Vector4D.cs
@@ -54,13 +54,13 @@ namespace Silk.NET.Maths
         /// <param name="value">The element to fill the vector with.</param>
         public Vector4D(T value) => (X, Y, Z, W) = (value, value, value, value);
 
-        /// <summary>Constructs a Vector4D from the given Vector2D and a Z and W component.</summary>
+        /// <summary>Constructs a <see cref="Vector4D{T}"/> from the given <see cref="Vector2D{T}"/> and a Z and W component.</summary>
         /// <param name="value">The vector to use as the X and Y components.</param>
         /// <param name="z">The Z component.</param>
         /// <param name="w">The W component.</param>
         public Vector4D(Vector2D<T> value, T z, T w) => (X, Y, Z, W) = (value.X, value.Y, z, w);
 
-        /// <summary>Constructs a Vector4D from the given Vector3D and a W component.</summary>
+        /// <summary>Constructs a <see cref="Vector4D{T}"/> from the given <see cref="Vector3D{T}"/> and a W component.</summary>
         /// <param name="value">The vector to use as the X, Y, and Z components.</param>
         /// <param name="w">The W component.</param>
         public Vector4D(Vector3D<T> value, T w) => (X, Y, Z, W) = (value.X, value.Y, value.Z, w);
@@ -211,13 +211,13 @@ namespace Silk.NET.Maths
             array[index + 3] = W;
         }
 
-        /// <summary>Returns a boolean indicating whether the given Vector4D is equal to this Vector4D instance.</summary>
-        /// <param name="other">The Vector4D to compare this instance to.</param>
-        /// <returns>True if the other Vector4D is equal to this instance; False otherwise.</returns>
+        /// <summary>Returns a boolean indicating whether the given <see cref="Vector4D{T}"/> is equal to this <see cref="Vector4D{T}"/> instance.</summary>
+        /// <param name="other">The <see cref="Vector4D{T}"/> to compare this instance to.</param>
+        /// <returns>True if the other <see cref="Vector4D{T}"/> is equal to this instance; False otherwise.</returns>
         public readonly bool Equals(Vector4D<T> other)
             => this == other;
 
-        /// <summary>Returns a boolean indicating whether the given Object is equal to this Vector4D instance.</summary>
+        /// <summary>Returns a boolean indicating whether the given Object is equal to this <see cref="Vector4D{T}"/> instance.</summary>
         /// <param name="obj">The Object to compare against.</param>
         /// <returns>True if the Object is equal to this Vector4D; False otherwise.</returns>
         [MethodImpl((MethodImplOptions) 768)]
@@ -245,14 +245,14 @@ namespace Silk.NET.Maths
             get => Vector4D.Dot(this, this);
         }
 
-        /// <summary>Returns a String representing this Vector4D instance.</summary>
+        /// <summary>Returns a String representing this <see cref="Vector4D{T}"/> instance.</summary>
         /// <returns>The string representation.</returns>
         public override readonly string ToString()
         {
             return ToString("G", CultureInfo.CurrentCulture);
         }
 
-        /// <summary>Returns a String representing this Vector4D instance, using the specified format to format individual elements.</summary>
+        /// <summary>Returns a String representing this <see cref="Vector4D{T}"/> instance, using the specified format to format individual elements.</summary>
         /// <param name="format">The format of individual elements.</param>
         /// <returns>The string representation.</returns>
         public readonly string ToString(string? format)
@@ -260,7 +260,7 @@ namespace Silk.NET.Maths
             return ToString(format, CultureInfo.CurrentCulture);
         }
 
-        /// <summary>Returns a String representing this Vector4D instance, using the specified format to format individual elements
+        /// <summary>Returns a String representing this <see cref="Vector4D{T}"/> instance, using the specified format to format individual elements
         /// and the given IFormatProvider.</summary>
         /// <param name="format">The format of individual elements.</param>
         /// <param name="formatProvider">The format provider to use when formatting elements.</param>


### PR DESCRIPTION
# Summary of the PR
- Fixed the documentation comments where the description did not match the actual arguments e.g. for matrix sizes.
- Added  `<see cref="..."/>`tags for consistency as some methods had them but others did not.

# Further Comments

