### PR TITLE
Fix DoRender being called if Window.Close was called during DoUpdate

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Common/WindowExtensions.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/WindowExtensions.cs
@@ -51,6 +51,9 @@ namespace Silk.NET.Windowing
                     if (!view.IsClosing)
                     {
                         view.DoUpdate();
+                    }
+                    if (!view.IsClosing)
+                    {
                         view.DoRender();
                     }
                 }


### PR DESCRIPTION
# Summary of the PR
DoRender was always called after DoUpdate, even if window was requested to close. This could cause an exception, for example if Graphics resource disposing was set to happen on the Closing-event.