### PR TITLE
#591 Add validation preventing System.AccessViolationException when using CreateInput on uninitialized views

### DIFF
--- a/src/Input/Silk.NET.Input.Common/InputWindowExtensions.cs
+++ b/src/Input/Silk.NET.Input.Common/InputWindowExtensions.cs
@@ -53,12 +53,18 @@ namespace Silk.NET.Input
         /// </summary>
         /// <param name="view">The view to create an input context for.</param>
         /// <returns>The new input context.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Couldn't create input context as the view was not initialized. This occurs when you try to create an InputContext without initializing the view first.
+        /// </exception>
         /// <exception cref="NotSupportedException">
         /// Couldn't find a suitable input platform for this view. This occurs when you've created a window/view using
         /// a window platform, but haven't installed
         /// </exception>
         public static IInputContext CreateInput(this IView view)
         {
+            if (!view.IsInitialized)
+                throw new InvalidOperationException("Couldn't create input context as the view was not initialized.");
+
             foreach (var inputPlatform in Platforms)
             {
                 if (inputPlatform.IsApplicable(view))

--- a/src/Input/Silk.NET.Input.Common/InputWindowExtensions.cs
+++ b/src/Input/Silk.NET.Input.Common/InputWindowExtensions.cs
@@ -63,7 +63,9 @@ namespace Silk.NET.Input
         public static IInputContext CreateInput(this IView view)
         {
             if (!view.IsInitialized)
+            {
                 throw new InvalidOperationException("Couldn't create input context as the view was not initialized.");
+            }
 
             foreach (var inputPlatform in Platforms)
             {

--- a/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IView.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IView.cs
@@ -35,6 +35,11 @@ namespace Silk.NET.Windowing
         Vector2D<int> FramebufferSize { get; }
 
         /// <summary>
+        /// Determines if the window is initialized.
+        /// </summary>
+        bool IsInitialized {  get; }
+
+        /// <summary>
         /// Raised when the window is resized.
         /// </summary>
         event Action<Vector2D<int>>? Resize;

--- a/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
@@ -192,7 +192,7 @@ namespace Silk.NET.Windowing.Internals
         }
 
         // Misc properties
-        protected bool IsInitialized { get; set; }
+        public bool IsInitialized { get; protected set; }
         public INativeWindow? Native { get; private set; }
         public Vector2D<int> Size => IsInitialized ? CoreSize : default;
         public nint Handle => IsInitialized ? CoreHandle : 0;


### PR DESCRIPTION
# Summary of the PR
- Added an `IsInitialized` property to `IView`
- Changed `IsInitialized` property visibility in `ViewImplementationBase`  to `public `with `protected set`.
- `InputWindowExtensions.CreateInput` now throws an `InvalidOperationException` if `IsInitialized` returns `false`.

# Related issues, Discord discussions, or proposals
https://github.com/dotnet/Silk.NET/issues/591

# Further Comments
