### PR TITLE
Add TryGetExtension methods to AL & ALContext

### DIFF
--- a/src/OpenAL/Silk.NET.OpenAL/AL/AL.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/AL/AL.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Numerics;
-using Microsoft.Extensions.DependencyModel;
 using Silk.NET.Core.Attributes;
 using Silk.NET.Core.Contexts;
 using Silk.NET.Core.Loader;
@@ -348,6 +347,27 @@ namespace Silk.NET.OpenAL
             ctx.Contexts[1] = new LamdaNativeContext
                 (x => x.EndsWith("GetProcAddress") ? default : ret.GetProcAddress(x));
             return ret;
+        }
+
+        /// <summary>
+        ///     Attempts to load a native OpenAL extension of type <typeparamref name="T" />.
+        /// </summary>
+        /// <param name="ext">
+        ///     The loaded extension.
+        /// </param>
+        /// <typeparam name="T">
+        ///     Type of <see cref="NativeExtension{T}" /> to load.
+        /// </typeparam>
+        /// <returns>
+        ///     <c>True</c> if the extension was loaded, otherwise <c>False</c>.
+        /// </returns>
+        public bool TryGetExtension<T>(out T ext)
+            where T : NativeExtension<AL>
+        {
+            ext = IsExtensionPresent(ExtensionAttribute.GetExtensionAttribute(typeof(T)).Name)
+                ? (T) Activator.CreateInstance(typeof(T), Context)
+                : null;
+            return ext != null;
         }
 
         /// <summary>

--- a/src/OpenAL/Silk.NET.OpenAL/AL/AL.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/AL/AL.cs
@@ -375,6 +375,7 @@ namespace Silk.NET.OpenAL
         /// </summary>
         /// <typeparam name="TExtension">The extension type.</typeparam>
         /// <returns>The extension.</returns>
+        [Obsolete("This method has been deprecated and will be removed in Silk.NET 3.0. Please use TryGetExtension instead.")]
         public TExtension GetExtension<TExtension>()
             where TExtension : NativeExtension<AL>
         {

--- a/src/OpenAL/Silk.NET.OpenAL/AL/AL.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/AL/AL.cs
@@ -350,24 +350,18 @@ namespace Silk.NET.OpenAL
         }
 
         /// <summary>
-        ///     Attempts to load a native OpenAL extension of type <typeparamref name="T" />.
+        /// Attempts to load a native OpenAL extension of type <typeparamref name="T" />.
         /// </summary>
-        /// <param name="ext">
-        ///     The loaded extension.
-        /// </param>
-        /// <typeparam name="T">
-        ///     Type of <see cref="NativeExtension{T}" /> to load.
-        /// </typeparam>
-        /// <returns>
-        ///     <c>True</c> if the extension was loaded, otherwise <c>False</c>.
-        /// </returns>
+        /// <param name="ext">The loaded extension.</param>
+        /// <typeparam name="T">Type of <see cref="NativeExtension{T}" /> to load.</typeparam>
+        /// <returns><c>true</c> if the extension was loaded, otherwise <c>false</c>.</returns>
         public bool TryGetExtension<T>(out T ext)
             where T : NativeExtension<AL>
         {
             ext = IsExtensionPresent(ExtensionAttribute.GetExtensionAttribute(typeof(T)).Name)
                 ? (T) Activator.CreateInstance(typeof(T), Context)
                 : null;
-            return ext != null;
+            return ext is not null;
         }
 
         /// <summary>
@@ -375,7 +369,11 @@ namespace Silk.NET.OpenAL
         /// </summary>
         /// <typeparam name="TExtension">The extension type.</typeparam>
         /// <returns>The extension.</returns>
-        [Obsolete("This method has been deprecated and will be removed in Silk.NET 3.0. Please use TryGetExtension instead.")]
+        [Obsolete
+        (
+            "This method has been deprecated and will be removed in Silk.NET 3.0. " +
+            "Please use TryGetExtension instead."
+        )]
         public TExtension GetExtension<TExtension>()
             where TExtension : NativeExtension<AL>
         {

--- a/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs
@@ -117,10 +117,6 @@ namespace Silk.NET.OpenAL
         /// <typeparam name="T">The extension type.</typeparam>
         /// <param name="device">The device the context is on.</param>
         /// <param name="ext">The extension to check for.</param>
-        /// <remarks>
-        /// This function doesn't check that the extension is enabled - you will get an error later on if you attempt
-        /// to call an extension function from an extension that isn't loaded.
-        /// </remarks>
         /// <returns>Whether the extension is available.</returns>
         public unsafe bool TryGetExtension<T>
             (Device* device, out T ext) where T : NativeExtension<ALContext> => 

--- a/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs
@@ -111,9 +111,20 @@ namespace Silk.NET.OpenAL
             return ret;
         }
 
-        public bool TryGetExtension<T>
-            (out T ext) where T : NativeExtension<ALContext> => 
-            !((ext = IsExtensionPresent(ExtensionAttribute.GetExtensionAttribute(typeof(T)).Name)
+        /// <summary>
+        /// Attempts to load the given extension.
+        /// </summary>
+        /// <typeparam name="T">The extension type.</typeparam>
+        /// <param name="device">The device the context is on.</param>
+        /// <param name="ext">The extension to check for.</param>
+        /// <remarks>
+        /// This function doesn't check that the extension is enabled - you will get an error later on if you attempt
+        /// to call an extension function from an extension that isn't loaded.
+        /// </remarks>
+        /// <returns>Whether the extension is available.</returns>
+        public unsafe bool TryGetExtension<T>
+            (Device* device, out T ext) where T : NativeExtension<ALContext> => 
+            !((ext = IsExtensionPresent(device, ExtensionAttribute.GetExtensionAttribute(typeof(T)).Name)
                 ? (T) Activator.CreateInstance(typeof(T), Context)
                 : null) is null);
 

--- a/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs
@@ -134,6 +134,7 @@ namespace Silk.NET.OpenAL
         /// <typeparam name="TContextExtension">The extension type.</typeparam>
         /// <param name="device">The device the context is on.</param>
         /// <returns>The extension.</returns>
+        [Obsolete("This method has been deprecated and will be removed in Silk.NET 3.0. Please use TryGetExtension instead.")]
         public unsafe TContextExtension GetExtension<TContextExtension>(Device* device)
             where TContextExtension : ContextExtensionBase
         {

--- a/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Silk.NET.Core.Attributes;
 using Silk.NET.Core.Contexts;
 using Silk.NET.Core.Loader;
 using Silk.NET.Core.Native;
@@ -109,6 +110,12 @@ namespace Silk.NET.OpenAL
                 });
             return ret;
         }
+
+        public bool TryGetExtension<T>
+            (out T ext) where T : NativeExtension<ALContext> => 
+            !((ext = IsExtensionPresent(ExtensionAttribute.GetExtensionAttribute(typeof(T)).Name)
+                ? (T) Activator.CreateInstance(typeof(T), Context)
+                : null) is null);
 
         /// <summary>
         /// Gets an instance of the API of an extension to the API.

--- a/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs
@@ -118,9 +118,8 @@ namespace Silk.NET.OpenAL
         /// <param name="device">The device the context is on.</param>
         /// <param name="ext">The extension to check for.</param>
         /// <returns>Whether the extension is available.</returns>
-        public unsafe bool TryGetExtension<T>
-            (Device* device, out T ext) where T : NativeExtension<ALContext> => 
-            !((ext = IsExtensionPresent(device, ExtensionAttribute.GetExtensionAttribute(typeof(T)).Name)
+        public unsafe bool TryGetExtension<T>(Device* device, out T ext) where T : NativeExtension<ALContext>
+            => !((ext = IsExtensionPresent(device, ExtensionAttribute.GetExtensionAttribute(typeof(T)).Name)
                 ? (T) Activator.CreateInstance(typeof(T), Context)
                 : null) is null);
 
@@ -130,7 +129,11 @@ namespace Silk.NET.OpenAL
         /// <typeparam name="TContextExtension">The extension type.</typeparam>
         /// <param name="device">The device the context is on.</param>
         /// <returns>The extension.</returns>
-        [Obsolete("This method has been deprecated and will be removed in Silk.NET 3.0. Please use TryGetExtension instead.")]
+        [Obsolete
+        (
+            "This method has been deprecated and will be removed in Silk.NET 3.0. " +
+            "Please use TryGetExtension instead."
+        )]
         public unsafe TContextExtension GetExtension<TContextExtension>(Device* device)
             where TContextExtension : ContextExtensionBase
         {

--- a/src/OpenAL/Silk.NET.OpenAL/Extensions/ALExtensionLoader.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/Extensions/ALExtensionLoader.cs
@@ -11,6 +11,7 @@ namespace Silk.NET.OpenAL.Extensions
     /// <summary>
     /// A loader for OpenAL extensions.
     /// </summary>
+    [Obsolete("This class is deprecated and will be removed in Silk.NET 3.0. Please use the TryGetExtension method on ALContext.")]
     public static class ALExtensionLoader
     {
         /// <summary>

--- a/src/OpenAL/Silk.NET.OpenAL/Extensions/ALExtensionLoader.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/Extensions/ALExtensionLoader.cs
@@ -11,7 +11,11 @@ namespace Silk.NET.OpenAL.Extensions
     /// <summary>
     /// A loader for OpenAL extensions.
     /// </summary>
-    [Obsolete("This class is deprecated and will be removed in Silk.NET 3.0. Please use the TryGetExtension method on ALContext.")]
+    [Obsolete
+    (
+        "This class is deprecated and will be removed in Silk.NET 3.0. "+
+        "Please use the TryGetExtension method on ALContext."
+    )]
     public static class ALExtensionLoader
     {
         /// <summary>


### PR DESCRIPTION
# Summary of the PR
This PR adds `TryGetExtension` methods to `AL` and `ALContext` classes in `Silk.NET.OpenAL`

# Related issues, Discord discussions, or proposals
https://github.com/dotnet/Silk.NET/issues/574

# Further Comments
`TryGetExtension` method in `AL` is nearly the same as in OpenGL bindings. It was trivial to copy-paste and then compare to `GetExtension` to verify. The XML documentation was also taken from `GL` and modified.

However, `GetExtension` method in `ALContext` is different and also it doesn't use `ExtensionAttribute`. Also it requires a pointer to a `Device `to operate. So I am not sure if "copy-paste" approach would work. Should I convert `ALContext.GetExtension` to `TryGetExtension`?
Or maybe I am wrong, and it will be enough to copy existing method and import  `Silk.NET.Core.Attributes` namespace?
Just want to be sure.