### PR TITLE
Add IDisposable call to SilkMarshall.Free for all PFN-structs

### DIFF
--- a/src/Core/Silk.NET.Core/Miscellaneous/PfnVoidFunction.cs
+++ b/src/Core/Silk.NET.Core/Miscellaneous/PfnVoidFunction.cs
@@ -3,7 +3,7 @@ using Silk.NET.Core.Native;
 
 namespace Silk.NET.Core
 {
-    public readonly unsafe struct PfnVoidFunction
+    public readonly unsafe struct PfnVoidFunction : IDisposable
     {
         private readonly void* _handle;
 
@@ -16,6 +16,7 @@ namespace Silk.NET.Core
             (Delegate func) => _handle = (delegate* unmanaged[Cdecl]<void>) SilkMarshal.DelegateToPtr
             (func);
 
+        public void Dispose() => SilkMarshal.Free((nint) _handle);
         public static implicit operator delegate* unmanaged[Cdecl]<void>
             (PfnVoidFunction pfn) => pfn.Handle;
 

--- a/src/OpenXR/Silk.NET.OpenXR/PfnDebugUtilsMessengerCallbackEXT.cs
+++ b/src/OpenXR/Silk.NET.OpenXR/PfnDebugUtilsMessengerCallbackEXT.cs
@@ -4,7 +4,7 @@ using Silk.NET.Core.Native;
 
 namespace Silk.NET.OpenXR
 {
-    public readonly unsafe struct PfnDebugUtilsMessengerCallbackEXT
+    public readonly unsafe struct PfnDebugUtilsMessengerCallbackEXT : IDisposable
     {
         private readonly void* _handle;
 
@@ -19,6 +19,7 @@ namespace Silk.NET.OpenXR
                 DebugUtilsMessengerCallbackDataEXT*, void*, Bool32> ptr
         ) => _handle = ptr;
 
+        public void Dispose() => SilkMarshal.Free((nint) _handle);
         public static implicit operator nint(PfnDebugUtilsMessengerCallbackEXT pfn) => (nint) pfn.Handle;
 
         public PfnDebugUtilsMessengerCallbackEXT(DebugUtilsMessengerCallbackFunctionEXT func) => _handle =

--- a/src/Vulkan/Silk.NET.Vulkan/PfnAllocationFunction.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/PfnAllocationFunction.cs
@@ -3,7 +3,7 @@ using Silk.NET.Core.Native;
 
 namespace Silk.NET.Vulkan
 {
-    public readonly unsafe struct PfnAllocationFunction
+    public readonly unsafe struct PfnAllocationFunction : IDisposable
     {
         private readonly void* _handle;
 
@@ -13,6 +13,7 @@ namespace Silk.NET.Vulkan
         public PfnAllocationFunction
             (delegate* unmanaged[Cdecl]<void*, nuint, nuint, SystemAllocationScope, void*> ptr) => _handle = ptr;
 
+        public void Dispose() => SilkMarshal.Free((nint) _handle);
         public static implicit operator nint(PfnAllocationFunction pfn) => (nint) pfn.Handle;
 
         public PfnAllocationFunction

--- a/src/Vulkan/Silk.NET.Vulkan/PfnDebugReportCallbackEXT.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/PfnDebugReportCallbackEXT.cs
@@ -4,7 +4,7 @@ using Silk.NET.Core.Native;
 
 namespace Silk.NET.Vulkan
 {
-    public readonly unsafe struct PfnDebugReportCallbackEXT
+    public readonly unsafe struct PfnDebugReportCallbackEXT : IDisposable
     {
         private readonly void* _handle;
 
@@ -19,6 +19,7 @@ namespace Silk.NET.Vulkan
                 void*, Bool32> ptr
         ) => _handle = ptr;
 
+        public void Dispose() => SilkMarshal.Free((nint) _handle);
         public static implicit operator nint(PfnDebugReportCallbackEXT pfn) => (nint) pfn.Handle;
 
         public PfnDebugReportCallbackEXT

--- a/src/Vulkan/Silk.NET.Vulkan/PfnDebugUtilsMessengerCallbackEXT.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/PfnDebugUtilsMessengerCallbackEXT.cs
@@ -4,7 +4,7 @@ using Silk.NET.Core.Native;
 
 namespace Silk.NET.Vulkan
 {
-    public readonly unsafe struct PfnDebugUtilsMessengerCallbackEXT
+    public readonly unsafe struct PfnDebugUtilsMessengerCallbackEXT : IDisposable
     {
         private readonly void* _handle;
 
@@ -19,6 +19,7 @@ namespace Silk.NET.Vulkan
                 DebugUtilsMessengerCallbackDataEXT*, void*, Bool32> ptr
         ) => _handle = ptr;
 
+        public void Dispose() => SilkMarshal.Free((nint) _handle);
         public static implicit operator nint(PfnDebugUtilsMessengerCallbackEXT pfn) => (nint) pfn.Handle;
 
         public PfnDebugUtilsMessengerCallbackEXT(DebugUtilsMessengerCallbackFunctionEXT func) => _handle =

--- a/src/Vulkan/Silk.NET.Vulkan/PfnDeviceMemoryReportCallbackEXT.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/PfnDeviceMemoryReportCallbackEXT.cs
@@ -1,11 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Silk.NET.Core.Native;
 
 namespace Silk.NET.Vulkan
 {
-    public readonly unsafe struct PfnDeviceMemoryReportCallbackEXT
+    public readonly unsafe struct PfnDeviceMemoryReportCallbackEXT : IDisposable
     {
         private readonly void* _handle;
 
@@ -15,6 +16,7 @@ namespace Silk.NET.Vulkan
         public PfnDeviceMemoryReportCallbackEXT
             (delegate* unmanaged[Cdecl]<DeviceMemoryReportCallbackDataEXT*, void*, void> ptr) => _handle = ptr;
 
+        public void Dispose() => SilkMarshal.Free((nint) _handle);
         public static implicit operator nint(PfnDeviceMemoryReportCallbackEXT pfn) => (nint) pfn.Handle;
 
         public PfnDeviceMemoryReportCallbackEXT

--- a/src/Vulkan/Silk.NET.Vulkan/PfnFreeFunction.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/PfnFreeFunction.cs
@@ -3,7 +3,7 @@ using Silk.NET.Core.Native;
 
 namespace Silk.NET.Vulkan
 {
-    public readonly unsafe struct PfnFreeFunction
+    public readonly unsafe struct PfnFreeFunction : IDisposable
     {
         private readonly void* _handle;
 
@@ -12,6 +12,7 @@ namespace Silk.NET.Vulkan
 
         public PfnFreeFunction(delegate* unmanaged[Cdecl]<void*, void*, void> ptr) => _handle = ptr;
 
+        public void Dispose() => SilkMarshal.Free((nint) _handle);
         public static implicit operator nint(PfnFreeFunction pfn) => (nint) pfn.Handle;
 
         public PfnFreeFunction

--- a/src/Vulkan/Silk.NET.Vulkan/PfnInternalAllocationNotification.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/PfnInternalAllocationNotification.cs
@@ -6,7 +6,7 @@ using Silk.NET.Core.Native;
 
 namespace Silk.NET.Vulkan
 {
-    public readonly unsafe struct PfnInternalAllocationNotification
+    public readonly unsafe struct PfnInternalAllocationNotification : IDisposable
     {
         private readonly void* _handle;
 
@@ -23,6 +23,7 @@ namespace Silk.NET.Vulkan
             (delegate* unmanaged[Cdecl]<void*, nuint, InternalAllocationType, SystemAllocationScope, void>) SilkMarshal
                 .DelegateToPtr(func);
 
+        public void Dispose() => SilkMarshal.Free((nint) _handle);
         public static implicit operator delegate* unmanaged[Cdecl]<void*, nuint, InternalAllocationType,
             SystemAllocationScope, void>(PfnInternalAllocationNotification pfn) => pfn.Handle;
 

--- a/src/Vulkan/Silk.NET.Vulkan/PfnInternalFreeNotification.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/PfnInternalFreeNotification.cs
@@ -3,7 +3,7 @@ using Silk.NET.Core.Native;
 
 namespace Silk.NET.Vulkan
 {
-    public readonly unsafe struct PfnInternalFreeNotification
+    public readonly unsafe struct PfnInternalFreeNotification : IDisposable
     {
         private readonly void* _handle;
 
@@ -20,6 +20,7 @@ namespace Silk.NET.Vulkan
             (delegate* unmanaged[Cdecl]<void*, nuint, InternalAllocationType, SystemAllocationScope, void>) SilkMarshal
                 .DelegateToPtr(func);
 
+        public void Dispose() => SilkMarshal.Free((nint) _handle);
         public static implicit operator delegate* unmanaged[Cdecl]<void*, nuint, InternalAllocationType,
             SystemAllocationScope, void>(PfnInternalFreeNotification pfn) => pfn.Handle;
 

--- a/src/Vulkan/Silk.NET.Vulkan/PfnReallocationFunction.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/PfnReallocationFunction.cs
@@ -3,7 +3,7 @@ using Silk.NET.Core.Native;
 
 namespace Silk.NET.Vulkan
 {
-    public readonly unsafe struct PfnReallocationFunction
+    public readonly unsafe struct PfnReallocationFunction : IDisposable
     {
         private readonly void* _handle;
 
@@ -13,6 +13,7 @@ namespace Silk.NET.Vulkan
         public PfnReallocationFunction
             (delegate* unmanaged[Cdecl]<void*, void*, nuint, nuint, SystemAllocationScope, void*> ptr) => _handle = ptr;
 
+        public void Dispose() => SilkMarshal.Free((nint) _handle);
         public static implicit operator nint(PfnReallocationFunction pfn) => (nint) pfn.Handle;
 
         public PfnReallocationFunction


### PR DESCRIPTION
Adding the IDisposable interface as it is implemented for the generated PFN structs (see StructWriter)

