### PR TITLE
Added ISurface.PreUpdate event

### DIFF
--- a/documentation/proposals/Proposal - Windowing 3.0.md
+++ b/documentation/proposals/Proposal - Windowing 3.0.md
@@ -215,7 +215,7 @@ namespace Silk.NET.Windowing
         /// <summary>
         /// Raised just before the Update event is raised.
         /// </summary>
-        event DeltaAction? PreUpdate;
+        event Action? PreUpdate;
 
         /// <summary>
         /// Raised when an update should be run.


### PR DESCRIPTION
# Summary of the PR
The ISurface.PreUpdate event would be used to run things like Input, which need to be updated before the user code's Update is called.

In the current state of the library, depending on how the user hooks to the events, it is possible for the input to hook to the IView.Update after the user code, which would result in the user code not seeing the latest input (until the next update).

PreUpdate would not ensure things like input are up to date, but Update would.