### PR TITLE
Fix incorrect character encoding in SdlKeyboard

### DIFF
--- a/src/Input/Silk.NET.Input.Sdl/SdlKeyboard.cs
+++ b/src/Input/Silk.NET.Input.Sdl/SdlKeyboard.cs
@@ -66,8 +66,7 @@ namespace Silk.NET.Input.Sdl
                     // run the KeyChar event until we get a null terminator
                     while (chars[i] != default)
                     {
-                        KeyChar?.Invoke(this, chars[i]);
-                        i++;
+                        KeyChar?.Invoke(this, chars[i++]);
                     }
 
                     break;


### PR DESCRIPTION
# Summary of the PR
Characters were incorrectly decoded as ASCII in Sdl's TextInput. Fixed by decoding them as UTF8.

# Related issues, Discord discussions, or proposals
https://discord.com/channels/521092042781229087/607634593201520651/896375164600721418