### PR TITLE
#643 Conditionally including legacy packages

### DIFF
--- a/src/Core/Silk.NET.Core/Silk.NET.Core.csproj
+++ b/src/Core/Silk.NET.Core/Silk.NET.Core.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
         <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
         <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.1" />
@@ -16,6 +15,10 @@
         <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
         <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
     </ItemGroup>
 
     <Import Project="..\..\..\build\props\common.props" />

--- a/src/Maths/Silk.NET.Maths/Silk.NET.Maths.csproj
+++ b/src/Maths/Silk.NET.Maths/Silk.NET.Maths.csproj
@@ -16,11 +16,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
       <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.1">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
       <PackageReference Include="Ultz.Bcl.Half" Version="1.0.0" />
     </ItemGroup>
 

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.NV/Silk.NET.OpenGL.Legacy.Extensions.NV.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.NV/Silk.NET.OpenGL.Legacy.Extensions.NV.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\..\Silk.NET.OpenGL.Legacy\Silk.NET.OpenGL.Legacy.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
     <PackageReference Include="Ultz.Bcl.Half" Version="1.0.0" />
   </ItemGroup>
 

--- a/src/OpenGL/Silk.NET.OpenGL.Legacy/Silk.NET.OpenGL.Legacy.csproj
+++ b/src/OpenGL/Silk.NET.OpenGL.Legacy/Silk.NET.OpenGL.Legacy.csproj
@@ -6,7 +6,7 @@
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
     <PackageReference Include="Ultz.Bcl.Half" Version="1.0.0" />
   </ItemGroup>
 

--- a/src/OpenGL/Silk.NET.OpenGL/Silk.NET.OpenGL.csproj
+++ b/src/OpenGL/Silk.NET.OpenGL/Silk.NET.OpenGL.csproj
@@ -6,7 +6,7 @@
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
     <PackageReference Include="Ultz.Bcl.Half" Version="1.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
# Summary of the PR

The `Microsoft.Bcl.HashCode` and `Ultz.Bcl.Half` packages are now being conditionally included based on the TFM.

| Package | Included with TFMs |
| - | - |
| `Microsoft.Bcl.HashCode` | `netstandard2.0` |
| `Ultz.Bcl.Half` | `netstandard2.0;netstandard2.1;netcoreapp3.1` |

# Related issues, Discord discussions, or proposals

Discord link in related issue.

# Further Comments

I tested this locally by running `dotnet build` with `--framework netstandard2.0` for the five affected projects, then checking their references in ReSharper's Assembly Explorer. You can see the reference differences below:

![image](https://user-images.githubusercontent.com/1189759/137640283-117fad71-a93a-45c7-99fa-a1fafadd4e42.png)

I did not have to modify any source files due to this change. I think that's because the two types in question are in the `System` namespace, which is included in nearly every source file.