### PR TITLE
[Proposal] AllBitsSet for Scalar

### DIFF
--- a/documentation/proposals/Proposal - Bitwise - Scalar.md
+++ b/documentation/proposals/Proposal - Bitwise - Scalar.md
@@ -20,6 +20,8 @@ To make this simpler for both me, and anyone who reads this, I've provided the A
 This same API would also be amended to the Vectorization/SIMD proposal, if both are accepted.
 
 ```cs
+static readonly Silk.NET.Maths.Scalar<T>.AllBitsSet -> T
+
 static Silk.NET.Maths.Scalar.And<T>(T left, T right) -> T
 static Silk.NET.Maths.Scalar.Or<T>(T left, T right) -> T
 static Silk.NET.Maths.Scalar.Xor<T>(T left, T right) -> T


### PR DESCRIPTION
Similarly to .NET 5's Vector64<T>.AllBitsSet (and other bitnesses) I suggest adding `AllBitsSet` public readonly field to `Scalar<T>`.

It is already implemented as `internal` field in #670 (so I propose making it public)