### PR TITLE
No need to run CI on source-unrelated files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
       - 'main'
       - 'release/*'
     paths-ignore:
-      - 'proposals/**'
+      - 'documentation/**'
       - 'README.md'
   pull_request:
     # all branches

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,14 @@ on:
     branches:
       - 'main'
       - 'release/*'
+    paths-ignore:
+      - 'proposals/**'
+      - 'README.md'
   pull_request:
-    # none
+    # all branches
+    paths-ignore:
+      - 'proposals/**'
+      - 'README.md'
 jobs:
   Build:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
     # all branches
     paths-ignore:
-      - 'proposals/**'
+      - 'documentation/**'
       - 'README.md'
 jobs:
   Build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,12 +6,10 @@ on:
       - 'release/*'
     paths-ignore:
       - 'documentation/**'
-      - 'README.md'
   pull_request:
     # all branches
     paths-ignore:
       - 'documentation/**'
-      - 'README.md'
 jobs:
   Build:
     runs-on: windows-latest


### PR DESCRIPTION
I intentionally only wrote down just two: those are assumed to change often. We could add all files which don't affect the build to it, but imo it makes maintaining this thing harder. 