### PR TITLE
start of adding window class option

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IWindowProperties.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IWindowProperties.cs
@@ -66,11 +66,12 @@ namespace Silk.NET.Windowing
         /// <summary>
         /// Window class name used in systems like X11.
         /// Also known as WM_CLASS.
-        /// 
+        /// </summary>
+        /// <remarks>
         /// If omitted the following default values are used:
         /// - The name of the main assembly without extension
         /// - "SilkNET_App" if the name of the main assembly could not be determined
-        /// </summary>
+        /// </remarks>
         string? WindowClass { get; }
     }
 }

--- a/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IWindowProperties.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IWindowProperties.cs
@@ -70,7 +70,7 @@ namespace Silk.NET.Windowing
         /// <remarks>
         /// If omitted the following default values are used:
         /// - The name of the main assembly without extension
-        /// - "SilkNET_App" if the name of the main assembly could not be determined
+        /// - "Silk.NET" if the name of the main assembly could not be determined
         /// </remarks>
         string? WindowClass { get; }
     }

--- a/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IWindowProperties.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IWindowProperties.cs
@@ -62,5 +62,15 @@ namespace Silk.NET.Windowing
         /// The context with which this window's context's resources are shared.
         /// </summary>
         IGLContext? SharedContext { get; }
+
+        /// <summary>
+        /// Window class name used in systems like X11.
+        /// Also known as WM_CLASS.
+        /// 
+        /// If omitted the following default values are used:
+        /// - GLFW: Title of the window
+        /// - SDL:  The string "SDL_App"
+        /// </summary>
+        string? WindowClass { get; }
     }
 }

--- a/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IWindowProperties.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IWindowProperties.cs
@@ -68,8 +68,8 @@ namespace Silk.NET.Windowing
         /// Also known as WM_CLASS.
         /// 
         /// If omitted the following default values are used:
-        /// - GLFW: Title of the window
-        /// - SDL:  The string "SDL_App"
+        /// - The name of the main assembly without extension
+        /// - "SilkNET_App" if the name of the main assembly could not be determined
         /// </summary>
         string? WindowClass { get; }
     }

--- a/src/Windowing/Silk.NET.Windowing.Common/Internals/WindowImplementationBase.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Internals/WindowImplementationBase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -31,6 +31,7 @@ namespace Silk.NET.Windowing.Internals
         protected abstract string CoreTitle { get; set; }
         protected abstract WindowState CoreWindowState { get; set; }
         protected abstract WindowBorder CoreWindowBorder { get; set; }
+        protected abstract string? CoreWindowClass { get; set; }
         protected abstract bool IsClosingSettable { set; }
         protected abstract Vector2D<int> SizeSettable { set; }
         protected abstract Rectangle<int> CoreBorderSize { get; }
@@ -172,6 +173,20 @@ namespace Silk.NET.Windowing.Internals
                 }
 
                 ExtendedOptionsCache.WindowBorder = value;
+            }
+        }
+
+        public string? WindowClass
+        {
+            get => IsInitialized ? ExtendedOptionsCache.WindowClass = CoreWindowClass : ExtendedOptionsCache.WindowClass;
+            set
+            {
+                if (IsInitialized)
+                {
+                    CoreWindowClass = value;
+                }
+
+                ExtendedOptionsCache.WindowClass = value;
             }
         }
 

--- a/src/Windowing/Silk.NET.Windowing.Common/Internals/WindowImplementationBase.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Internals/WindowImplementationBase.cs
@@ -31,7 +31,6 @@ namespace Silk.NET.Windowing.Internals
         protected abstract string CoreTitle { get; set; }
         protected abstract WindowState CoreWindowState { get; set; }
         protected abstract WindowBorder CoreWindowBorder { get; set; }
-        protected abstract string? CoreWindowClass { get; set; }
         protected abstract bool IsClosingSettable { set; }
         protected abstract Vector2D<int> SizeSettable { set; }
         protected abstract Rectangle<int> CoreBorderSize { get; }
@@ -49,6 +48,7 @@ namespace Silk.NET.Windowing.Internals
         public abstract IWindowHost? Parent { get; }
         public abstract IGLContext? SharedContext { get; }
         public abstract IMonitor? Monitor { get; set; }
+        public abstract string? WindowClass { get; }
         public abstract void SetWindowIcon(ReadOnlySpan<RawImage> icons);
 
         // Cache updates for dervied classes
@@ -173,20 +173,6 @@ namespace Silk.NET.Windowing.Internals
                 }
 
                 ExtendedOptionsCache.WindowBorder = value;
-            }
-        }
-
-        public string? WindowClass
-        {
-            get => IsInitialized ? ExtendedOptionsCache.WindowClass = CoreWindowClass : ExtendedOptionsCache.WindowClass;
-            set
-            {
-                if (IsInitialized)
-                {
-                    CoreWindowClass = value;
-                }
-
-                ExtendedOptionsCache.WindowClass = value;
             }
         }
 

--- a/src/Windowing/Silk.NET.Windowing.Common/Structs/WindowOptions.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Structs/WindowOptions.cs
@@ -102,7 +102,7 @@ namespace Silk.NET.Windowing
         public IGLContext? SharedContext { get; }
 
         /// <inheritdoc />
-        public string? WindowClass { get; }
+        public string? WindowClass { get; set; }
 
         /// <summary>
         /// Creates a new WindowOptions struct.

--- a/src/Windowing/Silk.NET.Windowing.Common/Structs/WindowOptions.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Structs/WindowOptions.cs
@@ -41,6 +41,7 @@ namespace Silk.NET.Windowing
             PreferredStencilBufferBits = opts.PreferredStencilBufferBits;
             PreferredBitDepth = opts.PreferredBitDepth;
             Samples = opts.Samples;
+            WindowClass = null;
         }
 
         /// <inheritdoc />
@@ -100,6 +101,9 @@ namespace Silk.NET.Windowing
         /// <inheritdoc />
         public IGLContext? SharedContext { get; }
 
+        /// <inheritdoc />
+        public string? WindowClass { get; }
+
         /// <summary>
         /// Creates a new WindowOptions struct.
         /// </summary>
@@ -123,7 +127,8 @@ namespace Silk.NET.Windowing
             bool transparentFramebuffer = false,
             bool isEventDriven = false,
             IGLContext? sharedContext = null,
-            int? samples = null
+            int? samples = null,
+            string? windowClass = null
         )
         {
             IsVisible = isVisible;
@@ -146,6 +151,7 @@ namespace Silk.NET.Windowing
             PreferredStencilBufferBits = preferredStencilBufferBits;
             PreferredBitDepth = preferredBitDepth;
             Samples = samples;
+            WindowClass = windowClass;
         }
 
         static WindowOptions()

--- a/src/Windowing/Silk.NET.Windowing.Common/Window.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Window.cs
@@ -19,7 +19,7 @@ namespace Silk.NET.Windowing
         private const string SdlBackendNamespace = "Silk.NET.Windowing.Sdl";
         private const string GlfwBackendName = "GlfwPlatform";
         private const string SdlBackendName = "SdlPlatform";
-        private const string FallbackWindowClass = "SilkNET_App";
+        private const string FallbackWindowClass = "Silk.NET";
 
         private static List<Type> _platformsKeys = new List<Type>();
         private static List<IWindowPlatform> _platformsValues = new List<IWindowPlatform>();

--- a/src/Windowing/Silk.NET.Windowing.Common/Window.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Window.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
-using Silk.NET.Windowing.Internals;
 
 namespace Silk.NET.Windowing
 {
@@ -19,12 +19,25 @@ namespace Silk.NET.Windowing
         private const string SdlBackendNamespace = "Silk.NET.Windowing.Sdl";
         private const string GlfwBackendName = "GlfwPlatform";
         private const string SdlBackendName = "SdlPlatform";
+        private const string FallbackWindowClass = "SilkNET_App";
 
         private static List<Type> _platformsKeys = new List<Type>();
         private static List<IWindowPlatform> _platformsValues = new List<IWindowPlatform>();
 
         private static bool _initializedFirstPartyPlatforms = false;
-        
+
+        internal static string DefaultWindowClass { get; }
+
+        static Window()
+        {
+            string? defaultWindowClassName = Process.GetCurrentProcess().MainModule?.ModuleName;
+
+            if (defaultWindowClassName != null)
+                DefaultWindowClass = Path.GetFileNameWithoutExtension(defaultWindowClassName);
+            else
+                DefaultWindowClass = Assembly.GetEntryAssembly()?.GetName()?.Name ?? FallbackWindowClass;
+        }
+
         public static IReadOnlyCollection<IWindowPlatform> Platforms
         {
             get

--- a/src/Windowing/Silk.NET.Windowing.Common/Window.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Window.cs
@@ -30,12 +30,14 @@ namespace Silk.NET.Windowing
 
         static Window()
         {
-            string? defaultWindowClassName = Process.GetCurrentProcess().MainModule?.ModuleName;
-
-            if (defaultWindowClassName != null)
+            var defaultWindowClassName = Process.GetCurrentProcess().MainModule?.ModuleName;
+            if (defaultWindowClassName is not null)
+            {
                 DefaultWindowClass = Path.GetFileNameWithoutExtension(defaultWindowClassName);
-            else
-                DefaultWindowClass = Assembly.GetEntryAssembly()?.GetName()?.Name ?? FallbackWindowClass;
+                return;
+            }
+
+            DefaultWindowClass = Assembly.GetEntryAssembly()?.GetName()?.Name ?? FallbackWindowClass;
         }
 
         public static IReadOnlyCollection<IWindowPlatform> Platforms

--- a/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
@@ -36,6 +36,7 @@ namespace Silk.NET.Windowing.Glfw
         private Vector2D<int> _nonFullscreenSize;
         private string _localTitleCache; // glfw doesn't let us get the window title.
         private GlfwContext? _glContext;
+        private string? _windowClass;
 
         public GlfwWindow(WindowOptions optionsCache, GlfwWindow? parent, GlfwMonitor? monitor) : base(optionsCache)
         {
@@ -289,6 +290,11 @@ namespace Silk.NET.Windowing.Glfw
                     break;
             }
 
+            // Set window class.
+            _windowClass = opts.WindowClass;
+            if (_windowClass is not null)
+                _glfw.WindowHintString((int)WindowHintString.X11ClassName, _windowClass);
+
             // Set window API.
             switch (opts.API.API)
             {
@@ -418,6 +424,7 @@ namespace Silk.NET.Windowing.Glfw
 
         public override IWindowHost? Parent => (IWindowHost?) _parent ?? Monitor;
         public override IGLContext? SharedContext { get; }
+        public override string? WindowClass => _windowClass ?? CoreTitle;
 
 
         public override IMonitor? Monitor

--- a/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
@@ -36,7 +36,7 @@ namespace Silk.NET.Windowing.Glfw
         private Vector2D<int> _nonFullscreenSize;
         private string _localTitleCache; // glfw doesn't let us get the window title.
         private GlfwContext? _glContext;
-        private string? _windowClass;
+        private string _windowClass;
 
         public GlfwWindow(WindowOptions optionsCache, GlfwWindow? parent, GlfwMonitor? monitor) : base(optionsCache)
         {
@@ -291,11 +291,8 @@ namespace Silk.NET.Windowing.Glfw
             }
 
             // Set window class.
-            _windowClass = opts.WindowClass;
-            if (_windowClass is not null)
-                _glfw.WindowHintString((int)WindowHintString.X11ClassName, _windowClass);
-            else
-                _windowClass = _localTitleCache;
+            _windowClass = opts.WindowClass ?? Window.DefaultWindowClass;
+            _glfw.WindowHintString((int)WindowHintString.X11ClassName, _windowClass);
 
             // Set window API.
             switch (opts.API.API)

--- a/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
@@ -294,6 +294,8 @@ namespace Silk.NET.Windowing.Glfw
             _windowClass = opts.WindowClass;
             if (_windowClass is not null)
                 _glfw.WindowHintString((int)WindowHintString.X11ClassName, _windowClass);
+            else
+                _windowClass = _localTitleCache;
 
             // Set window API.
             switch (opts.API.API)
@@ -424,7 +426,7 @@ namespace Silk.NET.Windowing.Glfw
 
         public override IWindowHost? Parent => (IWindowHost?) _parent ?? Monitor;
         public override IGLContext? SharedContext { get; }
-        public override string? WindowClass => _windowClass ?? CoreTitle;
+        public override string? WindowClass => _windowClass;
 
 
         public override IMonitor? Monitor

--- a/src/Windowing/Silk.NET.Windowing.Sdl/SdlWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Sdl/SdlWindow.cs
@@ -24,6 +24,7 @@ namespace Silk.NET.Windowing.Sdl
             : base(new ViewOptions(opts), parent, monitor, platform)
         {
             _extendedOptionsCache = opts;
+            WindowClass = opts.WindowClass ?? "SDL_App";
         }
 
         public SdlWindow(void* nativeHandle, IGLContext? ctx, SdlPlatform platform) : base(nativeHandle, ctx, platform)
@@ -195,6 +196,8 @@ namespace Silk.NET.Windowing.Sdl
                 }
             }
         }
+
+        public string? WindowClass { get; }
 
         public unsafe Rectangle<int> BorderSize
         {

--- a/src/Windowing/Silk.NET.Windowing.Sdl/SdlWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Sdl/SdlWindow.cs
@@ -415,6 +415,9 @@ namespace Silk.NET.Windowing.Sdl
 
         protected override void CoreInitialize(ViewOptions opts)
         {
+            if (_extendedOptionsCache.WindowClass is not null)
+                Sdl.Setenv("SDL_VIDEO_X11_WMCLASS", _extendedOptionsCache.WindowClass, 1);
+
             WindowFlags flags = 0;
             flags |= IsVisible ? WindowFlags.WindowShown : WindowFlags.WindowHidden;
             flags |= WindowBorder switch

--- a/src/Windowing/Silk.NET.Windowing.Sdl/SdlWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Sdl/SdlWindow.cs
@@ -24,7 +24,7 @@ namespace Silk.NET.Windowing.Sdl
             : base(new ViewOptions(opts), parent, monitor, platform)
         {
             _extendedOptionsCache = opts;
-            WindowClass = opts.WindowClass ?? "SDL_App";
+            WindowClass = opts.WindowClass ?? Window.DefaultWindowClass;
         }
 
         public SdlWindow(void* nativeHandle, IGLContext? ctx, SdlPlatform platform) : base(nativeHandle, ctx, platform)
@@ -418,8 +418,7 @@ namespace Silk.NET.Windowing.Sdl
 
         protected override void CoreInitialize(ViewOptions opts)
         {
-            if (_extendedOptionsCache.WindowClass is not null)
-                Sdl.Setenv("SDL_VIDEO_X11_WMCLASS", _extendedOptionsCache.WindowClass, 1);
+            Sdl.Setenv("SDL_VIDEO_X11_WMCLASS", WindowClass, 1);
 
             WindowFlags flags = 0;
             flags |= IsVisible ? WindowFlags.WindowShown : WindowFlags.WindowHidden;


### PR DESCRIPTION
# Summary of the PR

Adds the possibility to specify an optional window class for a window. Systems like X11 use the window class to store settings for specific applications. Glfw defaults the window class to the window title which is not always wanted. Especially with version numbers in the title this causes problems as a window class should stay the same for the same application.

