### PR TITLE
Fix website build pipeline

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -10,6 +10,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+        token: ${{ secrets.PUSHABLE_GITHUB_TOKEN }}
     - name: Setup .NET 5.0
       uses: actions/setup-dotnet@v1
       with:


### PR DESCRIPTION
Apparently the CI token can't push anymore so let's use the same one the rewrite merger pipeline uses...