### PR TITLE
Add support for cloning Vk objects to reuse their function tables independently

### DIFF
--- a/src/Core/Silk.NET.Core/Native/IVTable.cs
+++ b/src/Core/Silk.NET.Core/Native/IVTable.cs
@@ -11,6 +11,7 @@ namespace Silk.NET.Core.Native
         [Obsolete("Use method without slot - this method will be removed in 3.0")]
         nint Load(int slot, string entryPoint);
         nint Load(string entryPoint);
+        IVTable Clone();
         void Purge();
     }
 }

--- a/src/Core/Silk.NET.SilkTouch/NativeApiGenerator.cs
+++ b/src/Core/Silk.NET.SilkTouch/NativeApiGenerator.cs
@@ -100,7 +100,7 @@ namespace Silk.NET.SilkTouch
                     context.ReportDiagnostic
                     (
                         Diagnostic.Create
-                            (Diagnostics.ProcessClassFailure, group.First().Item1.GetLocation(), ex.ToString())
+                            (Diagnostics.ProcessClassFailure, group.First().Item1.GetLocation(), ex.ToString().Replace("\n", " | "))
                     );
                 }
             }


### PR DESCRIPTION
Popped up while looking at the Stride migration, which has a graphics abstraction that can create multiple devices but only ever has one instance: let's just reuse the instance functions we've already loaded!

Considering our (my) advice is to have one object for each instance-device combination, this is quite a nice-to-have but at the same time a niche one so if you're not comfortable with it that's fine.