### PR TITLE
hotfix: Inconsistent test failure

### DIFF
--- a/src/Vulkan/Silk.NET.Vulkan.Tests/TestChains.cs
+++ b/src/Vulkan/Silk.NET.Vulkan.Tests/TestChains.cs
@@ -314,8 +314,9 @@ public class TestChains
         Assert.Equal(2, errorsArray.Length);
         Assert.Equal
         (
-            "The unmanaged chain has a structure type PhysicalDeviceFeatures2 at position 2; expected PhysicalDeviceAccelerationStructureFeaturesKhr",
-            errorsArray[0]
+            "The unmanaged chain has a structure type PhysicalDeviceFeatures2 at position 2; expected PhysicalDeviceAccelerationStructureFeatures",
+            // PATCH: Due to the way ToString() interacts with enum aliases, the structure types may end in Khr, so removing. 
+            errorsArray[0].Replace("Khr", "")
         );
         Assert.Equal
         (


### PR DESCRIPTION
# Summary of the PR
`Enum.ToString()` output is undefined when dealing with aliases, as any
alias can be picked.  Patched `TestChainLoadWithError` so it will pass
regardless of which alias is returned.

# Related issues, Discord discussions, or proposals
#706 

# Further Comments
This is a 'harmless' issue, as the error messages are intended for debugging 
purposes.  The patch makes the test pass consistently.