### PR TITLE
Create custom ImGuiController constructor with onConfigureAction

### DIFF
--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.ImGui/ImGuiController.cs
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.ImGui/ImGuiController.cs
@@ -38,31 +38,39 @@ namespace Silk.NET.OpenGL.Extensions.ImGui
         /// <summary>
         /// Constructs a new ImGuiController.
         /// </summary>
-        public ImGuiController(GL gl, IView view, IInputContext input)
+        public ImGuiController(GL gl, IView view, IInputContext input) : this(gl, view, input, null, null)
         {
-            Init(gl, view, input);
-
-            var io = ImGuiNET.ImGui.GetIO();
-            io.Fonts.AddFontDefault();
-            io.BackendFlags |= ImGuiBackendFlags.RendererHasVtxOffset;
-
-            CreateDeviceResources();
-            SetKeyMappings();
-
-            SetPerFrameImGuiData(1f / 60f);
-
-            BeginFrame();
         }
 
         /// <summary>
         /// Constructs a new ImGuiController with font configuration.
         /// </summary>
-        public ImGuiController(GL gl, IView view, IInputContext input, ImGuiFontConfig imGuiFontConfig)
+        public ImGuiController(GL gl, IView view, IInputContext input, ImGuiFontConfig imGuiFontConfig) : this(gl, view, input, imGuiFontConfig, null)
+        {
+        }
+        
+        /// <summary>
+        /// Constructs a new ImGuiController with an onConfigureIO Action.
+        /// </summary>
+        public ImGuiController(GL gl, IView view, IInputContext input, Action onConfigureIO) : this(gl, view, input, null, onConfigureIO)
+        {
+        }
+        
+        /// <summary>
+        /// Constructs a new ImGuiController with font configuration and onConfigure Action.
+        /// </summary>
+        public ImGuiController(GL gl, IView view, IInputContext input, ImGuiFontConfig? imGuiFontConfig = null, Action onConfigureIO = null)
         {
             Init(gl, view, input);
 
             var io = ImGuiNET.ImGui.GetIO();
-            io.Fonts.AddFontFromFileTTF(imGuiFontConfig.FontPath, imGuiFontConfig.FontSize);
+            if (imGuiFontConfig is not null)
+            {
+                io.Fonts.AddFontFromFileTTF(imGuiFontConfig.Value.FontPath, imGuiFontConfig.Value.FontSize);
+            }
+
+            onConfigureIO?.Invoke();
+
             io.BackendFlags |= ImGuiBackendFlags.RendererHasVtxOffset;
 
             CreateDeviceResources();


### PR DESCRIPTION
# Summary of the PR
Add a custom constructor for `ImGuiController`, so user can configure the ImGui before the first frame.

# Related issues, Discord discussions, or proposals

# Further Comments
The pain is the following. 

- I needed a Docking feature of ImGui, which is being enabled with the next code:
	```csharp
	var io = ImGui.GetIO();
	io.ConfigFlags |= ImGuiConfigFlags.DockingEnable;
	```
	If I set the config flag before calling the constructor - exception (ImGui is not yet initialized)
	If I set the config flag after the constructor - my docking configuration is reset (because of new frame has begun without a flag)
- I also needed to load many custom fonts, which is most conviniently can be done before the first frame, so that ImGui can bake the font texture. The code is as follows:
	```csharp
	var io = ImGui.GetIO();
	io.Fonts.AddFontFromFileTTF("path/to/font.ttf", 24);
	```

Both of these pains are because of `ImGuiController` constructor not only initializes the ImGui, but also the resources, and more of that - begins new frame.

So I decided to add a new constructor to the `ImGuiController`, that allows user to customly configure the ImGui before the first frame.

This helped me do the following (adapted sample):
```csharp
ImFontPtr openSansFont = null;
// Our loading function
window.Load += () =>
{
	controller = new ImGuiController(
		gl = window.CreateOpenGL(), // load OpenGL
		window, // pass in our window
 		inputContext = window.CreateInput(), // create an input context
		() =>
		{
			var io = ImGui.GetIO();
			io.ConfigFlags |= ImGuiConfigFlags.DockingEnable;
			openSansFont = io.Fonts.AddFontFromFileTTF("assets/Font/OpenSans-Regular.ttf", 18);
		}
	);
};
```

## There is a small suggestion I need 
Do I need to still do the 
```csharp
io.BackendFlags |= ImGuiBackendFlags.RendererHasVtxOffset;
```
in constructor, or in this case it should be relied to the user