### PR TITLE
Fixed loading Vulkan loader on Android (.Net 6)

### DIFF
--- a/generator.json
+++ b/generator.json
@@ -486,7 +486,7 @@
                 "win-x64": "vulkan-1.dll",
                 "win-x86": "vulkan-1.dll",
                 "osx-x64": "libMoltenVK.dylib",
-                "android": "libvulkan.so.1",
+                "android": "libvulkan.so",
                 "iOS": "__Internal",
                 "className": "VulkanLibraryNameContainer"
             },

--- a/src/Core/Silk.NET.Core/Loader/DefaultPathResolver.cs
+++ b/src/Core/Silk.NET.Core/Loader/DefaultPathResolver.cs
@@ -277,7 +277,7 @@ namespace Silk.NET.Core.Loader
         {
             var allRiDs = new List<string>();
 
-            if (ctx != null) // prevent null reference exception on net6.0-android where DependencyContext.Default is null
+            if (ctx is not null) // prevent null reference exception on net6.0-android where DependencyContext.Default is null
             {
                 allRiDs.Add(currentRid);
                 if (!AddFallbacks(allRiDs, currentRid, ctx.RuntimeGraph))

--- a/src/Core/Silk.NET.Core/Loader/DefaultPathResolver.cs
+++ b/src/Core/Silk.NET.Core/Loader/DefaultPathResolver.cs
@@ -277,7 +277,8 @@ namespace Silk.NET.Core.Loader
         {
             var allRiDs = new List<string>();
 
-            if (ctx is not null) // prevent null reference exception on net6.0-android where DependencyContext.Default is null
+            // prevent null reference exception on net6.0-android where DependencyContext.Default is null
+            if (ctx is not null)
             {
                 allRiDs.Add(currentRid);
                 if (!AddFallbacks(allRiDs, currentRid, ctx.RuntimeGraph))

--- a/src/Core/Silk.NET.Core/Loader/DefaultPathResolver.cs
+++ b/src/Core/Silk.NET.Core/Loader/DefaultPathResolver.cs
@@ -276,14 +276,18 @@ namespace Silk.NET.Core.Loader
         private List<string> GetAllRuntimeIds(string currentRid, DependencyContext ctx)
         {
             var allRiDs = new List<string>();
-            allRiDs.Add(currentRid);
-            if (!AddFallbacks(allRiDs, currentRid, ctx.RuntimeGraph))
+
+            if (ctx != null) // prevent null reference exception on net6.0-android where DependencyContext.Default is null
             {
-                var guessedFallbackRid = GuessFallbackRid(currentRid);
-                if (guessedFallbackRid != null)
+                allRiDs.Add(currentRid);
+                if (!AddFallbacks(allRiDs, currentRid, ctx.RuntimeGraph))
                 {
-                    allRiDs.Add(guessedFallbackRid);
-                    AddFallbacks(allRiDs, guessedFallbackRid, ctx.RuntimeGraph);
+                    var guessedFallbackRid = GuessFallbackRid(currentRid);
+                    if (guessedFallbackRid != null)
+                    {
+                        allRiDs.Add(guessedFallbackRid);
+                        AddFallbacks(allRiDs, guessedFallbackRid, ctx.RuntimeGraph);
+                    }
                 }
             }
 

--- a/src/Vulkan/Silk.NET.Vulkan/VulkanLibraryNameContainer.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/VulkanLibraryNameContainer.cs
@@ -17,7 +17,7 @@ namespace Silk.NET.Vulkan
         public override string MacOS => "libMoltenVK.dylib";
 
         /// <inheritdoc />
-        public override string Android => "libvulkan.so.1";
+        public override string Android => "libvulkan.so";
 
         /// <inheritdoc />
         public override string IOS => "__Internal";


### PR DESCRIPTION
Fixed name of the Vulkan loader library on Android (changed from "libvulkan.so.1" to "libvulkan.so") - see [https://source.android.com/devices/graphics/implement-vulkan](https://source.android.com/devices/graphics/implement-vulkan) "Vulkan loader" section that this is the officially correct name of the library.

With this change the Vk.GetApi will load the library successfully without any additional magic from the path resolver.

But even with using the "libvulkan.so.1" name, the path resolved that is used in Silk.Net could correctly resolve the library name in the GetLinuxPossibilities method that would strip the ending ".1" and this will lead to the correct library name.

But this does not happen because a null reference exception is thrown before the GetLinuxPossibilities is called. This happens when the GetAllRuntimeIds method is called from the TryLocateNativeAssetInRuntimesFolder method. There the value DependencyContext.Default is passed to the GetAllRuntimeIds method. But in .Net 6.0 on Android this value is null and this results in the null reference exception with the following call stack:

 	0xD in Silk.NET.Core.Loader.DefaultPathResolver.GetAllRuntimeIds	C#
 	0xB in Silk.NET.Core.Loader.DefaultPathResolver.TryLocateNativeAssetInRuntimesFolder	C#
 	0x1C0 in Silk.NET.Core.Loader.DefaultPathResolver.CoreEnumeratePossibleLibraryLoadTargets	C#
 	0x50 in Silk.NET.Core.Loader.LibraryLoader.LoadWithResolver	C#
 	0x1B in Silk.NET.Core.Loader.LibraryLoader.TryLoadNativeLibrary	C#
 	0xE in Silk.NET.Core.Loader.LibraryLoader.TryLoadNativeLibrary	C#
 	0x1A in Silk.NET.Core.Loader.LibraryLoader.LoadNativeLibrary	C#
 	0x16 in Silk.NET.Core.Loader.UnmanagedLibrary..ctor	C#
 	0xC in Silk.NET.Core.Loader.UnmanagedLibrary..ctor	C#
 	0x2 in Silk.NET.Core.Contexts.DefaultNativeContext..ctor	C#
 	0x1 in Silk.NET.Vulkan.Vk.CreateDefaultContext	C#
 	0x18 in Silk.NET.Vulkan.Vk.GetApi	C#

This can be prevented by adding a null check into the GetAllRuntimeIds method.
