### PR TITLE
Ensure that the SDL mouse wheel is updated

### DIFF
--- a/src/Input/Silk.NET.Input.Common/Structs/ScrollWheel.cs
+++ b/src/Input/Silk.NET.Input.Common/Structs/ScrollWheel.cs
@@ -11,7 +11,7 @@ namespace Silk.NET.Input
     /// <summary>
     /// Represents a scroll wheel.
     /// </summary>
-    public readonly struct ScrollWheel : IEquatable<ScrollWheel>
+    public struct ScrollWheel : IEquatable<ScrollWheel>
     {
         /// <summary>
         /// The X position of the scroll wheel.
@@ -36,18 +36,18 @@ namespace Silk.NET.Input
 
         /// <summary>Returns a String representing this <see cref="ScrollWheel"/> instance.</summary>
         /// <returns>The string representation.</returns>
-        public override string ToString() => ToString("G", CultureInfo.CurrentCulture);
+        public override readonly string ToString() => ToString("G", CultureInfo.CurrentCulture);
 
         /// <summary>Returns a String representing this <see cref="ScrollWheel"/> instance, using the specified format to format individual elements.</summary>
         /// <param name="format">The format of individual elements.</param>
         /// <returns>The string representation.</returns>
-        public string ToString(string? format) => ToString(format, CultureInfo.CurrentCulture);
+        public readonly string ToString(string? format) => ToString(format, CultureInfo.CurrentCulture);
 
         /// <summary>Returns a String representing this <see cref="ScrollWheel"/> instance, using the specified format to format individual elements and the given IFormatProvider.</summary>
         /// <param name="format">The format of individual elements.</param>
         /// <param name="formatProvider">The format provider to use when formatting elements.</param>
         /// <returns>The string representation.</returns>
-        public string ToString(string? format, IFormatProvider? formatProvider)
+        public readonly string ToString(string? format, IFormatProvider? formatProvider)
         {
             StringBuilder sb = new();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;

--- a/src/Input/Silk.NET.Input.Common/Structs/ScrollWheel.cs
+++ b/src/Input/Silk.NET.Input.Common/Structs/ScrollWheel.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Silk.NET.Input
@@ -10,7 +11,7 @@ namespace Silk.NET.Input
     /// <summary>
     /// Represents a scroll wheel.
     /// </summary>
-    public struct ScrollWheel
+    public readonly struct ScrollWheel : IEquatable<ScrollWheel>
     {
         /// <summary>
         /// The X position of the scroll wheel.
@@ -35,18 +36,18 @@ namespace Silk.NET.Input
 
         /// <summary>Returns a String representing this <see cref="ScrollWheel"/> instance.</summary>
         /// <returns>The string representation.</returns>
-        public override readonly string ToString() => ToString("G", CultureInfo.CurrentCulture);
+        public override string ToString() => ToString("G", CultureInfo.CurrentCulture);
 
         /// <summary>Returns a String representing this <see cref="ScrollWheel"/> instance, using the specified format to format individual elements.</summary>
         /// <param name="format">The format of individual elements.</param>
         /// <returns>The string representation.</returns>
-        public readonly string ToString(string? format) => ToString(format, CultureInfo.CurrentCulture);
+        public string ToString(string? format) => ToString(format, CultureInfo.CurrentCulture);
 
         /// <summary>Returns a String representing this <see cref="ScrollWheel"/> instance, using the specified format to format individual elements and the given IFormatProvider.</summary>
         /// <param name="format">The format of individual elements.</param>
         /// <param name="formatProvider">The format provider to use when formatting elements.</param>
         /// <returns>The string representation.</returns>
-        public readonly string ToString(string? format, IFormatProvider? formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
         {
             StringBuilder sb = new();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
@@ -58,5 +59,32 @@ namespace Silk.NET.Input
             sb.Append('>');
             return sb.ToString();
         }
+
+        /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public override bool Equals(object obj) => obj is ScrollWheel other && Equals(other);
+
+        /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Equals(ScrollWheel other) => this == other;
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(X, Y);
+
+        /// <summary>Returns a boolean indicating whether the two given ScrollWheels are equal.</summary>
+        /// <param name="left">The first ScrollWheel to compare.</param>
+        /// <param name="right">The second ScrollWheel to compare.</param>
+        /// <returns>True if the ScrollWheel are equal; False otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator ==(ScrollWheel left, ScrollWheel right) =>
+            left.X == right.X &&
+            left.Y == right.Y;
+
+        /// <summary>Returns a boolean indicating whether the two given ScrollWheels are not equal.</summary>
+        /// <param name="left">The first ScrollWheel to compare.</param>
+        /// <param name="right">The second ScrollWheel to compare.</param>
+        /// <returns>True if the ScrollWheel are not equal; False if they are equal.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator !=(ScrollWheel left, ScrollWheel right) => !(left == right);
     }
 }


### PR DESCRIPTION
This is in line with equivalent logic in `GlfwMouse`.

Previously, wheel data was only updated when the `SdlMouse` `Scroll` event was invoked. Additionally, the scroll wheels data was never reset which lead to incorrect scrolling behavior.
This CL also adds an `IEquatable<ScrollWheel>` implementation to the `ScrollWheel` struct so we can value-compare instances without casting the underlying data to `System.Numerics.Vector2`.

# Steps to reproduce the previously faulty SDL mouse wheel behavior
1. Validate correct behavior when using the standard GLfw backend:

- Open the Silk.NET solution and compile the `Examples/CSharp/OpenGL Demos/ImGui` example project.
- Run the `Examples/CSharp/OpenGL Demos/ImGui` example project.
- Open the `Child windows` section from the `Layout & Scrolling` section of the ImGui demo window.
- Position the mouse cursor over the `Menu` child window and scroll the mouse wheel
- Observe: the child window contents are scrolled as expected.

2. Reproduce incorrect behavior when using the SDL backend.

- Open `Silk.NET\examples\CSharp\OpenGL Demos\ImGui\Program.cs` and insert `Window.PrioritizeSdl();` as the first line of the `Main` function. This will force selection of the SDL render backend.
- Repeat the steps described in 1.
- Observe: the child window contents can no longer be scrolled using the mouse wheel.
