### PR TITLE
Add native GLFW binary builds

### DIFF
--- a/.github/workflows/GLFW.yml
+++ b/.github/workflows/GLFW.yml
@@ -1,45 +1,43 @@
 name: glfw
- on:
-   push:
-     paths:
-       - build/submodules/GLFW
-       - build/nuke/Build.Native.cs
-     branches-ignore:
-       - "ci/*"
-       - "develop/*"
-       - "main"
- jobs:
-   Build:
-     strategy: 
-       fail-fast: false
-       matrix:
-         env:
-           - os: ubuntu-latest
-             name: Linux
-             nuke_invoke: ./build.sh
-             extras: |
-               sudo apt-get install -y xorg-dev 
-           - os: windows-latest
-             name: Windows
-             nuke_invoke: ./build.cmd
-             extras: ""
-           - os: macos-latest
-             name: Darwin
-             nuke_invoke: ./build.sh
-             extras: ""
-     name: ${{ matrix.env.name }} Build
-     runs-on: ${{ matrix.env.os }}
-     steps:
-       - uses: actions/checkout@v2
-       - name: Extra prerequisites
-         run: |
-           echo running extras
-           ${{ matrix.env.extras }}
-       - name: Setup .NET 6.0
-         uses: actions/setup-dotnet@v1
-         with:
-           dotnet-version: 6.0.100
-       - name: Build GLFW
-         run: ${{ matrix.env.nuke_invoke }} glfw
-         env:
-
+on:
+  push:
+    paths:
+      - build/submodules/GLFW
+      - build/nuke/Build.Native.cs
+    branches-ignore:
+      - "ci/*"
+      - "develop/*"
+      - "main"
+jobs:
+  Build:
+    strategy: 
+      fail-fast: false
+      matrix:
+        env:
+          - os: ubuntu-latest
+            name: Linux
+            nuke_invoke: ./build.sh
+            extras: |
+              sudo apt-get install -y xorg-dev 
+          - os: windows-latest
+            name: Windows
+            nuke_invoke: ./build.cmd
+            extras: ""
+          - os: macos-latest
+            name: Darwin
+            nuke_invoke: ./build.sh
+            extras: ""
+    name: ${{ matrix.env.name }} Build
+    runs-on: ${{ matrix.env.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extra prerequisites
+        run: |
+          echo running extras
+          ${{ matrix.env.extras }}
+      - name: Setup .NET 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.100
+      - name: Build GLFW
+        run: ${{ matrix.env.nuke_invoke }} glfw

--- a/.github/workflows/GLFW.yml
+++ b/.github/workflows/GLFW.yml
@@ -41,6 +41,3 @@ jobs:
           dotnet-version: 6.0.100
       - name: Build GLFW
         run: ${{ matrix.env.nuke_invoke }} glfw
-      - uses: actions/upload-artifact@v2
-        with:
-          path: build/submodules/GLFW/compiled

--- a/.github/workflows/GLFW.yml
+++ b/.github/workflows/GLFW.yml
@@ -1,9 +1,6 @@
 name: glfw
 on:
   push:
-    paths:
-      - build/submodules/GLFW
-      - build/nuke/Build.Native.cs
     branches-ignore:
       - "ci/*"
       - "develop/*"

--- a/.github/workflows/GLFW.yml
+++ b/.github/workflows/GLFW.yml
@@ -43,4 +43,4 @@ jobs:
         run: ${{ matrix.env.nuke_invoke }} glfw
       - uses: actions/upload-artifact@v2
         with:
-          path: build/submodules/GLFW/build/src
+          path: build/submodules/GLFW/compiled

--- a/.github/workflows/GLFW.yml
+++ b/.github/workflows/GLFW.yml
@@ -28,6 +28,9 @@ jobs:
     runs-on: ${{ matrix.env.os }}
     steps:
       - uses: actions/checkout@v2
+      - name: Checkout submodules
+        run: |
+          git -c submodule.third_party/git-hooks.update=none submodule update --init --recursive
       - name: Extra prerequisites
         run: |
           echo running extras

--- a/.github/workflows/GLFW.yml
+++ b/.github/workflows/GLFW.yml
@@ -1,0 +1,45 @@
+name: glfw
+ on:
+   push:
+     paths:
+       - build/submodules/GLFW
+       - build/nuke/Build.Native.cs
+     branches-ignore:
+       - "ci/*"
+       - "develop/*"
+       - "main"
+ jobs:
+   Build:
+     strategy: 
+       fail-fast: false
+       matrix:
+         env:
+           - os: ubuntu-latest
+             name: Linux
+             nuke_invoke: ./build.sh
+             extras: |
+               sudo apt-get install -y xorg-dev 
+           - os: windows-latest
+             name: Windows
+             nuke_invoke: ./build.cmd
+             extras: ""
+           - os: macos-latest
+             name: Darwin
+             nuke_invoke: ./build.sh
+             extras: ""
+     name: ${{ matrix.env.name }} Build
+     runs-on: ${{ matrix.env.os }}
+     steps:
+       - uses: actions/checkout@v2
+       - name: Extra prerequisites
+         run: |
+           echo running extras
+           ${{ matrix.env.extras }}
+       - name: Setup .NET 6.0
+         uses: actions/setup-dotnet@v1
+         with:
+           dotnet-version: 6.0.100
+       - name: Build GLFW
+         run: ${{ matrix.env.nuke_invoke }} glfw
+         env:
+

--- a/.github/workflows/GLFW.yml
+++ b/.github/workflows/GLFW.yml
@@ -1,4 +1,4 @@
-name: glfw
+name: GLFW
 on:
   push:
     branches-ignore:

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "build/submodules/Vulkan-Headers"]
 	path = build/submodules/Vulkan-Headers
 	url = https://github.com/KhronosGroup/Vulkan-Headers
+[submodule "build/submodules/GLFW"]
+	path = build/submodules/GLFW
+	url = https://github.com/glfw/glfw.git

--- a/build/nuke/Build.Native.cs
+++ b/build/nuke/Build.Native.cs
@@ -130,7 +130,7 @@ partial class Build
                     }
                     else if (OperatingSystem.IsLinux())
                     {
-                        InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -A -m64", GLFWPath)
+                        InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -A -DCMAKE_SYSTEM_PROCESSOR=x86_64", GLFWPath)
                             .AssertZeroExitCode();
                         InheritedShell("cmake --build build", GLFWPath)
                             .AssertZeroExitCode();
@@ -138,7 +138,7 @@ partial class Build
 
                         EnsureCleanDirectory(@out);
                         
-                        InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -A -m32", GLFWPath)
+                        InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -DCMAKE_SYSTEM_PROCESSOR=i368", GLFWPath)
                             .AssertZeroExitCode();
                         InheritedShell("cmake --build build", GLFWPath)
                             .AssertZeroExitCode();

--- a/build/nuke/Build.Native.cs
+++ b/build/nuke/Build.Native.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -110,7 +110,7 @@ partial class Build
                 {
                     var @out = GLFWPath / "build";
                     EnsureCleanDirectory(@out);
-                    var runtimes = GLFWPath / "compiled"; // testing
+                    var runtimes = RootDirectory / "src" / "Native" / "Silk.NET.GLFW.Native" / "runtimes";
                     if (OperatingSystem.IsWindows())
                     {
                         InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -A X64", GLFWPath)
@@ -132,7 +132,7 @@ partial class Build
                     {
                         InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -DCMAKE_SYSTEM_PROCESSOR=x86_64", GLFWPath)
                             .AssertZeroExitCode();
-                        InheritedShell("cmake --build build", GLFWPath)
+                        InheritedShell("cmake --build build --config Release", GLFWPath)
                             .AssertZeroExitCode();
                         CopyAll(@out.GlobFiles("src/libglfw.so"), runtimes / "linux-x64" / "native");
 
@@ -140,7 +140,7 @@ partial class Build
                         
                         InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -DCMAKE_SYSTEM_PROCESSOR=i368", GLFWPath)
                             .AssertZeroExitCode();
-                        InheritedShell("cmake --build build", GLFWPath)
+                        InheritedShell("cmake --build build --config Release", GLFWPath)
                             .AssertZeroExitCode();
                         
                         CopyAll(@out.GlobFiles("src/libglfw.so"), runtimes / "linux-x86" / "native");
@@ -149,7 +149,7 @@ partial class Build
                     {
                         InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=x86_64", GLFWPath)
                             .AssertZeroExitCode();
-                        InheritedShell("cmake --build build", GLFWPath)
+                        InheritedShell("cmake --build build --config Release", GLFWPath)
                             .AssertZeroExitCode();
                         CopyAll(@out.GlobFiles("src/libglfw.3.dylib"), runtimes / "osx-x64" / "native");
 
@@ -157,13 +157,11 @@ partial class Build
                         
                         InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=arm64", GLFWPath)
                             .AssertZeroExitCode();
-                        InheritedShell("cmake --build build", GLFWPath)
+                        InheritedShell("cmake --build build --config Release", GLFWPath)
                             .AssertZeroExitCode();
                         
                         CopyAll(@out.GlobFiles("src/libglfw.3.dylib"), runtimes / "osx-arm64" / "native");
                     }
-                    
-                    //var runtimes = RootDirectory / "src" / "Native" / "Silk.NET.GLFW.Native" / "runtimes";
                 }
             )
     );

--- a/build/nuke/Build.Native.cs
+++ b/build/nuke/Build.Native.cs
@@ -137,15 +137,6 @@ partial class Build
                         InheritedShell(build, GLFWPath)
                             .AssertZeroExitCode();
                         CopyAll(@out.GlobFiles("src/libglfw.so"), runtimes / "linux-x64" / "native");
-
-                        EnsureCleanDirectory(@out);
-                        
-                        InheritedShell($"{prepare} -DCMAKE_SYSTEM_PROCESSOR=i368", GLFWPath)
-                            .AssertZeroExitCode();
-                        InheritedShell(build, GLFWPath)
-                            .AssertZeroExitCode();
-                        
-                        CopyAll(@out.GlobFiles("src/libglfw.so"), runtimes / "linux-x86" / "native");
                     }
                     else if (OperatingSystem.IsMacOS())
                     {

--- a/build/nuke/Build.Native.cs
+++ b/build/nuke/Build.Native.cs
@@ -115,18 +115,18 @@ partial class Build
                     {
                         InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -A X64", GLFWPath)
                             .AssertZeroExitCode();
-                        InheritedShell("cmake --build build", GLFWPath)
+                        InheritedShell("cmake --build build --config Release", GLFWPath)
                             .AssertZeroExitCode();
-                        CopyAll(@out.GlobFiles("Release/glfw3.dll"), runtimes / "win-x64" / "native");
+                        CopyAll(@out.GlobFiles("src/Release/glfw3.dll"), runtimes / "win-x64" / "native");
                         
                         EnsureCleanDirectory(@out);
                         
                         InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -A Win32", GLFWPath)
                             .AssertZeroExitCode();
-                        InheritedShell("cmake --build build", GLFWPath)
+                        InheritedShell("cmake --build build --config Release", GLFWPath)
                             .AssertZeroExitCode();
                         
-                        CopyAll(@out.GlobFiles("Release/glfw3.dll"), runtimes / "win-x86" / "native");
+                        CopyAll(@out.GlobFiles("src/Release/glfw3.dll"), runtimes / "win-x86" / "native");
                     }
                     else if (OperatingSystem.IsLinux())
                     {
@@ -134,7 +134,7 @@ partial class Build
                             .AssertZeroExitCode();
                         InheritedShell("cmake --build build", GLFWPath)
                             .AssertZeroExitCode();
-                        CopyAll(@out.GlobFiles("libglfw.so"), runtimes / "linux-x64" / "native");
+                        CopyAll(@out.GlobFiles("src/libglfw.so"), runtimes / "linux-x64" / "native");
 
                         EnsureCleanDirectory(@out);
                         
@@ -143,7 +143,7 @@ partial class Build
                         InheritedShell("cmake --build build", GLFWPath)
                             .AssertZeroExitCode();
                         
-                        CopyAll(@out.GlobFiles("libglfw.so"), runtimes / "linux-x86" / "native");
+                        CopyAll(@out.GlobFiles("src/libglfw.so"), runtimes / "linux-x86" / "native");
                     }
                     else if (OperatingSystem.IsMacOS())
                     {

--- a/build/nuke/Build.Native.cs
+++ b/build/nuke/Build.Native.cs
@@ -113,10 +113,10 @@ partial class Build
                     var abi = OperatingSystem.IsWindows() ? " -DCMAKE_GENERATOR_PLATFORM=Win32" : string.Empty;
                     InheritedShell
                     (
-                        $"cmake -S . -B build/ -D BUILD_SHARED_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=Release{abi}",
+                        $"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release{abi}",
                         GLFWPath
                     ).AssertZeroExitCode();
-                    InheritedShell("cmake --build build --config Release", GLFWPath)
+                    InheritedShell("cmake --build build", GLFWPath)
                         .AssertZeroExitCode();
                     var runtimes = RootDirectory / "src" / "Native" / "Silk.NET.GLFW.Native" / "runtimes";
                     if (OperatingSystem.IsWindows())

--- a/build/nuke/Build.Native.cs
+++ b/build/nuke/Build.Native.cs
@@ -109,55 +109,57 @@ partial class Build
                 () =>
                 {
                     var @out = GLFWPath / "build";
+                    var prepare = "cmake -S. -B build -D BUILD_SHARED_LIBS=ON";
+                    var build = "cmake --build build --config Release";
                     EnsureCleanDirectory(@out);
                     var runtimes = RootDirectory / "src" / "Native" / "Silk.NET.GLFW.Native" / "runtimes";
                     if (OperatingSystem.IsWindows())
                     {
-                        InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -A X64", GLFWPath)
+                        InheritedShell($"{prepare} -A X64", GLFWPath)
                             .AssertZeroExitCode();
-                        InheritedShell("cmake --build build --config Release", GLFWPath)
+                        InheritedShell(build, GLFWPath)
                             .AssertZeroExitCode();
                         CopyAll(@out.GlobFiles("src/Release/glfw3.dll"), runtimes / "win-x64" / "native");
                         
                         EnsureCleanDirectory(@out);
                         
-                        InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -A Win32", GLFWPath)
+                        InheritedShell($"{prepare} -A Win32", GLFWPath)
                             .AssertZeroExitCode();
-                        InheritedShell("cmake --build build --config Release", GLFWPath)
+                        InheritedShell(build, GLFWPath)
                             .AssertZeroExitCode();
                         
                         CopyAll(@out.GlobFiles("src/Release/glfw3.dll"), runtimes / "win-x86" / "native");
                     }
                     else if (OperatingSystem.IsLinux())
                     {
-                        InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -DCMAKE_SYSTEM_PROCESSOR=x86_64", GLFWPath)
+                        InheritedShell($"{prepare} -DCMAKE_SYSTEM_PROCESSOR=x86_64", GLFWPath)
                             .AssertZeroExitCode();
-                        InheritedShell("cmake --build build --config Release", GLFWPath)
+                        InheritedShell(build, GLFWPath)
                             .AssertZeroExitCode();
                         CopyAll(@out.GlobFiles("src/libglfw.so"), runtimes / "linux-x64" / "native");
 
                         EnsureCleanDirectory(@out);
                         
-                        InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -DCMAKE_SYSTEM_PROCESSOR=i368", GLFWPath)
+                        InheritedShell($"{prepare} -DCMAKE_SYSTEM_PROCESSOR=i368", GLFWPath)
                             .AssertZeroExitCode();
-                        InheritedShell("cmake --build build --config Release", GLFWPath)
+                        InheritedShell(build, GLFWPath)
                             .AssertZeroExitCode();
                         
                         CopyAll(@out.GlobFiles("src/libglfw.so"), runtimes / "linux-x86" / "native");
                     }
                     else if (OperatingSystem.IsMacOS())
                     {
-                        InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=x86_64", GLFWPath)
+                        InheritedShell($"{prepare} -DCMAKE_OSX_ARCHITECTURES=x86_64", GLFWPath)
                             .AssertZeroExitCode();
-                        InheritedShell("cmake --build build --config Release", GLFWPath)
+                        InheritedShell(build, GLFWPath)
                             .AssertZeroExitCode();
                         CopyAll(@out.GlobFiles("src/libglfw.3.dylib"), runtimes / "osx-x64" / "native");
 
                         EnsureCleanDirectory(@out);
                         
-                        InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES=arm64", GLFWPath)
+                        InheritedShell($"{prepare} -DCMAKE_OSX_ARCHITECTURES=arm64", GLFWPath)
                             .AssertZeroExitCode();
-                        InheritedShell("cmake --build build --config Release", GLFWPath)
+                        InheritedShell(build, GLFWPath)
                             .AssertZeroExitCode();
                         
                         CopyAll(@out.GlobFiles("src/libglfw.3.dylib"), runtimes / "osx-arm64" / "native");

--- a/build/nuke/Build.Native.cs
+++ b/build/nuke/Build.Native.cs
@@ -130,7 +130,7 @@ partial class Build
                     }
                     else if (OperatingSystem.IsLinux())
                     {
-                        InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -A -DCMAKE_SYSTEM_PROCESSOR=x86_64", GLFWPath)
+                        InheritedShell($"cmake -S . -B build -D BUILD_SHARED_LIBS=ON -DCMAKE_SYSTEM_PROCESSOR=x86_64", GLFWPath)
                             .AssertZeroExitCode();
                         InheritedShell("cmake --build build", GLFWPath)
                             .AssertZeroExitCode();

--- a/build/nuke/Build.Support.cs
+++ b/build/nuke/Build.Support.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -14,6 +15,10 @@ using Nuke.Common;
 using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
+using Nuke.Common.Tooling;
+using Nuke.Common.Utilities;
+using static Nuke.Common.IO.FileSystemTasks;
+using static Nuke.Common.Tooling.ProcessTasks;
 using Octokit;
 using Octokit.Internal;
 
@@ -36,6 +41,36 @@ partial class Build
         }
 
         return idx;
+    }
+
+    Dictionary<string, string> CreateEnvVarDictionary()
+        => Environment.GetEnvironmentVariables()
+            .Cast<DictionaryEntry>()
+            .ToDictionary(x => (string) x.Key, x => (string) x.Value);
+
+    IProcess InheritedShell(string cmd, [CanBeNull] string workDir = null)
+        => OperatingSystem.IsWindows()
+            ? StartProcess("powershell", $"-Command {cmd.DoubleQuote()}", workDir, CreateEnvVarDictionary())
+            : StartProcess("bash", $"-c {cmd.DoubleQuote()}", workDir, CreateEnvVarDictionary());
+
+    void AddToPath(string dir)
+    {
+        var pathVar = Environment.GetEnvironmentVariables()
+            .Cast<DictionaryEntry>()
+            .First(x => ((string) x.Key).Equals("PATH", StringComparison.OrdinalIgnoreCase));
+        Environment.SetEnvironmentVariable
+        (
+            (string) pathVar.Key,
+            (string) pathVar.Value + (OperatingSystem.IsWindows() ? $";{dir}" : $":{dir}")
+        );
+    }
+
+    static void CopyAll(IEnumerable<AbsolutePath> paths, AbsolutePath dir)
+    {
+        foreach (var path in paths)
+        {
+            CopyFile(path, dir / Path.GetFileName(path), FileExistsPolicy.Overwrite);
+        }
     }
 
     [Nuke.Common.Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]

--- a/build/nuke/Build.Support.cs
+++ b/build/nuke/Build.Support.cs
@@ -17,10 +17,10 @@ using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Utilities;
-using static Nuke.Common.IO.FileSystemTasks;
-using static Nuke.Common.Tooling.ProcessTasks;
 using Octokit;
 using Octokit.Internal;
+using static Nuke.Common.IO.FileSystemTasks;
+using static Nuke.Common.Tooling.ProcessTasks;
 
 partial class Build
 {


### PR DESCRIPTION
# Summary of the PR
Self building GLFW for Windows, Mac and Linux, including Mac arm64.
This partially resolves #727.

# Related issues, Discord discussions, or proposals
https://discord.com/channels/521092042781229087/587346162802229298/936229014249562172

# Further work
Currently the mac libraries cause a security warning, since they are not signed. This needs to be resolved before shipping them.

Silk is also still missing arm64 build for OpenAL, and ImGUI.NET also does not ship with arm natives. 