### PR TITLE
Start of rotate vector by quaternion with multiplication operator

### DIFF
--- a/src/Maths/Silk.NET.Maths/Quaternion.cs
+++ b/src/Maths/Silk.NET.Maths/Quaternion.cs
@@ -224,6 +224,19 @@ namespace Silk.NET.Maths
 
             return ans;
         }
+        
+        /// <summary>Multiplies a Vector by a Quaternion, effectively rotating it.</summary>
+        /// <param name="value1">The Quaternion.</param>
+        /// <param name="value2">The Vector.</param>
+        /// <returns>The result of the multiplication.</returns>
+        public static Vector3D<T> operator *(Quaternion<T> value1, Vector3D<T> value2)
+        {
+            var u = new Vector3D<T>(value1.X, value1.Y, value1.Z);
+            T s = value1.W;
+            return Scalar.Multiply(Scalar<T>.Two, Vector3D.Dot(u, value2)) * u
+                 + Scalar.Subtract(Scalar.Multiply(s, s), Vector3D.Dot(u, u)) * value2
+                 + Scalar.Multiply(Scalar<T>.Two, s) * Vector3D.Cross(u, value2);
+        }
 
         /// <summary>Adds two Quaternions element-by-element.</summary>
         /// <param name="value1">The first source Quaternion.</param>


### PR DESCRIPTION
# Summary of the PR
Adds the ability to "multiply" a vector by a quaternion, effectively rotating it. This is supported by Unity.

Mock implementation (no operator signature yet):
```csharp
public static Vector3D<double> Rotate(in Vector3D<double> v, in Quaternion<double> q)
{
    Debug.Assert(Math.Abs(q.LengthSquared() - 1.0) < 1e-6f);
    var u = new Vector3D<double>(q.X, q.Y, q.Z);
    double s = q.W;
    return 2.0 * Vector3D.Dot(u, v) * u
         + (s * s - Vector3D.Dot(u, u)) * v
         + 2.0 * s * Vector3D.Cross(u, v);
}
```

# Related issues, Discord discussions, or proposals
https://gamedev.stackexchange.com/questions/28395/rotating-vector3-by-a-quaternion

# Further Comments
I was looking for a builtin function, couldn't seem to find it (or wasn't obvious)