### PR TITLE
Fix SilkMarshal.GetMaxSizeOf not including space for null terminator for NativeStringEncoding.LPStr

### DIFF
--- a/src/Core/Silk.NET.Core/Native/SilkMarshal.cs
+++ b/src/Core/Silk.NET.Core/Native/SilkMarshal.cs
@@ -155,7 +155,7 @@ namespace Silk.NET.Core.Native
             => encoding switch
             {
                 NativeStringEncoding.BStr => -1,
-                NativeStringEncoding.LPStr => ((input?.Length ?? 0) + 1) * Marshal.SystemMaxDBCSCharSize,
+                NativeStringEncoding.LPStr => ((input?.Length ?? 0) + 1) * Marshal.SystemMaxDBCSCharSize + 1,
                 NativeStringEncoding.LPTStr => (input is null ? 0 : Encoding.UTF8.GetMaxByteCount(input.Length)) + 1,
                 NativeStringEncoding.LPUTF8Str => (input is null ? 0 : Encoding.UTF8.GetMaxByteCount(input.Length)) + 1,
                 NativeStringEncoding.LPWStr => ((input?.Length ?? 0) + 1) * 2,


### PR DESCRIPTION
# Summary of the PR

```cs
var ptr = Silk.NET.Core.Native.SilkMarshal.StringToPtr("ä", Silk.NET.Core.Native.NativeStringEncoding.Ansi);
```
Threw `The output byte buffer is too small to contain the encoded data`

GetMaxSizeOf did not include a null terminator byte for Ansi/LPStr strings, which then caused StringIntoSpan to fail.