### PR TITLE
set callbacks on GlfwWindow to null after unregistering

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
@@ -701,6 +701,15 @@ namespace Silk.NET.Windowing.Glfw
                 _glfw.GcUtility.Unpin(_onFramebufferResize);
                 _glfw.GcUtility.Unpin(_onFileDrop);
                 _glfw.GcUtility.Unpin(_onFocusChanged);
+
+                _onClosing = null;
+                _onMaximized = null;
+                _onMinimized = null;
+                _onMove = null;
+                _onResize = null;
+                _onFramebufferResize = null;
+                _onFileDrop = null;
+                _onFocusChanged = null;
             }
         }
 


### PR DESCRIPTION
# Summary of the PR
Set the callbacks in GlfwWindow to null after unregistering so the originally registered methods are released.

# Related issues, Discord discussions, or proposals
This addresses part of #821 

# Further Comments
My current understanding is that the registered callbacks are closures that capture the window itself. This creates a kind of circular reference that seems to prevent the window from being released by the GC.