### PR TITLE
KeyDown/KeyUp map to unknown and call event

### DIFF
--- a/src/Input/Silk.NET.Input.Glfw/GlfwKeyboard.cs
+++ b/src/Input/Silk.NET.Input.Glfw/GlfwKeyboard.cs
@@ -187,7 +187,7 @@ namespace Silk.NET.Input.Glfw
             Keys.AltRight => Key.AltRight,
             Keys.SuperRight => Key.SuperRight,
             Keys.Menu => Key.Menu,
-            _ => throw new ArgumentOutOfRangeException()
+            _ => Key.Unknown
         };
 
         private static Keys ConvertKey(Key keys) => keys switch
@@ -313,7 +313,7 @@ namespace Silk.NET.Input.Glfw
             Key.AltRight => Keys.AltRight,
             Key.SuperRight => Keys.SuperRight,
             Key.Menu => Keys.Menu,
-            _ => throw new ArgumentOutOfRangeException()
+            _ => Keys.Unknown
         };
     }
 }

--- a/src/Input/Silk.NET.Input.Sdl/SdlKeyboard.cs
+++ b/src/Input/Silk.NET.Input.Sdl/SdlKeyboard.cs
@@ -70,7 +70,7 @@ namespace Silk.NET.Input.Sdl
                         }
                         else
                         {
-                            keyUp = key;
+                            keyUp = Key.Unknown;
                         }
 
                         KeyUp?.Invoke(this, keyUp, (int) @event.Key.Keysym.Scancode);

--- a/src/Input/Silk.NET.Input.Sdl/SdlKeyboard.cs
+++ b/src/Input/Silk.NET.Input.Sdl/SdlKeyboard.cs
@@ -40,20 +40,40 @@ namespace Silk.NET.Input.Sdl
             {
                 case EventType.Keydown:
                 {
-                    if (@event.Key.Repeat != 1 && _keyMap.TryGetValue((KeyCode) @event.Key.Keysym.Sym, out var key))
+                    if (@event.Key.Repeat != 1)
                     {
-                        _keysDown.Add(key);
-                        KeyDown?.Invoke(this, key, (int) @event.Key.Keysym.Scancode);
+                        Key keyDown;
+                        if (_keyMap.TryGetValue((KeyCode) @event.Key.Keysym.Sym, out var key))
+                        {
+                            keyDown = key;
+                            _keysDown.Add(keyDown);
+                        }
+                        else
+                        {
+                            keyDown = Key.Unknown;
+                        }
+
+                        KeyDown?.Invoke(this, keyDown, (int) @event.Key.Keysym.Scancode);
                     }
 
                     break;
                 }
                 case EventType.Keyup:
                 {
-                    if (@event.Key.Repeat != 1 && _keyMap.TryGetValue((KeyCode) @event.Key.Keysym.Sym, out var key))
+                    if (@event.Key.Repeat != 1)
                     {
-                        _keysDown.Remove(key);
-                        KeyUp?.Invoke(this, key, (int) @event.Key.Keysym.Scancode);
+                        Key keyUp;
+                        if (_keyMap.TryGetValue((KeyCode) @event.Key.Keysym.Sym, out var key))
+                        {
+                            keyUp = key;
+                            _keysDown.Remove(keyUp);
+                        }
+                        else
+                        {
+                            keyUp = key;
+                        }
+
+                        KeyUp?.Invoke(this, keyUp, (int) @event.Key.Keysym.Scancode);
                     }
 
                     break;


### PR DESCRIPTION
# Summary of the PR
Instead of not calling KeyDown when the key is not found, call it with Key.Unknown and the platform specific scan code.

# Related issues, Discord discussions, or proposals
[Issue 846](https://github.com/dotnet/Silk.NET/issues/846)

# Further Comments
Perhaps as a next step the scan codes between GLFW and SDL should be made the same.