### PR TITLE
Dont set context profile on OpenGL < 3.2

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
@@ -326,12 +326,13 @@ namespace Silk.NET.Windowing.Glfw
                 _glfw.WindowHint(WindowHintBool.OpenGLDebugContext, true);
             }
 
-            // Set API profile
-            _glfw.WindowHint
-            (
-                WindowHintOpenGlProfile.OpenGlProfile,
-                opts.API.Profile == ContextProfile.Core ? OpenGlProfile.Core : OpenGlProfile.Compat
-            );
+            if((opts.API.Version.MajorVersion == 3 && opts.API.Version.MinorVersion >= 2) || opts.API.Version.MajorVersion > 3)
+                // Set API profile
+                _glfw.WindowHint
+                (
+                    WindowHintOpenGlProfile.OpenGlProfile,
+                    opts.API.Profile == ContextProfile.Core ? OpenGlProfile.Core : OpenGlProfile.Compat
+                );
 
             // Set video mode (-1 = don't care)
             _glfw.WindowHint(WindowHintInt.RefreshRate, opts.VideoMode.RefreshRate ?? -1);

--- a/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
@@ -326,13 +326,15 @@ namespace Silk.NET.Windowing.Glfw
                 _glfw.WindowHint(WindowHintBool.OpenGLDebugContext, true);
             }
 
-            if((opts.API.Version.MajorVersion == 3 && opts.API.Version.MinorVersion >= 2) || opts.API.Version.MajorVersion > 3)
+            if ((opts.API.Version.MajorVersion == 3 && opts.API.Version.MinorVersion >= 2) || opts.API.Version.MajorVersion > 3)
+            {
                 // Set API profile
                 _glfw.WindowHint
                 (
                     WindowHintOpenGlProfile.OpenGlProfile,
                     opts.API.Profile == ContextProfile.Core ? OpenGlProfile.Core : OpenGlProfile.Compat
                 );
+            }
 
             // Set video mode (-1 = don't care)
             _glfw.WindowHint(WindowHintInt.RefreshRate, opts.VideoMode.RefreshRate ?? -1);


### PR DESCRIPTION
# Summary of the PR
On GLFW, it will error out if you set the OpenGL context profile on OpenGL versions less then 3.2

# Related issues, Discord discussions, or proposals
https://discord.com/channels/521092042781229087/587346162802229298/964611543406878780