### PR TITLE
Update tutorials

### DIFF
--- a/examples/CSharp/OpenAL Demos/WavePlayer/WavePlayer.csproj
+++ b/examples/CSharp/OpenAL Demos/WavePlayer/WavePlayer.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/examples/CSharp/OpenGL Demos/AndroidDemo/AndroidDemo.csproj
+++ b/examples/CSharp/OpenGL Demos/AndroidDemo/AndroidDemo.csproj
@@ -22,7 +22,7 @@
     </AndroidAsset>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />

--- a/examples/CSharp/OpenGL Demos/ImGui/ImGui.csproj
+++ b/examples/CSharp/OpenGL Demos/ImGui/ImGui.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/examples/CSharp/OpenGL Demos/ImGui/ImGui.csproj
+++ b/examples/CSharp/OpenGL Demos/ImGui/ImGui.csproj
@@ -7,10 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="ImGui.NET" Version="1.86.0" />
-    </ItemGroup>
-
-    <ItemGroup>
       <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
       <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
       <ProjectReference Include="..\..\..\..\src\OpenGL\Extensions\Silk.NET.OpenGL.Extensions.ImGui\Silk.NET.OpenGL.Extensions.ImGui.csproj" />

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.1 - Hello Window/Program.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.1 - Hello Window/Program.cs
@@ -1,4 +1,3 @@
-using System.Drawing;
 using Silk.NET.Input;
 using Silk.NET.Maths;
 using Silk.NET.Windowing;

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.1 - Hello Window/Tutorial 1.1 - Hello Window.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.1 - Hello Window/Tutorial 1.1 - Hello Window.csproj
@@ -7,7 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
+      <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
+      <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />
     </ItemGroup>
 
 </Project>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.1 - Hello Window/Tutorial 1.1 - Hello Window.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.1 - Hello Window/Tutorial 1.1 - Hello Window.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Tutorial</RootNamespace>
     </PropertyGroup>
 

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.2 - Hello quad/Program.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.2 - Hello quad/Program.cs
@@ -2,7 +2,6 @@ using Silk.NET.Input;
 using Silk.NET.OpenGL;
 using Silk.NET.Windowing;
 using System;
-using System.Drawing;
 using Silk.NET.Maths;
 
 namespace Tutorial

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.2 - Hello quad/Tutorial 1.2 - Hello quad.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.2 - Hello quad/Tutorial 1.2 - Hello quad.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Tutorial</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.2 - Hello quad/Tutorial 1.2 - Hello quad.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.2 - Hello quad/Tutorial 1.2 - Hello quad.csproj
@@ -8,7 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
+        <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />
     </ItemGroup>
 
 </Project>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.3 - Abstractions/Program.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.3 - Abstractions/Program.cs
@@ -2,7 +2,6 @@ using Silk.NET.Input;
 using Silk.NET.OpenGL;
 using Silk.NET.Windowing;
 using System;
-using System.Drawing;
 using Silk.NET.Maths;
 
 namespace Tutorial

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.3 - Abstractions/Tutorial 1.3 - Abstraction.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.3 - Abstractions/Tutorial 1.3 - Abstraction.csproj
@@ -8,7 +8,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
+        <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.3 - Abstractions/Tutorial 1.3 - Abstraction.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.3 - Abstractions/Tutorial 1.3 - Abstraction.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Tutorial</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.4 - Textures/Program.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.4 - Textures/Program.cs
@@ -1,7 +1,6 @@
 using Silk.NET.Input;
 using Silk.NET.OpenGL;
 using Silk.NET.Windowing;
-using System.Drawing;
 using Silk.NET.Maths;
 
 namespace Tutorial

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.4 - Textures/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.4 - Textures/Texture.cs
@@ -2,8 +2,6 @@ using Silk.NET.OpenGL;
 using System;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using System.Runtime.InteropServices;
-using SixLabors.ImageSharp.Processing;
 
 namespace Tutorial
 {

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.4 - Textures/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.4 - Textures/Texture.cs
@@ -14,30 +14,36 @@ namespace Tutorial
 
         public unsafe Texture(GL gl, string path)
         {
-            //Loading an image using imagesharp.
-            Image<Rgba32> img = (Image<Rgba32>) Image.Load(path);
+            _gl = gl;
 
-            // OpenGL has image origin in the bottom-left corner.
-            fixed (void* data = &MemoryMarshal.GetReference(img.GetPixelRowSpan(0)))
+            _handle = _gl.GenTexture();
+            Bind();
+
+            //Loading an image using imagesharp.
+            using (var img = Image.Load<Rgba32>(path))
             {
-                //Loading the actual image.
-                Load(gl, data, (uint) img.Width, (uint) img.Height);
+                //Reserve enough memory from the gpu for the whole image
+                gl.TexImage2D(TextureTarget.Texture2D, 0, InternalFormat.Rgba8, (uint) img.Width, (uint) img.Height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, null);
+
+                img.ProcessPixelRows(accessor =>
+                {
+                    //ImageSharp 2 does not store images in contiguous memory by default, so we must send the image row by row
+                    for (int y = 0; y < accessor.Height; y++)
+                    {
+                        fixed (void* data = accessor.GetRowSpan(y))
+                        {
+                            //Loading the actual image.
+                            gl.TexSubImage2D(TextureTarget.Texture2D, 0, 0, y, (uint) accessor.Width, 1, PixelFormat.Rgba, PixelType.UnsignedByte, data);
+                        }
+                    }
+                });
             }
 
-            //Deleting the img from imagesharp.
-            img.Dispose();
+            SetParameters();
+
         }
 
         public unsafe Texture(GL gl, Span<byte> data, uint width, uint height)
-        {
-            //We want the ability to create a texture using data generated from code aswell.
-            fixed (void* d = &data[0])
-            {
-                Load(gl, d, width, height);
-            }
-        }
-
-        private unsafe void Load(GL gl, void* data, uint width, uint height)
         {
             //Saving the gl instance.
             _gl = gl;
@@ -46,14 +52,22 @@ namespace Tutorial
             _handle = _gl.GenTexture();
             Bind();
 
-            //Setting the data of a texture.
-            _gl.TexImage2D(TextureTarget.Texture2D, 0, (int) InternalFormat.Rgba, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, data);
+            //We want the ability to create a texture using data generated from code aswell.
+            fixed (void* d = &data[0])
+            {
+                //Setting the data of a texture.
+                _gl.TexImage2D(TextureTarget.Texture2D, 0, (int) InternalFormat.Rgba, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, d);
+                SetParameters();
+            }
+        }
+
+        private void SetParameters()
+        {
             //Setting some texture perameters so the texture behaves as expected.
-            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int) GLEnum.Repeat);
-            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.Repeat);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int) GLEnum.ClampToEdge);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.Linear);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) GLEnum.Linear);
-
             //Generating mipmaps.
             _gl.GenerateMipmap(TextureTarget.Texture2D);
         }

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.4 - Textures/Tutorial 1.4 - Textures.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.4 - Textures/Tutorial 1.4 - Textures.csproj
@@ -12,7 +12,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
+        <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.4 - Textures/Tutorial 1.4 - Textures.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.4 - Textures/Tutorial 1.4 - Textures.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Tutorial</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.4 - Textures/Tutorial 1.4 - Textures.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.4 - Textures/Tutorial 1.4 - Textures.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Program.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Program.cs
@@ -1,7 +1,6 @@
 using Silk.NET.Input;
 using Silk.NET.OpenGL;
 using Silk.NET.Windowing;
-using System.Drawing;
 using System.Numerics;
 using Silk.NET.Maths;
 

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Texture.cs
@@ -15,32 +15,46 @@ namespace Tutorial
 
         public unsafe Texture(GL gl, string path)
         {
-            Image<Rgba32> img = (Image<Rgba32>) Image.Load(path);
-            
-            fixed (void* data = &MemoryMarshal.GetReference(img.GetPixelRowSpan(0)))
+            _gl = gl;
+
+            _handle = _gl.GenTexture();
+            Bind();
+
+            using (var img = Image.Load<Rgba32>(path))
             {
-                Load(gl, data, (uint) img.Width, (uint) img.Height);
+                gl.TexImage2D(TextureTarget.Texture2D, 0, InternalFormat.Rgba8, (uint) img.Width, (uint) img.Height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, null);
+
+                img.ProcessPixelRows(accessor =>
+                {
+                    for (int y = 0; y < accessor.Height; y++)
+                    {
+                        fixed (void* data = accessor.GetRowSpan(y))
+                        {
+                            gl.TexSubImage2D(TextureTarget.Texture2D, 0, 0, y, (uint) accessor.Width, 1, PixelFormat.Rgba, PixelType.UnsignedByte, data);
+                        }
+                    }
+                });
             }
 
-            img.Dispose();
+            SetParameters();
         }
 
         public unsafe Texture(GL gl, Span<byte> data, uint width, uint height)
-        {
-            fixed (void* d = &data[0])
-            {
-                Load(gl, d, width, height);
-            }
-        }
-
-        private unsafe void Load(GL gl, void* data, uint width, uint height)
         {
             _gl = gl;
 
             _handle = _gl.GenTexture();
             Bind();
 
-            _gl.TexImage2D(TextureTarget.Texture2D, 0, (int) InternalFormat.Rgba, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, data);
+            fixed (void* d = &data[0])
+            {
+                _gl.TexImage2D(TextureTarget.Texture2D, 0, (int) InternalFormat.Rgba, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, d);
+                SetParameters();
+            }
+        }
+
+        private void SetParameters()
+        {
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.Linear);

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Texture.cs
@@ -2,9 +2,6 @@ using Silk.NET.OpenGL;
 using System;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using System.Runtime.InteropServices;
-using SixLabors.ImageSharp.Advanced;
-using SixLabors.ImageSharp.Processing;
 
 namespace Tutorial
 {

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Tutorial 1.5 - Transformations.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Tutorial 1.5 - Transformations.csproj
@@ -12,7 +12,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
+        <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Tutorial 1.5 - Transformations.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Tutorial 1.5 - Transformations.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Tutorial</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Tutorial 1.5 - Transformations.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Tutorial 1.5 - Transformations.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Program.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Program.cs
@@ -1,7 +1,6 @@
 using Silk.NET.Input;
 using Silk.NET.OpenGL;
 using Silk.NET.Windowing;
-using System.Drawing;
 using System.Numerics;
 using Silk.NET.Maths;
 

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Texture.cs
@@ -14,33 +14,46 @@ namespace Tutorial
 
         public unsafe Texture(GL gl, string path)
         {
-            Image<Rgba32> img = (Image<Rgba32>) Image.Load(path);
-            img.Mutate(x => x.Flip(FlipMode.Vertical));
+            _gl = gl;
 
-            fixed (void* data = &MemoryMarshal.GetReference(img.GetPixelRowSpan(0)))
+            _handle = _gl.GenTexture();
+            Bind();
+
+            using (var img = Image.Load<Rgba32>(path))
             {
-                Load(gl, data, (uint) img.Width, (uint) img.Height);
+                gl.TexImage2D(TextureTarget.Texture2D, 0, InternalFormat.Rgba8, (uint) img.Width, (uint) img.Height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, null);
+
+                img.ProcessPixelRows(accessor =>
+                {
+                    for (int y = 0; y < accessor.Height; y++)
+                    {
+                        fixed (void* data = accessor.GetRowSpan(y))
+                        {
+                            gl.TexSubImage2D(TextureTarget.Texture2D, 0, 0, y, (uint) accessor.Width, 1, PixelFormat.Rgba, PixelType.UnsignedByte, data);
+                        }
+                    }
+                });
             }
 
-            img.Dispose();
+            SetParameters();
         }
 
         public unsafe Texture(GL gl, Span<byte> data, uint width, uint height)
-        {
-            fixed (void* d = &data[0])
-            {
-                Load(gl, d, width, height);
-            }
-        }
-
-        private unsafe void Load(GL gl, void* data, uint width, uint height)
         {
             _gl = gl;
 
             _handle = _gl.GenTexture();
             Bind();
 
-            _gl.TexImage2D(TextureTarget.Texture2D, 0, (int) InternalFormat.Rgba, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, data);
+            fixed (void* d = &data[0])
+            {
+                _gl.TexImage2D(TextureTarget.Texture2D, 0, (int) InternalFormat.Rgba, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, d);
+                SetParameters();
+            }
+        }
+
+        private void SetParameters()
+        {
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.Linear);

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Texture.cs
@@ -1,9 +1,7 @@
 using Silk.NET.OpenGL;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
 using System;
-using System.Runtime.InteropServices;
 
 namespace Tutorial
 {

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Tutorial 2.1 - Co-ordinate Systems.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Tutorial 2.1 - Co-ordinate Systems.csproj
@@ -12,7 +12,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
+        <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Tutorial 2.1 - Co-ordinate Systems.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Tutorial 2.1 - Co-ordinate Systems.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Tutorial</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Tutorial 2.1 - Co-ordinate Systems.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Tutorial 2.1 - Co-ordinate Systems.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Program.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Program.cs
@@ -2,7 +2,6 @@ using Silk.NET.Input;
 using Silk.NET.OpenGL;
 using Silk.NET.Windowing;
 using System;
-using System.Drawing;
 using System.Linq;
 using System.Numerics;
 using Silk.NET.Maths;

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Texture.cs
@@ -14,32 +14,46 @@ namespace Tutorial
 
         public unsafe Texture(GL gl, string path)
         {
-            Image<Rgba32> img = (Image<Rgba32>) Image.Load(path);
-            
-            fixed (void* data = &MemoryMarshal.GetReference(img.GetPixelRowSpan(0)))
+            _gl = gl;
+
+            _handle = _gl.GenTexture();
+            Bind();
+
+            using (var img = Image.Load<Rgba32>(path))
             {
-                Load(gl, data, (uint) img.Width, (uint) img.Height);
+                gl.TexImage2D(TextureTarget.Texture2D, 0, InternalFormat.Rgba8, (uint) img.Width, (uint) img.Height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, null);
+
+                img.ProcessPixelRows(accessor =>
+                {
+                    for (int y = 0; y < accessor.Height; y++)
+                    {
+                        fixed (void* data = accessor.GetRowSpan(y))
+                        {
+                            gl.TexSubImage2D(TextureTarget.Texture2D, 0, 0, y, (uint) accessor.Width, 1, PixelFormat.Rgba, PixelType.UnsignedByte, data);
+                        }
+                    }
+                });
             }
 
-            img.Dispose();
+            SetParameters();
         }
 
         public unsafe Texture(GL gl, Span<byte> data, uint width, uint height)
-        {
-            fixed (void* d = &data[0])
-            {
-                Load(gl, d, width, height);
-            }
-        }
-
-        private unsafe void Load(GL gl, void* data, uint width, uint height)
         {
             _gl = gl;
 
             _handle = _gl.GenTexture();
             Bind();
 
-            _gl.TexImage2D(TextureTarget.Texture2D, 0, (int) InternalFormat.Rgba, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, data);
+            fixed (void* d = &data[0])
+            {
+                _gl.TexImage2D(TextureTarget.Texture2D, 0, (int) InternalFormat.Rgba, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, d);
+                SetParameters();
+            }
+        }
+
+        private void SetParameters()
+        {
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.Linear);

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Texture.cs
@@ -1,9 +1,7 @@
 using Silk.NET.OpenGL;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
 using System;
-using System.Runtime.InteropServices;
 
 namespace Tutorial
 {

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Tutorial 2.2 - Camera.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Tutorial 2.2 - Camera.csproj
@@ -12,7 +12,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
+        <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Tutorial 2.2 - Camera.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Tutorial 2.2 - Camera.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Tutorial</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Tutorial 2.2 - Camera.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Tutorial 2.2 - Camera.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.1 - Ambient Lighting/Program.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.1 - Ambient Lighting/Program.cs
@@ -1,7 +1,6 @@
 using Silk.NET.Input;
 using Silk.NET.OpenGL;
 using Silk.NET.Windowing;
-using System.Drawing;
 using System.Linq;
 using System.Numerics;
 using Silk.NET.Maths;

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.1 - Ambient Lighting/Tutorial 3.1 - Ambient Lighting.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.1 - Ambient Lighting/Tutorial 3.1 - Ambient Lighting.csproj
@@ -12,7 +12,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
+        <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.1 - Ambient Lighting/Tutorial 3.1 - Ambient Lighting.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.1 - Ambient Lighting/Tutorial 3.1 - Ambient Lighting.csproj
@@ -8,10 +8,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
         <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
         <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.1 - Ambient Lighting/Tutorial 3.1 - Ambient Lighting.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.1 - Ambient Lighting/Tutorial 3.1 - Ambient Lighting.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Tutorial</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.2 - Diffuse Lighting/Program.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.2 - Diffuse Lighting/Program.cs
@@ -1,7 +1,6 @@
 using Silk.NET.Input;
 using Silk.NET.OpenGL;
 using Silk.NET.Windowing;
-using System.Drawing;
 using System.Linq;
 using System.Numerics;
 using Silk.NET.Maths;

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.2 - Diffuse Lighting/Tutorial 3.2 - Diffuse Lighting.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.2 - Diffuse Lighting/Tutorial 3.2 - Diffuse Lighting.csproj
@@ -12,7 +12,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
+        <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.2 - Diffuse Lighting/Tutorial 3.2 - Diffuse Lighting.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.2 - Diffuse Lighting/Tutorial 3.2 - Diffuse Lighting.csproj
@@ -8,10 +8,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
         <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
         <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.2 - Diffuse Lighting/Tutorial 3.2 - Diffuse Lighting.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.2 - Diffuse Lighting/Tutorial 3.2 - Diffuse Lighting.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Tutorial</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.3 - Specular Lighting/Program.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.3 - Specular Lighting/Program.cs
@@ -1,7 +1,6 @@
 using Silk.NET.Input;
 using Silk.NET.OpenGL;
 using Silk.NET.Windowing;
-using System.Drawing;
 using System.Linq;
 using System.Numerics;
 using Silk.NET.Maths;

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.3 - Specular Lighting/Tutorial 3.3 - Specular Lighting.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.3 - Specular Lighting/Tutorial 3.3 - Specular Lighting.csproj
@@ -12,7 +12,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
+        <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.3 - Specular Lighting/Tutorial 3.3 - Specular Lighting.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.3 - Specular Lighting/Tutorial 3.3 - Specular Lighting.csproj
@@ -8,10 +8,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
         <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
         <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.3 - Specular Lighting/Tutorial 3.3 - Specular Lighting.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.3 - Specular Lighting/Tutorial 3.3 - Specular Lighting.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Tutorial</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.4 - Materials/Program.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.4 - Materials/Program.cs
@@ -2,7 +2,6 @@ using Silk.NET.Input;
 using Silk.NET.OpenGL;
 using Silk.NET.Windowing;
 using System;
-using System.Drawing;
 using System.Linq;
 using System.Numerics;
 using Silk.NET.Maths;

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.4 - Materials/Tutorial 3.4 - Materials.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.4 - Materials/Tutorial 3.4 - Materials.csproj
@@ -12,7 +12,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
+        <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.4 - Materials/Tutorial 3.4 - Materials.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.4 - Materials/Tutorial 3.4 - Materials.csproj
@@ -8,10 +8,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
         <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
         <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.4 - Materials/Tutorial 3.4 - Materials.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.4 - Materials/Tutorial 3.4 - Materials.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Tutorial</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Program.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Program.cs
@@ -2,7 +2,6 @@ using Silk.NET.Input;
 using Silk.NET.OpenGL;
 using Silk.NET.Windowing;
 using System;
-using System.Drawing;
 using System.Linq;
 using System.Numerics;
 using Silk.NET.Maths;

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Texture.cs
@@ -14,32 +14,46 @@ namespace Tutorial
 
         public unsafe Texture(GL gl, string path)
         {
-            Image<Rgba32> img = (Image<Rgba32>) Image.Load(path);
+            _gl = gl;
+
+            _handle = _gl.GenTexture();
+            Bind();
             
-            fixed (void* data = &MemoryMarshal.GetReference(img.GetPixelRowSpan(0)))
+            using (var img = Image.Load<Rgba32>(path))
             {
-                Load(gl, data, (uint) img.Width, (uint) img.Height);
+                gl.TexImage2D(TextureTarget.Texture2D, 0, InternalFormat.Rgba8, (uint)img.Width, (uint)img.Height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, null);
+                
+                img.ProcessPixelRows(accessor =>
+                {
+                    for (int y = 0; y < accessor.Height; y++)
+                    {
+                        fixed (void* data = accessor.GetRowSpan(y))
+                        {
+                            gl.TexSubImage2D(TextureTarget.Texture2D, 0, 0, y, (uint) accessor.Width, 1, PixelFormat.Rgba, PixelType.UnsignedByte, data);
+                        }
+                    }
+                });
             }
 
-            img.Dispose();
+            SetParameters();
         }
 
         public unsafe Texture(GL gl, Span<byte> data, uint width, uint height)
-        {
-            fixed (void* d = &data[0])
-            {
-                Load(gl, d, width, height);
-            }
-        }
-
-        private unsafe void Load(GL gl, void* data, uint width, uint height)
         {
             _gl = gl;
 
             _handle = _gl.GenTexture();
             Bind();
+            
+            fixed (void* d = &data[0])
+            {
+                _gl.TexImage2D(TextureTarget.Texture2D, 0, (int) InternalFormat.Rgba, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, d);
+                SetParameters();
+            }
+        }
 
-            _gl.TexImage2D(TextureTarget.Texture2D, 0, (int) InternalFormat.Rgba, width, height, 0, PixelFormat.Rgba, PixelType.UnsignedByte, data);
+        private void SetParameters()
+        {
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.Linear);

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Texture.cs
@@ -1,9 +1,7 @@
 using Silk.NET.OpenGL;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
 using System;
-using System.Runtime.InteropServices;
 
 namespace Tutorial
 {

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Tutorial 3.5 - Lighting Maps.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Tutorial 3.5 - Lighting Maps.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Tutorial 3.5 - Lighting Maps.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Tutorial 3.5 - Lighting Maps.csproj
@@ -12,7 +12,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Input\Silk.NET.Input\Silk.NET.Input.csproj" />
+        <ProjectReference Include="..\..\..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
+        <ProjectReference Include="..\..\..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Tutorial 3.5 - Lighting Maps.csproj
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Tutorial 3.5 - Lighting Maps.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Tutorial</RootNamespace>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>


### PR DESCRIPTION
# Summary of the PR
Update tutorials to .NET6, use latest ImageSharp with new type of image loading and only reference packages which are actually needed.