### PR TITLE
Better Identifier Emission & State Handling

### DIFF
--- a/src/generators/Silk.NET.SilkTouch.Emitter/CSharpEmitter.cs
+++ b/src/generators/Silk.NET.SilkTouch.Emitter/CSharpEmitter.cs
@@ -108,7 +108,7 @@ public sealed class CSharpEmitter
         {
             AssertClearState();
             
-            _syntaxToken = Identifier(identifierSymbol.Value);
+            _syntaxToken = Identifier(SyntaxTriviaList.Empty, identifierSymbol.Value, SyntaxTriviaList.Empty);
             _syntax = IdentifierName(_syntaxToken.Value);
             return identifierSymbol;
         }

--- a/tests/Silk.NET.SilkTouch.Emitter.Tests/IdentifierTests.cs
+++ b/tests/Silk.NET.SilkTouch.Emitter.Tests/IdentifierTests.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Silk.NET.SilkTouch.Symbols;
+using Xunit;
+
+namespace Silk.NET.SilkTouch.Emitter.Tests;
+
+public sealed class IdentifierTests : EmitterTest
+{
+    [Fact]
+    public void IdentifierHasNoLeadingTrivia()
+    {
+        var node = Transform(new IdentifierSymbol("Test"));
+        
+        Assert.Empty(node.GetLeadingTrivia());
+        Assert.False(node.HasLeadingTrivia);
+    }
+    
+    [Fact]
+    public void IdentifierHasNoTrailingTrivia()
+    {
+        var node = Transform(new IdentifierSymbol("Test"));
+        
+        Assert.Empty(node.GetTrailingTrivia());
+        Assert.False(node.HasTrailingTrivia);
+    }
+
+    [Fact]
+    public void IdentifierIntegration()
+    {
+        var node = Transform(new IdentifierSymbol("Test"));
+        
+        Assert.Equal("Test", node.ToFullString());
+    }
+}


### PR DESCRIPTION
Note that tests are indeed failing, but this is due to an oddity in roslyn that means Identifiers are created with trivia. Investigating but I'd like to merge this, ignoring the failing tests. I think it's worth tracking this oddity, but not worth blocking on.