### PR TITLE
Closing an SDL window fails when multiple window were created

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Sdl/SdlView.cs
+++ b/src/Windowing/Silk.NET.Windowing.Sdl/SdlView.cs
@@ -372,6 +372,11 @@ namespace Silk.NET.Windowing.Sdl
                                 FocusChanged?.Invoke(false);
                                 break;
                             }
+                            case WindowEventID.WindoweventClose:
+                            {
+                                Close();
+                                break;
+                            }
                             default:
                             {
                                 i++;


### PR DESCRIPTION
# Summary of the PR
When using the SDL backend with more than one window, clicking the main window's close button will be ignored. This does not happen when using the GLFW backend.

As discussed e.g. at https://stackoverflow.com/questions/17541127/sdl-2-0-quit-event-with-multiple-windows, SDL emits a dedicated window-close event that's not currently handled. This PR adds a suitable event handling so users can now close the SDL window.

# Reproduction steps 
* Check out Silk.net on the main branch. Tested with 4dd24efed9eeb416268d9634ed5a3bb9ddf58ff9
* Open Silk.net.sln and set the ImGui project as startup project
* Add a 2nd window by replacing the lines
```
            // Now that everything's defined, let's run this bad boy!
            window.Run();
```
with
```
            window.Initialize();
            using var window2 = Window.Create(WindowOptions.Default);
            window2.Initialize();

            window.Run(() =>
            {
                // Note that we cannot close the other window this way. This seems
                // due to the event being filtered in SdlView.OnEventReceived and
                // subsequently lost. Thus, calling window2.DoEvents() afterwards will not help.
                // Perhaps the window manager from https://github.com/dotnet/Silk.NET/issues/82 would work here?
                window.DoEvents();

                foreach(var wnd in new[]{ window, window2 })
                {
                    if (!wnd.IsClosing)
                    {
                        wnd.DoUpdate();
                    }
                    if (!wnd.IsClosing)
                    {
                        wnd.DoRender();
                    }
                }
            });

```
* Run the example and try to close the main window. Observe: it works with the GLFW backend
* Add `Window.PrioritizeSdl();` to the first line in `Main()` in order to force the SDL render backend and rerun the application. Observe: the main window can no longer be closed.