### PR TITLE
GLFW windows cannot be created as invisible

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
@@ -369,14 +369,13 @@ namespace Silk.NET.Windowing.Glfw
             if (opts.IsVisible)
             {
                 _glfw.ShowWindow(_glfwWindow);
+                CoreWindowState = opts.WindowState;
             }
             else
             {
                 _glfw.HideWindow(_glfwWindow);
             }
             
-            CoreWindowState = opts.WindowState;
-
             if (opts.API.API == ContextAPI.OpenGL || opts.API.API == ContextAPI.OpenGLES)
             {
                 _glfw.MakeContextCurrent(_glfwWindow);


### PR DESCRIPTION
# Summary of the PR
When using the default GLFW backend, setting the window option `IsVisible` to `true` will be without effect. It seems, that this is due to the logic in `GlfwWindow.GCoreInitialize` that sets the core window state after hiding the window. This leads to calls such as `Glfw.RestoreWindow` which subsequently unhides the window again.

This PR naively prevents `GlfwWindow.CoreWindowState` from being set when the window should be hidden which leads to the desired outcome.

# Reproduction steps
* Check out Silk.net on the main branch. Tested with 4dd24efed9eeb416268d9634ed5a3bb9ddf58ff9
* Open Silk.net.sln and set the ImGui project as startup project
* Replace the line 
`            using var window = Window.Create(WindowOptions.Default);`
with
```
            var wndOptions = WindowOptions.Default;
            wndOptions.IsVisible = false;
            using var window = Window.Create(wndOptions);
```
* Run the program. Observe: the window is still shown.
