### PR TITLE
Do not fail resolution process on resolver failure

### DIFF
--- a/src/Core/Silk.NET.Core/Loader/DefaultPathResolver.cs
+++ b/src/Core/Silk.NET.Core/Loader/DefaultPathResolver.cs
@@ -143,18 +143,25 @@ namespace Silk.NET.Core.Loader
             var candidates = new List<string>();
             foreach (var resolver in Resolvers)
             {
-                if (candidates.Count == 0 || resolver == PassthroughResolver)
+                try
                 {
-                    candidates.AddRange(resolver.Invoke(name));
-                }
-                else
-                {
-                    for (var i = 0; i < candidates.Count; i++)
+                    if (candidates.Count == 0 || resolver == PassthroughResolver)
                     {
-                        var oldCnt = candidates.Count;
-                        candidates.InsertRange(i + 1, resolver.Invoke(candidates[i]));
-                        i += candidates.Count - oldCnt;
+                        candidates.AddRange(resolver.Invoke(name));
                     }
+                    else
+                    {
+                        for (var i = 0; i < candidates.Count; i++)
+                        {
+                            var oldCnt = candidates.Count;
+                            candidates.InsertRange(i + 1, resolver.Invoke(candidates[i]));
+                            i += candidates.Count - oldCnt;
+                        }
+                    }
+                }
+                catch
+                {
+                    // Skip failed resolver, to account for unexpected environment. Like NativeAOT for example.
                 }
             }
 


### PR DESCRIPTION
Currently if some resolver produce exception it fails whole resolution process. When code runs in the unanticipated configurations. Like NativeAOT without reflection, even if one resolver does not make sense to that environment, others can find native dependencies just fine. So that's unlock unforeseen environments.

Related #960
