### PR TITLE
External Type Reference

### DIFF
--- a/src/generators/Silk.NET.SilkTouch.Emitter/CSharpEmitter.cs
+++ b/src/generators/Silk.NET.SilkTouch.Emitter/CSharpEmitter.cs
@@ -100,7 +100,7 @@ public sealed class CSharpEmitter
         {
             AssertClearState();
             
-            VisitIdentifier(fieldSymbol.Type.Identifier);
+            VisitExternalTypeReference(fieldSymbol.Type);
             if (_syntax is not IdentifierNameSyntax typeIdentifierSyntax)
                 throw new InvalidOperationException("Field type Identifier was not visited correctly");
             ClearState();

--- a/src/generators/Silk.NET.SilkTouch.Scraper/XmlVisitor.cs
+++ b/src/generators/Silk.NET.SilkTouch.Scraper/XmlVisitor.cs
@@ -40,12 +40,14 @@ internal sealed class XmlVisitor
             throw new InvalidOperationException("Field requires a name");
         }
 
-        var type = new StructSymbol
+        var type = new ExternalTypeReference
         (
-            new IdentifierSymbol(
-            field.ChildNodes.Cast<XmlNode>().SingleOrDefault(x => x.Name == "type")?.InnerText ??
-            throw new InvalidOperationException("Could not decode Field Type")),
-            ImmutableArray<FieldSymbol>.Empty
+            null,
+            new IdentifierSymbol
+            (
+                field.ChildNodes.Cast<XmlNode>().SingleOrDefault(x => x.Name == "type")?.InnerText ??
+                throw new InvalidOperationException("Could not decode Field Type")
+            )
         );
 
         return new[]

--- a/src/generators/Silk.NET.SilkTouch.Symbols/ExternalTypeReference.cs
+++ b/src/generators/Silk.NET.SilkTouch.Symbols/ExternalTypeReference.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Silk.NET.SilkTouch.Symbols;
+
+/// <summary>
+/// Represents a reference to an external type
+/// </summary>
+public record ExternalTypeReference(string? Namespace, string TypeName) : Symbol
+{
+    /// <summary>
+    /// Gets the full unique name in C# global:: format.
+    /// </summary>
+    public string FullType => (Namespace is not null ? "global::" + Namespace + "." : "") + TypeName;
+}

--- a/src/generators/Silk.NET.SilkTouch.Symbols/ExternalTypeReference.cs
+++ b/src/generators/Silk.NET.SilkTouch.Symbols/ExternalTypeReference.cs
@@ -6,10 +6,10 @@ namespace Silk.NET.SilkTouch.Symbols;
 /// <summary>
 /// Represents a reference to an external type
 /// </summary>
-public record ExternalTypeReference(string? Namespace, string TypeName) : Symbol
+public record ExternalTypeReference(IdentifierSymbol? Namespace, IdentifierSymbol TypeIdentifier) : Symbol
 {
     /// <summary>
     /// Gets the full unique name in C# global:: format.
     /// </summary>
-    public string FullType => (Namespace is not null ? "global::" + Namespace + "." : "") + TypeName;
+    public string FullType => (Namespace is not null ? "global::" + Namespace.ToString() + "." : "") + TypeIdentifier.ToString();
 }

--- a/src/generators/Silk.NET.SilkTouch.Symbols/FieldSymbol.cs
+++ b/src/generators/Silk.NET.SilkTouch.Symbols/FieldSymbol.cs
@@ -6,7 +6,7 @@ namespace Silk.NET.SilkTouch.Symbols;
 /// <summary>
 /// A <see cref="FieldSymbol"/>. A field is simply a named location that can hold some type.
 /// </summary>
-/// <param name="Type">The <see cref="TypeSymbol"/> of the data stored in this field</param>
+/// <param name="Type">The <see cref="ExternalTypeReference"/> of the data stored in this field</param>
 /// <param name="Identifier">The Identifier of this field</param>
 /// <seealso cref="MemberSymbol"/>
-public sealed record FieldSymbol(TypeSymbol Type, IdentifierSymbol Identifier) : MemberSymbol;
+public sealed record FieldSymbol(ExternalTypeReference Type, IdentifierSymbol Identifier) : MemberSymbol;

--- a/src/generators/Silk.NET.SilkTouch.Symbols/IdentifierSymbol.cs
+++ b/src/generators/Silk.NET.SilkTouch.Symbols/IdentifierSymbol.cs
@@ -8,4 +8,8 @@ namespace Silk.NET.SilkTouch.Symbols;
 /// </summary>
 /// <param name="Value">The String Value of this identifier</param>
 /// <seealso cref="TypeSymbol"/>
-public sealed record IdentifierSymbol(string Value) : Symbol;
+public sealed record IdentifierSymbol(string Value) : Symbol
+{
+    /// <inheritdoc cref="object.ToString"/>
+    public override string ToString() => Value;
+}

--- a/src/generators/Silk.NET.SilkTouch.Symbols/SymbolVisitor.cs
+++ b/src/generators/Silk.NET.SilkTouch.Symbols/SymbolVisitor.cs
@@ -22,6 +22,7 @@ public abstract class SymbolVisitor
         if (symbol is NamespaceSymbol ns) return VisitNamespace(ns);
 
         if (symbol is IdentifierSymbol @is) return VisitIdentifier(@is);
+        if (symbol is ExternalTypeReference etr) return VisitExternalTypeReference(etr); 
 
         return ThrowUnknownSymbol<Symbol>(symbol);
     }
@@ -49,7 +50,24 @@ public abstract class SymbolVisitor
     /// </remarks>
     protected virtual FieldSymbol VisitField(FieldSymbol fieldSymbol)
     {
-        return new FieldSymbol(VisitType(fieldSymbol.Type), VisitIdentifier(fieldSymbol.Identifier));
+        return new FieldSymbol(VisitExternalTypeReference(fieldSymbol.Type), VisitIdentifier(fieldSymbol.Identifier));
+    }
+    
+    /// <summary>
+    /// Visit an <see cref="ExternalTypeReference"/>. Will call the appropriate methods to visit the different parts of the reference.
+    /// </summary>
+    /// <param name="typeReference">The type reference to visit</param>
+    /// <returns>The rewritten symbol</returns>
+    /// <remarks>
+    /// The order in which the parts of the struct are visited is kept as an implementation detail. Do not rely on this order.
+    /// </remarks>
+    protected virtual ExternalTypeReference VisitExternalTypeReference(ExternalTypeReference typeReference)
+    {
+        return new ExternalTypeReference
+        (
+            typeReference.Namespace is null ? null : VisitIdentifier(typeReference.Namespace),
+            VisitIdentifier(typeReference.TypeIdentifier)
+        );
     }
 
     /// <summary>

--- a/tests/Silk.NET.SilkTouch.Emitter.Tests/EmitterFieldTests.cs
+++ b/tests/Silk.NET.SilkTouch.Emitter.Tests/EmitterFieldTests.cs
@@ -19,7 +19,7 @@ public sealed class EmitterFieldIntegrationTests : EmitterTest
     Trait("Target Language", "C#")]
     public void FieldIntegration()
     {
-        var syntax = Transform(new FieldSymbol(new StructSymbol(new IdentifierSymbol("int"),ImmutableArray<FieldSymbol>.Empty), new IdentifierSymbol("Test")));
+        var syntax = Transform(new FieldSymbol(new ExternalTypeReference(null, new IdentifierSymbol("int")), new IdentifierSymbol("Test")));
 
         var result = syntax.ToFullString();
         Assert.Equal("public int Test;", result);
@@ -35,7 +35,7 @@ public sealed class EmitterFieldIntegrationTests : EmitterTest
         (
             new FieldSymbol
             (
-                new StructSymbol(new IdentifierSymbol("int"), ImmutableArray<FieldSymbol>.Empty),
+                new ExternalTypeReference(null, new IdentifierSymbol("")),
                 new IdentifierSymbol("Test")
             )
         ) as FieldDeclarationSyntax;
@@ -54,7 +54,7 @@ public sealed class EmitterFieldIntegrationTests : EmitterTest
         (
             new FieldSymbol
             (
-                new StructSymbol(new IdentifierSymbol("int"), ImmutableArray<FieldSymbol>.Empty),
+                new ExternalTypeReference(null, new IdentifierSymbol("int")),
                 new IdentifierSymbol("Test")
             )
         ) as FieldDeclarationSyntax;
@@ -75,7 +75,7 @@ public sealed class EmitterFieldIntegrationTests : EmitterTest
         (
             new FieldSymbol
             (
-                new StructSymbol(new IdentifierSymbol("int"), ImmutableArray<FieldSymbol>.Empty),
+                new ExternalTypeReference(null, new IdentifierSymbol("")),
                 new IdentifierSymbol("Test")
             )
         ) as FieldDeclarationSyntax;

--- a/tests/Silk.NET.SilkTouch.Emitter.Tests/EmitterStructMemberFieldsTests.cs
+++ b/tests/Silk.NET.SilkTouch.Emitter.Tests/EmitterStructMemberFieldsTests.cs
@@ -25,7 +25,7 @@ public class EmitterStructMemberFieldsTests : EmitterTest
                 { 
                     new FieldSymbol
                     (
-                        new StructSymbol(new IdentifierSymbol("int"), ImmutableArray<FieldSymbol>.Empty),
+                        new ExternalTypeReference(null, new IdentifierSymbol("int")),
                         new IdentifierSymbol("F1")
                     )  
                 }.ToImmutableArray()
@@ -57,17 +57,17 @@ public class EmitterStructMemberFieldsTests : EmitterTest
                 {
                     new FieldSymbol
                     (
-                        new StructSymbol(new IdentifierSymbol("int"), ImmutableArray<FieldSymbol>.Empty),
+                        new ExternalTypeReference(null, new IdentifierSymbol("int")),
                         new IdentifierSymbol("F1")
                     ),
                     new FieldSymbol
                     (
-                        new StructSymbol(new IdentifierSymbol("int"), ImmutableArray<FieldSymbol>.Empty),
+                        new ExternalTypeReference(null, new IdentifierSymbol("int")),
                         new IdentifierSymbol("F2")
                     ),
                     new FieldSymbol
                     (
-                        new StructSymbol(new IdentifierSymbol("int"), ImmutableArray<FieldSymbol>.Empty),
+                        new ExternalTypeReference(null, new IdentifierSymbol("int")),
                         new IdentifierSymbol("F3")
                     )
                 }.ToImmutableArray()

--- a/tests/Silk.NET.SilkTouch.Scraper.Tests/FieldScrapingTests.cs
+++ b/tests/Silk.NET.SilkTouch.Scraper.Tests/FieldScrapingTests.cs
@@ -50,6 +50,6 @@ public class FieldScrapingTests
         
         var symbol = Assert.Single(symbols);
         var field = Assert.IsType<FieldSymbol>(symbol);
-        Assert.Equal("int", field.Type.Identifier.Value);
+        Assert.Equal("int", field.Type.FullType);
     }
 }

--- a/tests/Silk.NET.SilkTouch.Symbols.Tests/ExternalTypeReferenceTests.cs
+++ b/tests/Silk.NET.SilkTouch.Symbols.Tests/ExternalTypeReferenceTests.cs
@@ -13,6 +13,11 @@ public class ExternalTypeReferenceTests
     [Trait("Category", "Symbols")]
     public void ProducesCorrectFullType(string? @namespace, string type, string expected)
     {
-        Assert.Equal(expected, new ExternalTypeReference(@namespace, type).FullType);
+        Assert.Equal
+        (
+            expected,
+            new ExternalTypeReference
+                (@namespace is null ? null : new IdentifierSymbol(@namespace), new IdentifierSymbol(type)).FullType
+        );
     }
 }

--- a/tests/Silk.NET.SilkTouch.Symbols.Tests/ExternalTypeReferenceTests.cs
+++ b/tests/Silk.NET.SilkTouch.Symbols.Tests/ExternalTypeReferenceTests.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Silk.NET.SilkTouch.Symbols.Tests;
+
+public class ExternalTypeReferenceTests
+{
+    [Theory]
+    [InlineData("N1", "T1", "global::N1.T1"), InlineData(null, "T1", "T1"), InlineData(null, "int", "int"),
+     InlineData("System", "Int32", "global::System.Int32")]
+    [Trait("Category", "Symbols")]
+    public void ProducesCorrectFullType(string? @namespace, string type, string expected)
+    {
+        Assert.Equal(expected, new ExternalTypeReference(@namespace, type).FullType);
+    }
+}

--- a/tests/Silk.NET.SilkTouch.Symbols.Tests/SymbolVisitorTests/ExternalTypeReferenceTests.cs
+++ b/tests/Silk.NET.SilkTouch.Symbols.Tests/SymbolVisitorTests/ExternalTypeReferenceTests.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Silk.NET.SilkTouch.Symbols.Tests.SymbolVisitorTests;
+
+public class ExternalTypeReferenceTests
+{
+    [Fact,
+     Trait("Category", "Symbols")]
+    public void RefIsVisitedAsRef()
+    {
+        var symbol = new ExternalTypeReference(null, new IdentifierSymbol(""));
+        var visitor = new Mock<SymbolVisitor>
+        {
+            CallBase = true
+        };
+
+        visitor.Object.Visit(symbol);
+        
+        visitor.Protected()
+            .Verify<ExternalTypeReference>("VisitExternalTypeReference", Times.Once(), ItExpr.IsAny<ExternalTypeReference>());
+    }
+    
+    [Fact,
+     Trait("Category", "Symbols")]
+    public void RefTypeIdentifierIsVisitedAsIdentifier()
+    {
+        var symbol = new ExternalTypeReference(null, new IdentifierSymbol(""));
+        var visitor = new Mock<SymbolVisitor>
+        {
+            CallBase = true
+        };
+
+        visitor.Object.Visit(symbol);
+        
+        visitor.Protected()
+            .Verify<IdentifierSymbol>("VisitIdentifier", Times.Once(), ItExpr.IsAny<IdentifierSymbol>());
+    }
+    
+    [Fact,
+     Trait("Category", "Symbols")]
+    public void RefNamespaceIsVisitedAsIdentifier()
+    {
+        var symbol = new ExternalTypeReference(new IdentifierSymbol(""), new IdentifierSymbol(""));
+        var visitor = new Mock<SymbolVisitor>
+        {
+            CallBase = true
+        };
+
+        visitor.Object.Visit(symbol);
+        
+        visitor.Protected()
+            .Verify<IdentifierSymbol>("VisitIdentifier", Times.Exactly(2), ItExpr.IsAny<IdentifierSymbol>());
+    }
+}

--- a/tests/Silk.NET.SilkTouch.Symbols.Tests/SymbolVisitorTests/FieldTests.cs
+++ b/tests/Silk.NET.SilkTouch.Symbols.Tests/SymbolVisitorTests/FieldTests.cs
@@ -15,7 +15,7 @@ public class FieldTests
      Trait("Feature", "Fields")]
     public void FieldIsVisitedAsField()
     {
-        var symbol = new FieldSymbol(new StructSymbol(new IdentifierSymbol(""), ImmutableArray<FieldSymbol>.Empty), new IdentifierSymbol(""));
+        var symbol = new FieldSymbol(new ExternalTypeReference(null, new IdentifierSymbol("")), new IdentifierSymbol(""));
         var visitor = new Mock<SymbolVisitor>
         {
             CallBase = true
@@ -32,7 +32,7 @@ public class FieldTests
      Trait("Feature", "Fields")]
     public void FieldIsVisitedAsMember()
     {
-        var symbol = new FieldSymbol(new StructSymbol(new IdentifierSymbol(""), ImmutableArray<FieldSymbol>.Empty), new IdentifierSymbol(""));
+        var symbol = new FieldSymbol(new ExternalTypeReference(null, new IdentifierSymbol("")), new IdentifierSymbol(""));
         var visitor = new Mock<SymbolVisitor>
         {
             CallBase = true
@@ -49,7 +49,7 @@ public class FieldTests
      Trait("Feature", "Fields")]
     public void FieldTypeIsVisited()
     {
-        var symbol = new FieldSymbol(new StructSymbol(new IdentifierSymbol(""), ImmutableArray<FieldSymbol>.Empty), new IdentifierSymbol(""));
+        var symbol = new FieldSymbol(new ExternalTypeReference(null, new IdentifierSymbol("")), new IdentifierSymbol(""));
         var visitor = new Mock<SymbolVisitor>
         {
             CallBase = true
@@ -58,7 +58,7 @@ public class FieldTests
         visitor.Object.Visit(symbol);
         
         visitor.Protected()
-            .Verify<TypeSymbol>("VisitType", Times.Once(), ItExpr.IsAny<TypeSymbol>());
+            .Verify<IdentifierSymbol>("VisitIdentifier", Times.Exactly(2), ItExpr.IsAny<IdentifierSymbol>());
     }
 
     [Fact,
@@ -66,7 +66,7 @@ public class FieldTests
      Trait("Feature", "Fields")]
     public void FieldIdentifierIsVisited()
     {
-        var symbol = new FieldSymbol(new StructSymbol(new IdentifierSymbol(""), ImmutableArray<FieldSymbol>.Empty), new IdentifierSymbol(""));
+        var symbol = new FieldSymbol(new ExternalTypeReference(null, new IdentifierSymbol("")), new IdentifierSymbol(""));
         var visitor = new Mock<SymbolVisitor>
         {
             CallBase = true
@@ -76,6 +76,6 @@ public class FieldTests
         
         // note that this also tests whether the struct identifier is visited, there's just no good way of testing JUST the field identifier
         visitor.Protected()
-            .Verify<IdentifierSymbol>("VisitIdentifier", Times.Exactly(2), ItExpr.IsAny<IdentifierSymbol>());
+            .Verify<ExternalTypeReference>("VisitExternalTypeReference", Times.Exactly(1), ItExpr.IsAny<ExternalTypeReference>());
     }
 }

--- a/tests/Silk.NET.SilkTouch.Symbols.Tests/SymbolVisitorTests/StructTests.cs
+++ b/tests/Silk.NET.SilkTouch.Symbols.Tests/SymbolVisitorTests/StructTests.cs
@@ -67,7 +67,7 @@ public class StructTests
      Trait("Feature", "Fields")]
     public void StructFieldIsVisited()
     {
-        var member = new FieldSymbol(new StructSymbol(new IdentifierSymbol("int"), ImmutableArray<FieldSymbol>.Empty), new IdentifierSymbol("Test1"));
+        var member = new FieldSymbol(new ExternalTypeReference(null, new IdentifierSymbol("int")), new IdentifierSymbol("Test1"));
         var symbol = new StructSymbol(new IdentifierSymbol("Test"), new[]
         {
             member
@@ -90,8 +90,8 @@ public class StructTests
      Trait("Feature", "Fields")]
     public void StructFieldsAreVisited()
     {
-        var member1 = new FieldSymbol(new StructSymbol(new IdentifierSymbol("int"), ImmutableArray<FieldSymbol>.Empty), new IdentifierSymbol("Test1"));
-        var member2 = new FieldSymbol(new StructSymbol(new IdentifierSymbol("int"), ImmutableArray<FieldSymbol>.Empty), new IdentifierSymbol("Test2"));
+        var member1 = new FieldSymbol(new ExternalTypeReference(null, new IdentifierSymbol("int")), new IdentifierSymbol("Test1"));
+        var member2 = new FieldSymbol(new ExternalTypeReference(null, new IdentifierSymbol("int")), new IdentifierSymbol("Test2"));
         var symbol = new StructSymbol(new IdentifierSymbol("Test"), new[]
         {
             member1, member2


### PR DESCRIPTION
This replaces the awkward type symbol used by fields with a new symbol "ExternalTypeReference"
This also lays the foundation for typing methods correctly