### PR TITLE
Texture completeness for examples

### DIFF
--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.4 - Textures/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.4 - Textures/Texture.cs
@@ -64,8 +64,10 @@ namespace Tutorial
             //Setting some texture perameters so the texture behaves as expected.
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.ClampToEdge);
-            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.Linear);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.LinearMipmapLinear);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) GLEnum.Linear);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, 8);
             //Generating mipmaps.
             _gl.GenerateMipmap(TextureTarget.Texture2D);
         }

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Texture.cs
@@ -56,6 +56,8 @@ namespace Tutorial
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.Linear);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) GLEnum.Linear);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, 8);
             _gl.GenerateMipmap(TextureTarget.Texture2D);
         }
 

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 1.5 - Transformations/Texture.cs
@@ -54,7 +54,7 @@ namespace Tutorial
         {
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.ClampToEdge);
-            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.Linear);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.LinearMipmapLinear);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) GLEnum.Linear);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, 8);

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Texture.cs
@@ -56,6 +56,8 @@ namespace Tutorial
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.Linear);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) GLEnum.Linear);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, 8);
             _gl.GenerateMipmap(TextureTarget.Texture2D);
         }
 

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.1 - Co-ordinate Systems/Texture.cs
@@ -54,7 +54,7 @@ namespace Tutorial
         {
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.ClampToEdge);
-            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.Linear);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.LinearMipmapLinear);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) GLEnum.Linear);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, 8);

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Texture.cs
@@ -56,6 +56,8 @@ namespace Tutorial
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.Linear);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) GLEnum.Linear);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, 8);
             _gl.GenerateMipmap(TextureTarget.Texture2D);
         }
 

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 2.2 - Camera/Texture.cs
@@ -54,7 +54,7 @@ namespace Tutorial
         {
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.ClampToEdge);
-            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.Linear);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.LinearMipmapLinear);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) GLEnum.Linear);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, 8);

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Texture.cs
@@ -56,6 +56,8 @@ namespace Tutorial
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.Linear);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) GLEnum.Linear);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, 8);
             _gl.GenerateMipmap(TextureTarget.Texture2D);
         }
 

--- a/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Texture.cs
+++ b/examples/CSharp/OpenGL Tutorials/Tutorial 3.5 - Lighting Maps/Texture.cs
@@ -54,7 +54,7 @@ namespace Tutorial
         {
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int) GLEnum.ClampToEdge);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int) GLEnum.ClampToEdge);
-            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.Linear);
+            _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int) GLEnum.LinearMipmapLinear);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int) GLEnum.Linear);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0);
             _gl.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, 8);


### PR DESCRIPTION
# Summary of the PR
This PR adds texture completeness for mipmaps. By default its something like min 0 to max 1000 levels. They were also never used by the minification filter.

# Related issues, Discord discussions, or proposals
* https://discord.com/channels/521092042781229087/607634593201520651/997288821764923514

# Further Comments
See https://www.khronos.org/opengl/wiki/Texture#Texture_completeness
