### PR TITLE
Aspect ratio calculation for VideoModes

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -29,6 +29,7 @@
             "AppVeyor",
             "AzurePipelines",
             "Bamboo",
+            "Bitbucket",
             "Bitrise",
             "GitHubActions",
             "GitLab",

--- a/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Silk.NET.Windowing.VideoMode.AspectRatio.get -> Silk.NET.Maths.Vector2D<int>?

--- a/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-Silk.NET.Windowing.VideoMode.AspectRatio.get -> Silk.NET.Maths.Vector2D<int>?
+Silk.NET.Windowing.VideoMode.AspectRatioEstimate.get -> Silk.NET.Maths.Vector2D<int>?

--- a/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Silk.NET.Windowing.VideoMode.AspectRatio.get -> Silk.NET.Maths.Vector2D<int>?

--- a/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-Silk.NET.Windowing.VideoMode.AspectRatio.get -> Silk.NET.Maths.Vector2D<int>?
+Silk.NET.Windowing.VideoMode.AspectRatioEstimate.get -> Silk.NET.Maths.Vector2D<int>?

--- a/src/Windowing/Silk.NET.Windowing.Common/Structs/VideoMode.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Structs/VideoMode.cs
@@ -11,6 +11,7 @@ namespace Silk.NET.Windowing
         {
             Resolution = resolution;
             RefreshRate = refreshRate;
+            AspectRatio = resolution != null ? resolution / GreatestCommonFactor(resolution.Value.X, resolution.Value.Y) : null;
         }
 
         public VideoMode(int refreshRate)
@@ -27,10 +28,51 @@ namespace Silk.NET.Windowing
         /// Refresh rate of the full screen window in Hz.
         /// </summary>
         public int? RefreshRate { get; }
+        
+        /// <summary>
+        /// Aspect ratio of the full screen window.
+        /// </summary>
+        public Vector2D<int>? AspectRatio { get; }
 
         /// <summary>
         /// The default video mode. This uses the window size for resolution and doesn't care about other values.
         /// </summary>
         public static VideoMode Default => new VideoMode();
+
+        private static int GreatestCommonFactor(int value1, int value2)
+        {
+            while (true)
+            {
+                if (value2 > value1)
+                {
+                    int val = value2 - value1;
+                    if (val <= 0)
+                        return value1;
+                    if (val > value1)
+                    {
+                        value2 = val;
+                        continue;
+                    }
+
+                    var value3 = value1;
+                    value1 = val;
+                    value2 = value3;
+                }
+                else
+                {
+                    int val = value1 - value2;
+                    if (val <= 0)
+                        return value2;
+                    if (val > value2)
+                    {
+                        value1 = value2;
+                        value2 = val;
+                        continue;
+                    }
+
+                    value1 = val;
+                }
+            }
+        }
     }
 }

--- a/src/Windowing/Silk.NET.Windowing.Common/Structs/VideoMode.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Structs/VideoMode.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Silk.NET.Maths;
 
 namespace Silk.NET.Windowing
@@ -11,13 +12,11 @@ namespace Silk.NET.Windowing
         {
             Resolution = resolution;
             RefreshRate = refreshRate;
-            AspectRatio = resolution != null ? resolution / GreatestCommonFactor(resolution.Value.X, resolution.Value.Y) : null;
+            AspectRatio = resolution != null ? CalculateAspectRatio(resolution.Value) : null;
         }
 
         public VideoMode(int refreshRate)
-            : this(null, refreshRate)
-        {
-        }
+            : this(null, refreshRate) { }
 
         /// <summary>
         /// Resolution of the full screen window.
@@ -28,9 +27,11 @@ namespace Silk.NET.Windowing
         /// Refresh rate of the full screen window in Hz.
         /// </summary>
         public int? RefreshRate { get; }
-        
+
         /// <summary>
-        /// Aspect ratio of the full screen window.
+        /// Aspect ratio of the full screen window. This value will not be 100% accurate to the actual value, however
+        /// is more accurate to what a user may expect the ratio to be (for example a resolution of 1366x768 will appear
+        /// as 16:9, even though it is not quite 16:9 in reality).
         /// </summary>
         public Vector2D<int>? AspectRatio { get; }
 
@@ -39,40 +40,23 @@ namespace Silk.NET.Windowing
         /// </summary>
         public static VideoMode Default => new VideoMode();
 
-        private static int GreatestCommonFactor(int value1, int value2)
+        private static Vector2D<int> CalculateAspectRatio(Vector2D<int> res)
         {
-            while (true)
+            // Calculate the width-height ratio.
+            float ratio = res.X / (float) res.Y;
+
+            // Count up until the lowest value as the aspect ratio cannot be higher than the lowest value.
+            int lowestValue = res.X < res.Y ? res.X : res.Y;
+            for (int i = 1; i < lowestValue; i++)
             {
-                if (value2 > value1)
-                {
-                    int val = value2 - value1;
-                    if (val <= 0)
-                        return value1;
-                    if (val > value1)
-                    {
-                        value2 = val;
-                        continue;
-                    }
-
-                    var value3 = value1;
-                    value1 = val;
-                    value2 = value3;
-                }
-                else
-                {
-                    int val = value1 - value2;
-                    if (val <= 0)
-                        return value2;
-                    if (val > value2)
-                    {
-                        value1 = value2;
-                        value2 = val;
-                        continue;
-                    }
-
-                    value1 = val;
-                }
+                // Multiply both together and calculate a good enough value, a bias of 0.1 seems to work well.
+                float multiplied = ratio * i;
+                if (multiplied - (int) multiplied < 0.1f)
+                    return new Vector2D<int>((int) multiplied, i);
             }
+
+            return res;
         }
+
     }
 }

--- a/src/Windowing/Silk.NET.Windowing.Common/Structs/VideoMode.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Structs/VideoMode.cs
@@ -12,7 +12,7 @@ namespace Silk.NET.Windowing
         {
             Resolution = resolution;
             RefreshRate = refreshRate;
-            AspectRatio = resolution != null ? CalculateAspectRatio(resolution.Value) : null;
+            AspectRatioEstimate = resolution != null ? CalculateAspectRatio(resolution.Value) : null;
         }
 
         public VideoMode(int refreshRate)

--- a/src/Windowing/Silk.NET.Windowing.Common/Structs/VideoMode.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Structs/VideoMode.cs
@@ -33,7 +33,7 @@ namespace Silk.NET.Windowing
         /// is more accurate to what a user may expect the ratio to be (for example a resolution of 1366x768 will appear
         /// as 16:9, even though it is not quite 16:9 in reality).
         /// </summary>
-        public Vector2D<int>? AspectRatio { get; }
+        public Vector2D<int>? AspectRatioEstimate { get; }
 
         /// <summary>
         /// The default video mode. This uses the window size for resolution and doesn't care about other values.


### PR DESCRIPTION
# Summary of the PR
Adds a built-in aspect ratio calculation for the `VideoMode`.
A user can query a video mode's aspect ratio and it will return a `Vector2D<int>` with the calculated aspect ratio (although will be precalculated for speed).

# Related issues, Discord discussions, or proposals
[Small discussion, confirming I am creating a PR.](https://discordapp.com/channels/521092042781229087/521092043288608781/1003327705036624003)

# Further Comments
None.