### PR TITLE
Fixing TransparentBuffer when AlphaBits is not set by the user

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
@@ -337,13 +337,18 @@ namespace Silk.NET.Windowing.Glfw
             }
 
             // Set video mode (-1 = don't care)
+            
             _glfw.WindowHint(WindowHintInt.RefreshRate, opts.VideoMode.RefreshRate ?? -1);
             _glfw.WindowHint(WindowHintInt.DepthBits, opts.PreferredDepthBufferBits ?? -1);
             _glfw.WindowHint(WindowHintInt.StencilBits, opts.PreferredStencilBufferBits ?? -1);
-            _glfw.WindowHint(WindowHintInt.RedBits, opts.PreferredBitDepth?.X ?? -1);
+            
+            _glfw.WindowHint(WindowHintInt.RedBits,   opts.PreferredBitDepth?.X ?? -1);
             _glfw.WindowHint(WindowHintInt.GreenBits, opts.PreferredBitDepth?.Y ?? -1);
-            _glfw.WindowHint(WindowHintInt.BlueBits, opts.PreferredBitDepth?.Z ?? -1);
-            _glfw.WindowHint(WindowHintInt.AlphaBits, opts.PreferredBitDepth?.W ?? -1);
+            _glfw.WindowHint(WindowHintInt.BlueBits,  opts.PreferredBitDepth?.Z ?? -1);
+            if (opts.TransparentFramebuffer && (opts.PreferredBitDepth?.W ?? -1) != -1)
+            {
+                _glfw.WindowHint(WindowHintInt.AlphaBits, opts.PreferredBitDepth?.W ?? -1);
+            }
 
             // Set transparent framebuffer
             _glfw.WindowHint(WindowHintBool.TransparentFramebuffer, opts.TransparentFramebuffer);


### PR DESCRIPTION
# Summary of the PR
This fixes a bug when setting TransparentBuffer to true and leaving PreferredBitDepth null, the transparent buffer would not be applied correctly.

You can do this to "hotfix" the problem until this is merged:
`options.PreferredBitDepth      = new Vector4D<int>(8);`