### PR TITLE
Fix runtime folder path checking

### DIFF
--- a/src/Core/Silk.NET.Core/Loader/DefaultPathResolver.cs
+++ b/src/Core/Silk.NET.Core/Loader/DefaultPathResolver.cs
@@ -304,7 +304,7 @@ namespace Silk.NET.Core.Loader
 
             foreach (var rid in GetAllRuntimeIds(RuntimeEnvironment.GetRuntimeIdentifier(), DependencyContext.Default))
             {
-                if (Check(name, Path.Combine(baseFolder, "runtimes", rid, "native", name), out result))
+                if (Check(name, Path.Combine(baseFolder, "runtimes", rid, "native"), out result))
                 {
                     return true;
                 }


### PR DESCRIPTION
# Summary of the PR
Before it would append the dll name onto the folder it was supposed to check, meaning when it looked for the file itd be /runtimes/arch/native/dll/dll.so rather than /runtimes/arch/native/dll.so

# Related issues, Discord discussions, or proposals
https://canary.discord.com/channels/521092042781229087/1004485065838956604/1004486394514776126
