### PR TITLE
Fixing minor typo

### DIFF
--- a/documentation/proposals/Proposal - Windowing 3.0.md
+++ b/documentation/proposals/Proposal - Windowing 3.0.md
@@ -800,7 +800,7 @@ namespace Silk.NET.Windowing
         /// Sets the window icon to default on the given window.
         /// </summary>
         /// <param name="window">The window.</param>
-        public static void SetDefaultIcon(this IDesktopWindow window);
+        public static void SetDefaultIcon(this IDesktopSurface window);
 
         /// <summary>
         /// Sets a single window icon on the given window.


### PR DESCRIPTION
This changes the "SurfaceExtensions" proposal's "SetDefaultIcon" method to correctly use IDesktopSurface, and not the nonexistent IDesktopWindow interface.

# Summary of the PR
This is just a minor typo fix, nothing major
