### PR TITLE
Fix xinput GetApi()

### DIFF
--- a/src/Microsoft/Silk.NET.XInput/XInput.cs
+++ b/src/Microsoft/Silk.NET.XInput/XInput.cs
@@ -12,7 +12,7 @@ namespace Silk.NET.XInput
     {
         public static XInput GetApi()
         {
-             throw new NotImplementedException();
+            return new XInput(CreateDefaultContext("XInput1_3"));
         }
 
         public bool TryGetExtension<T>(out T ext)


### PR DESCRIPTION
# Summary of the PR
Adds an implementation of `GetApi()` for XInput which currently throws a not implemented exception.

# Related issues, Discord discussions, or proposals
https://discord.com/channels/521092042781229087/587346162802229298/1007383458978467920

# Further Comments
None.