### PR TITLE
Add support for OpenAL disconnect extension

### DIFF
--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.EXT/Disconnect.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.EXT/Disconnect.cs
@@ -23,12 +23,10 @@ namespace Silk.NET.OpenAL.Extensions.EXT
 
         /// <inheritdoc />
         [NativeApi(EntryPoint = "GetIntegerv")]
-        public unsafe partial void GetContextProperty(Device* device, DisconnectContextInteger param, int count,
-            void* data);
+        public unsafe partial void GetContextProperty(Device* device, DisconnectContextInteger param, int count, void* data);
 
         /// <inheritdoc />
         [NativeApi(EntryPoint = "GetIntegerv")]
-        public unsafe partial void GetContextProperty(Device* device, DisconnectContextInteger param, int count,
-            int* data);
+        public unsafe partial void GetContextProperty(Device* device, DisconnectContextInteger param, int count, int* data);
     }
 }

--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.EXT/Disconnect.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.EXT/Disconnect.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Native;
+
+namespace Silk.NET.OpenAL.Extensions.EXT
+{
+    /// <summary>
+    /// Exposes the API in the Disconnect extension.
+    /// </summary>
+    [Extension("ALC_EXT_disconnect")]
+    [NativeApi(Prefix = "alc")]
+    public partial class Disconnect : ContextExtensionBase
+    {
+        /// <inheritdoc cref="ContextExtensionBase" />
+        public Disconnect(INativeContext ctx)
+            : base(ctx)
+        {
+        }
+
+        /// <inheritdoc />
+        [NativeApi(EntryPoint = "GetIntegerv")]
+        public unsafe partial void GetContextProperty(Device* device, DisconnectContextInteger param, int count,
+            void* data);
+
+        /// <inheritdoc />
+        [NativeApi(EntryPoint = "GetIntegerv")]
+        public unsafe partial void GetContextProperty(Device* device, DisconnectContextInteger param, int count,
+            int* data);
+    }
+}

--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.EXT/Enums/DisconnectContextInteger.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.EXT/Enums/DisconnectContextInteger.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Silk.NET.OpenAL.Extensions.EXT
+{
+    /// <summary>
+    /// Defines valid values for the <see cref="Disconnect.GetContextProperty" /> method.
+    /// </summary>
+    public enum DisconnectContextInteger
+    {
+        /// <summary>
+        /// Non-zero integer if device is connected and functional. NULL is an invalid device.
+        /// </summary>
+        Connected = 0x313
+    }
+}

--- a/src/OpenAL/Silk.NET.OpenAL.Tests/ExtensionLoadingTests.cs
+++ b/src/OpenAL/Silk.NET.OpenAL.Tests/ExtensionLoadingTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -78,6 +78,7 @@ public class ExtensionLoadingTests
         Test<EnumerateAll>();
         Test<CaptureEnumerationEnumeration>();
         Test<EffectExtensionContext>();
+        Test<Disconnect>();
 
         SilkMarshal.Free(loaderPtr);
         SilkMarshal.Free(ctxLoaderPtr);


### PR DESCRIPTION
# Summary of the PR
This adds support for the Disconnect extension for OpenAL (ALC_EXT_disconnect).

# Related issues, Discord discussions, or proposals
Reference: http://icculus.org/alextreg/wiki/action=printer&id=ALC_EXT_Disconnect

# Further Comments
This extension provides much needed functionality to OpenAL for detecting whether audio devices have been disconnected. This can happen for USB headsets, etc, and it is often necessary for applications to switch to a different device when this happens.
