### PR TITLE
try/catch usages of System.Diagnostics.Process

### DIFF
--- a/src/Core/Silk.NET.Core/Loader/DefaultPathResolver.cs
+++ b/src/Core/Silk.NET.Core/Loader/DefaultPathResolver.cs
@@ -74,18 +74,25 @@ namespace Silk.NET.Core.Loader
         /// </summary>
         public static readonly Func<string, IEnumerable<string>> MainModuleDirectoryResolver = name =>
         {
-            var mainModFname = Process.GetCurrentProcess().MainModule?.FileName;
-            // check that name doesn't have a directory name, we only want raw filenames so that the Path.Combine
-            // doesn't blow up.
-            if (!string.IsNullOrWhiteSpace(Path.GetDirectoryName(name)) && mainModFname is not null)
+            try
             {
-                mainModFname = Path.GetDirectoryName(mainModFname);
-                if (mainModFname is not null)
+                var mainModFname = Process.GetCurrentProcess().MainModule?.FileName;
+                // check that name doesn't have a directory name, we only want raw filenames so that the Path.Combine
+                // doesn't blow up.
+                if (!string.IsNullOrWhiteSpace(Path.GetDirectoryName(name)) && mainModFname is not null)
                 {
-                    return Enumerable.Repeat(Path.Combine(mainModFname, name), 1);
+                    mainModFname = Path.GetDirectoryName(mainModFname);
+                    if (mainModFname is not null)
+                    {
+                        return Enumerable.Repeat(Path.Combine(mainModFname, name), 1);
+                    }
                 }
             }
-            
+            catch
+            {
+                // System.Diagnostics.Process is not supported on the WASI-SDK
+            }
+
             return Enumerable.Empty<string>();
         };
 

--- a/src/Windowing/Silk.NET.Windowing.Common/Window.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Window.cs
@@ -49,11 +49,18 @@ namespace Silk.NET.Windowing
 
         static Window()
         {
-            var defaultWindowClassName = Process.GetCurrentProcess().MainModule?.ModuleName;
-            if (defaultWindowClassName is not null)
+            try
             {
-                DefaultWindowClass = Path.GetFileNameWithoutExtension(defaultWindowClassName);
-                return;
+                var defaultWindowClassName = Process.GetCurrentProcess().MainModule?.ModuleName;
+                if (defaultWindowClassName is not null)
+                {
+                    DefaultWindowClass = Path.GetFileNameWithoutExtension(defaultWindowClassName);
+                    return;
+                }
+            }
+            catch
+            {
+                // System.Diagnostics.Process is not supported on the WASI-SDK
             }
 
             DefaultWindowClass = Assembly.GetEntryAssembly()?.GetName()?.Name ?? FallbackWindowClass;


### PR DESCRIPTION
This class is unsupported when using WASM/WASI-SDK

# Related issues, Discord discussions, or proposals
[Links go here.](https://discord.com/channels/521092042781229087/521092043288608781/1030598895497121833)
