### PR TITLE
Revert "Bump coverlet.collector from 3.1.2 to 3.2.0 (#1126)"

### DIFF
--- a/src/Lab/Experiments/PrototypeStructChaining/PrototypeStructChaining.Test/PrototypeStructChaining.Test.csproj
+++ b/src/Lab/Experiments/PrototypeStructChaining/PrototypeStructChaining.Test/PrototypeStructChaining.Test.csproj
@@ -17,7 +17,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/OpenAL/Silk.NET.OpenAL.Tests/Silk.NET.OpenAL.Tests.csproj
+++ b/src/OpenAL/Silk.NET.OpenAL.Tests/Silk.NET.OpenAL.Tests.csproj
@@ -16,7 +16,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Vulkan/Silk.NET.Vulkan.Tests/Silk.NET.Vulkan.Tests.csproj
+++ b/src/Vulkan/Silk.NET.Vulkan.Tests/Silk.NET.Vulkan.Tests.csproj
@@ -21,7 +21,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
This seems to be causing a CI failure, so lets revert