### PR TITLE
Fix incorrect slice start index in OpenAL exsample

### DIFF
--- a/examples/CSharp/OpenAL Demos/WavePlayer/Program.cs
+++ b/examples/CSharp/OpenAL Demos/WavePlayer/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
@@ -124,7 +124,7 @@ namespace WavePlayer
                 } 
                 else if (identifier == "data")
                 {
-                    var data = file.Slice(44, size);
+                    var data = file.Slice(index, size);
                     index += size;
                     
                     fixed(byte* pData = data)


### PR DESCRIPTION
# Summary of the PR

Usually wav-files have their data section at 44 bytes, but not always. This fix removes a loud pop at the start of playback on those rare cases.