### PR TITLE
Make BuildTools related classes/methods public

### DIFF
--- a/src/Core/Silk.NET.BuildTools/Program.cs
+++ b/src/Core/Silk.NET.BuildTools/Program.cs
@@ -16,9 +16,9 @@ using Silk.NET.BuildTools.Common;
 
 namespace Silk.NET.BuildTools
 {
-    internal class Program
+    public class Program
     {
-        private static int Main(string[] args)
+        public static int Main(string[] args)
         {
             Console.WriteLine("Silk.NET Build Tools");
             Console.WriteLine("Copyright (C) .NET Foundation and Contributors");
@@ -119,7 +119,7 @@ namespace Silk.NET.BuildTools
             return 0;
         }
 
-        internal class ConsoleWriter : TextWriter
+        public class ConsoleWriter : TextWriter
         {
             internal static ConsoleWriter Instance { get; private set; }
             public ThreadLocal<string> CurrentName { get; private set; } = new ThreadLocal<string>();


### PR DESCRIPTION
# Summary of the PR
Makes BuildTools classes/methods public to allow external consumption through NuGet

# Related issues, Discord discussions, or proposals
[Links go here.](https://discord.com/channels/521092042781229087/587346162802229298/1041041517780934736)