### PR TITLE
Implement extensions functions to make use of AL_EXT_float32 enums

### DIFF
--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.EXT/FloatFormat.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.EXT/FloatFormat.cs
@@ -26,12 +26,12 @@ namespace Silk.NET.OpenAL.Extensions.EXT
     /// </summary>
     public static class FloatFormatALExtensions
     {
-        public static unsafe partial void BufferData(this AL al, uint buffer, FloatBufferFormat format, void* data, int size, int frequency)
+        public static unsafe void BufferData(this AL al, uint buffer, FloatBufferFormat format, void* data, int size, int frequency)
         {
             al.BufferData(buffer, (BufferFormat) format, data, size, frequency);
         }
 
-        public void BufferData<TElement>(this AL al, uint buffer, FloatBufferFormat format, TElement[] data, int frequency)
+        public static void BufferData<TElement>(this AL al, uint buffer, FloatBufferFormat format, TElement[] data, int frequency)
             where TElement : unmanaged
         {
             al.BufferData<TElement>(buffer, (BufferFormat) format, data, frequency);

--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.EXT/FloatFormat.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.EXT/FloatFormat.cs
@@ -20,4 +20,21 @@ namespace Silk.NET.OpenAL.Extensions.EXT
         {
         }
     }
+
+    /// <summary>
+    /// Extends the AL functions abilities to make use of the float enums provided by AL_EXT_float32.
+    /// </summary>
+    public static class FloatFormatALExtensions
+    {
+        public static unsafe partial void BufferData(this AL al, uint buffer, FloatBufferFormat format, void* data, int size, int frequency)
+        {
+            al.BufferData(buffer, (BufferFormat) format, data, size, frequency);
+        }
+
+        public void BufferData<TElement>(this AL al, uint buffer, FloatBufferFormat format, TElement[] data, int frequency)
+            where TElement : unmanaged
+        {
+            al.BufferData<TElement>(buffer, (BufferFormat) format, data, frequency);
+        }
+    }
 }


### PR DESCRIPTION
# Summary of the PR
Currently you have to explicitly cast FloatBufferFormat to BufferFormat to use the AL::BufferFormat function. alBufferFormat takes in two new enums provided by AL_EXT_float32  to provide the ability to load floating point data into openal buffer objects.

# Related issues, Discord discussions, or proposals
Issue Ref: #1149
[Spec Ref](https://github.com/openalext/openalext/blob/master/AL_EXT_float32.txt)

# Further Comments
There may be a possibility that the Capture feature of OpenAL supports floating point audio. I have no mind to include this because it adds more research that isn't easily presented in google. Silk.NET doesn't compile too well either. So, to keep it simple I won't add anything to do with anything other than what the spec AL_EXT_float32 says.