### PR TITLE
Add EGL display and surface to INativeWindow

### DIFF
--- a/src/Core/Silk.NET.Core/Contexts/INativeWindow.cs
+++ b/src/Core/Silk.NET.Core/Contexts/INativeWindow.cs
@@ -74,8 +74,13 @@ namespace Silk.NET.Core.Contexts
 
         /// <summaray>
         /// The handle to use for DirectX applications. This will be the Win32 Hwnd on Windows, and it will be the GLFW
-        /// or SDL handle on non-windows platforms for use with dxvk-native. May not be null.
+        /// or SDL handle on non-windows platforms for use with native builds of DXVK. May not be null.
         /// </summary>
         nint? DXHandle { get; }
+        
+        /// <summary>
+        /// The handles for the EGL display and EGL surface. May not be null.
+        /// </summary>
+        (nint? display, nint? surface)? EGL { get; } 
     }
 }

--- a/src/Core/Silk.NET.Core/Contexts/INativeWindow.cs
+++ b/src/Core/Silk.NET.Core/Contexts/INativeWindow.cs
@@ -81,6 +81,6 @@ namespace Silk.NET.Core.Contexts
         /// <summary>
         /// The handles for the EGL display and EGL surface. May not be null.
         /// </summary>
-        (nint? display, nint? surface)? EGL { get; } 
+        (nint? Display, nint? Durface)? EGL { get; } 
     }
 }

--- a/src/Core/Silk.NET.Core/Contexts/INativeWindow.cs
+++ b/src/Core/Silk.NET.Core/Contexts/INativeWindow.cs
@@ -81,6 +81,6 @@ namespace Silk.NET.Core.Contexts
         /// <summary>
         /// The handles for the EGL display and EGL surface. May not be null.
         /// </summary>
-        (nint? Display, nint? Durface)? EGL { get; } 
+        (nint? Display, nint? Surface)? EGL { get; } 
     }
 }

--- a/src/Core/Silk.NET.Core/Contexts/NativeWindowFlags.cs
+++ b/src/Core/Silk.NET.Core/Contexts/NativeWindowFlags.cs
@@ -21,6 +21,7 @@ namespace Silk.NET.Core.Contexts
         Android = 1 << 16,
         Vivante = 1 << 17,
         OS2 = 1 << 18,
-        Haiku = 1 << 19
+        Haiku = 1 << 19,
+        EGL = 1 << 20,
     }
 }

--- a/src/Windowing/Silk.NET.GLFW/GlfwNativeWindow.cs
+++ b/src/Windowing/Silk.NET.GLFW/GlfwNativeWindow.cs
@@ -89,6 +89,6 @@ namespace Silk.NET.GLFW
         public nint? Glfw { get; }
         public nint? Sdl { get; }
         public nint? DXHandle { get; }
-        public (nint? display, nint? surface)? EGL { get; }
+        public (nint? Display, nint? Surface)? EGL { get; }
     }
 }

--- a/src/Windowing/Silk.NET.GLFW/GlfwNativeWindow.cs
+++ b/src/Windowing/Silk.NET.GLFW/GlfwNativeWindow.cs
@@ -64,7 +64,15 @@ namespace Silk.NET.GLFW
             {
                 Kind |= NativeWindowFlags.Wayland;
                 Wayland = ((nint) ((delegate* unmanaged[Cdecl]<void*>) getWaylandDisplay)(),
-                    (nint) ((delegate* unmanaged[Cdecl]<WindowHandle*, void*>) getWaylandWindow)(window));
+                           (nint) ((delegate* unmanaged[Cdecl]<WindowHandle*, void*>) getWaylandWindow)(window));
+            }
+            
+            if (api.Context.TryGetProcAddress("glfwGetEGLDisplay", out var getEGLDisplay) && 
+                api.Context.TryGetProcAddress("glfwGetEGLSurface", out var getEGLSurface))
+            {
+                Kind |= NativeWindowFlags.EGL;
+                EGL = ((nint) ((delegate* unmanaged[Cdecl]<void*>) getEGLDisplay)(),
+                           (nint) ((delegate* unmanaged[Cdecl]<WindowHandle*, void*>) getEGLSurface)(window));
             }
 
             DXHandle ??= (nint)window;
@@ -81,5 +89,6 @@ namespace Silk.NET.GLFW
         public nint? Glfw { get; }
         public nint? Sdl { get; }
         public nint? DXHandle { get; }
+        public (nint? display, nint? surface)? EGL { get; }
     }
 }

--- a/src/Windowing/Silk.NET.SDL/SdlNativeWindow.cs
+++ b/src/Windowing/Silk.NET.SDL/SdlNativeWindow.cs
@@ -99,5 +99,6 @@ namespace Silk.NET.SDL
         public nint? Glfw { get; }
         public nint? Sdl { get; }
         public nint? DXHandle { get; }
+        public (nint? display, nint? surface)? EGL { get; }
     }
 }

--- a/src/Windowing/Silk.NET.SDL/SdlNativeWindow.cs
+++ b/src/Windowing/Silk.NET.SDL/SdlNativeWindow.cs
@@ -99,6 +99,6 @@ namespace Silk.NET.SDL
         public nint? Glfw { get; }
         public nint? Sdl { get; }
         public nint? DXHandle { get; }
-        public (nint? display, nint? surface)? EGL { get; }
+        public (nint? Display, nint? Surface)? EGL { get; }
     }
 }


### PR DESCRIPTION
# Summary of the PR
Adds EGL display and surface to INativeWindow

# Related issues, Discord discussions, or proposals
https://discord.com/channels/521092042781229087/521092043288608781/1051400061608788009

# Further Comments
This is required to use cl_khr_gl_sharing on platforms like Wayland which use EGL for GL contexts