### PR TITLE
Update ImGui.NET to latest

### DIFF
--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.ImGui/Silk.NET.OpenGL.Extensions.ImGui.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.ImGui/Silk.NET.OpenGL.Extensions.ImGui.csproj
@@ -19,7 +19,7 @@
         <ProjectReference Include="..\..\..\Input\Silk.NET.Input.Common\Silk.NET.Input.Common.csproj" />
         <ProjectReference Include="..\..\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
         <ProjectReference Include="..\..\..\Windowing\Silk.NET.Windowing.Common\Silk.NET.Windowing.Common.csproj" />
-        <PackageReference Include="ImGui.NET" Version="1.87.3" />
+        <PackageReference Include="ImGui.NET" Version="1.88.0" />
     </ItemGroup>
 
     <Import Project="..\..\..\..\build\props\common.props" />


### PR DESCRIPTION
# Summary of the PR
Updates ImGui.NET to latest version

Latest version of ImGui.NET fixes the issue of using it on Apple silicon devices (M1/M2).