### PR TITLE
Add ReopenDevices extension for OpenAL Soft

### DIFF
--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/ReopenDevices.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/ReopenDevices.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Native;
+
+namespace Silk.NET.OpenAL.Extensions.Soft
+{
+    /// <summary>
+    /// Exposes the public API of the OpenAL Soft Reopen Device extension.
+    /// </summary>
+    [NativeApi(Prefix = "alc")]
+    [Extension("ALC_SOFT_reopen_device")]
+    public partial class ReopenDevices : NativeExtension<AL>
+    {
+        /// <inheritdoc cref="ExtensionBase" />
+        public ReopenDevices(INativeContext ctx)
+            : base(ctx)
+        {
+        }
+
+        /// <inheritdoc />
+        [NativeApi(EntryPoint = "ReopenDeviceSOFT")]
+        public unsafe partial bool ReopenDevice(Device* device, string deviceName, int* attributeList);
+    }
+}


### PR DESCRIPTION
# Summary of the PR
Adds `ReopenDevices` extension for OpenAL soft.
OpenAL Soft Documentation: https://openal-soft.org/openal-extensions/SOFT_reopen_device.txt
