### PR TITLE
Implement AL_SOFT_callback_buffer extension

### DIFF
--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/Enums/SoftBufferCallback.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/Enums/SoftBufferCallback.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Silk.NET.OpenAL.Extensions.Soft
+{
+    /// <summary>
+    /// Strings for the AL_SOFT_callback_buffer extension.
+    /// </summary>
+    public enum SoftBufferCallback
+    {
+        /// <summary>
+        /// Query only. The function address for the callback currently
+        /// set on the buffer, from the last call to alBufferCallbackSOFT. A call to
+        /// alBufferData will reset this to NULL.
+        /// </summary>
+        Function  = 0x19A0,
+        /// <summary>
+        /// Query only. The user data pointer that will be passed to the
+        /// callback, from the last call to alBufferCallbackSOFT. A call to
+        /// alBufferData will reset this to NULL.
+        /// </summary>
+        UserParam = 0x19A1
+    }
+}

--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/SoftCallbackBuffer.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/SoftCallbackBuffer.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Native;
+using Silk.NET.OpenAL;
+
+namespace Silk.NET.OpenAL.Extensions.Soft
+{
+    /// <summary>
+    /// Exposes the public API of functions added by AL_SOFT_callback_buffer
+    /// </summary>
+    [NativeApi(Prefix = "al")]
+    [Extension("AL_SOFT_callback_buffer")]
+    public unsafe partial class SoftCallbackBuffer : NativeExtension<AL> 
+    {
+        /// <inheritdoc cref="ExtensionBase" />
+        public SoftCallbackBuffer(INativeContext ctx)
+            : base(ctx) 
+        {
+        }
+
+        /// <inheritdoc />
+        [NativeApi(EntryPoint = "BufferCallbackSOFT")]
+        public partial void BufferCallback(uint buffer, BufferFormat format, int freq, PfnBufferCallback callback, void* userPtr);
+
+        /// <inheritdoc />
+        [NativeApi(EntryPoint = "GetBufferPtrSOFT")]
+        public partial void GetBufferPtr(uint buffer, SoftBufferCallback param, void** ptr);
+        
+        /// <inheritdoc />
+        [NativeApi(EntryPoint = "GetBuffer3PtrSOFT")]
+        public partial void GetBuffer3Ptr(uint buffer, SoftBufferCallback param, void** ptr0, void** ptr1, void** ptr2);
+        
+        /// <inheritdoc />
+        [NativeApi(EntryPoint = "GetBufferPtrvSOFT")]
+        public partial void GetBufferPtrv(uint buffer, SoftBufferCallback param, void** ptr);
+    }
+}

--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/SoftCallbackBuffer.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/SoftCallbackBuffer.cs
@@ -35,6 +35,6 @@ namespace Silk.NET.OpenAL.Extensions.Soft
         
         /// <inheritdoc />
         [NativeApi(EntryPoint = "GetBufferPtrvSOFT")]
-        public partial void GetBufferPtr(uint buffer, SoftBufferCallback param, void** ptr);
+        public partial void GetBufferPtrv(uint buffer, SoftBufferCallback param, void** ptr);
     }
 }

--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/SoftCallbackBuffer.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/SoftCallbackBuffer.cs
@@ -35,6 +35,6 @@ namespace Silk.NET.OpenAL.Extensions.Soft
         
         /// <inheritdoc />
         [NativeApi(EntryPoint = "GetBufferPtrvSOFT")]
-        public partial void GetBufferPtrv(uint buffer, SoftBufferCallback param, void** ptr);
+        public partial void GetBufferPtr(uint buffer, SoftBufferCallback param, void** ptr);
     }
 }

--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/Structs/PfnBufferCallback.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/Structs/PfnBufferCallback.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using Silk.NET.Core.Native;
+
+namespace Silk.NET.OpenAL.Extensions.Soft
+{
+    public readonly unsafe struct PfnBufferCallback : IDisposable
+    {
+        private readonly void* _handle;
+        public delegate* unmanaged[Cdecl]<void*, void*, int, int> Handle => (delegate* unmanaged[Cdecl]<void*, void*, int, int>) this._handle;
+        public PfnBufferCallback
+        (
+            delegate* unmanaged[Cdecl]<void*, void*, int, int> ptr
+        ) => this._handle = ptr;
+
+        public PfnBufferCallback
+        (
+            BufferCallbackType proc
+        ) => this._handle = (void*) SilkMarshal.DelegateToPtr(proc);
+
+        public static PfnBufferCallback From(BufferCallbackType proc) => new PfnBufferCallback(proc);
+        public void Dispose()                     => SilkMarshal.Free((nint) this._handle);
+
+        public static implicit operator nint(PfnBufferCallback pfn) => (nint) pfn.Handle;
+        public static explicit operator PfnBufferCallback(nint pfn)
+            => new PfnBufferCallback((delegate* unmanaged[Cdecl]<void*, void*, int, int>) pfn);
+
+        public static implicit operator PfnBufferCallback(BufferCallbackType proc)
+            => new PfnBufferCallback(proc);
+
+        public static explicit operator BufferCallbackType(PfnBufferCallback pfn)
+            => SilkMarshal.PtrToDelegate<BufferCallbackType>(pfn);
+
+        public static implicit operator delegate* unmanaged[Cdecl]<void*, void*, int, int>(PfnBufferCallback pfn) => pfn.Handle;
+        public static implicit operator PfnBufferCallback(delegate* unmanaged[Cdecl]<void*, void*, int, int> ptr) => new PfnBufferCallback(ptr);
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public unsafe delegate int BufferCallbackType(void* userPtr, void* samplerData, int numBytes);
+}


### PR DESCRIPTION
# Summary of the PR
Implements the openal-soft extension AL_SOFT_callback_buffer

# Further Comments
It seems checking whether OpenAL extensions are available is broken, but that looks like an unrelated problem to solve at a later time