### PR TITLE
Add the ability to supply multiple library paths in SearchPathContainer

### DIFF
--- a/src/Assimp/Silk.NET.Assimp/Assimp.cs
+++ b/src/Assimp/Silk.NET.Assimp/Assimp.cs
@@ -13,7 +13,7 @@ namespace Silk.NET.Assimp
     {
         public static Assimp GetApi()
         {
-             return new Assimp(CreateDefaultContext(new AssimpLibraryNameContainer().GetLibraryName()));
+             return new Assimp(CreateDefaultContext(new AssimpLibraryNameContainer().GetLibraryNames()));
         }
 
         public override bool IsExtensionPresent(string extension) => IsExtensionSupported(extension) == 1;

--- a/src/Assimp/Silk.NET.Assimp/AssimpLibraryNameContainer.cs
+++ b/src/Assimp/Silk.NET.Assimp/AssimpLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.Assimp
     internal class AssimpLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libassimp.so.5";
+        public override string[] Linux => new[] { "libassimp.so.5" };
 
         /// <inheritdoc />
-        public override string MacOS => "libassimp.5.dylib";
+        public override string[] MacOS => new[] { "libassimp.5.dylib" };
 
         /// <inheritdoc />
-        public override string Android => "libassimp.so.5";
+        public override string[] Android => new[] { "libassimp.so.5" };
 
         /// <inheritdoc />
-        public override string IOS => "__Internal";
+        public override string[] IOS => new[] { "__Internal" };
 
         /// <inheritdoc />
-        public override string Windows64 => "Assimp64.dll";
+        public override string[] Windows64 => new[] { "Assimp64.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "Assimp32.dll";
+        public override string[] Windows86 => new[] { "Assimp32.dll" };
     }
 }

--- a/src/Core/Silk.NET.BuildTools/Bind/ClassWriter.cs
+++ b/src/Core/Silk.NET.BuildTools/Bind/ClassWriter.cs
@@ -39,22 +39,22 @@ namespace Silk.NET.BuildTools.Bind
             sw.WriteLine($"    internal class {task.Task.NameContainer.ClassName} : SearchPathContainer");
             sw.WriteLine("    {");
             sw.WriteLine("        /// <inheritdoc />");
-            sw.WriteLine($"        public override string Linux => \"{task.Task.NameContainer.Linux}\";");
+            sw.WriteLine($"        public override string[] Linux => new[] {{ \"{task.Task.NameContainer.Linux}\" }};");
             sw.WriteLine();
             sw.WriteLine("        /// <inheritdoc />");
-            sw.WriteLine($"        public override string MacOS => \"{task.Task.NameContainer.MacOS}\";");
+            sw.WriteLine($"        public override string[] MacOS => new[] {{ \"{task.Task.NameContainer.MacOS}\" }};");
             sw.WriteLine();
             sw.WriteLine("        /// <inheritdoc />");
-            sw.WriteLine($"        public override string Android => \"{task.Task.NameContainer.Android}\";");
+            sw.WriteLine($"        public override string[] Android => new[] {{ \"{task.Task.NameContainer.Android}\" }};");
             sw.WriteLine();
             sw.WriteLine("        /// <inheritdoc />");
-            sw.WriteLine($"        public override string IOS => \"{task.Task.NameContainer.IOS}\";");
+            sw.WriteLine($"        public override string[] IOS => {{ \"{task.Task.NameContainer.IOS}\" }};");
             sw.WriteLine();
             sw.WriteLine("        /// <inheritdoc />");
-            sw.WriteLine($"        public override string Windows64 => \"{task.Task.NameContainer.Windows64}\";");
+            sw.WriteLine($"        public override string[] Windows64 => {{ \"{task.Task.NameContainer.Windows64}\" }};");
             sw.WriteLine();
             sw.WriteLine("        /// <inheritdoc />");
-            sw.WriteLine($"        public override string Windows86 => \"{task.Task.NameContainer.Windows86}\";");
+            sw.WriteLine($"        public override string[] Windows86 => {{ \"{task.Task.NameContainer.Windows86}\" }};");
             sw.WriteLine("    }");
             sw.WriteLine("}");
         }
@@ -264,7 +264,7 @@ namespace Silk.NET.BuildTools.Bind
                             sw.WriteLine
                             (
                                 $"             return new(CreateDefaultContext" +
-                                $"(new {task.Task.NameContainer.ClassName}().GetLibraryName()));"
+                                $"(new {task.Task.NameContainer.ClassName}().GetLibraryNames()));"
                             );
                         }
                         else

--- a/src/Core/Silk.NET.Core/Contexts/DefaultNativeContext.cs
+++ b/src/Core/Silk.NET.Core/Contexts/DefaultNativeContext.cs
@@ -11,6 +11,18 @@ namespace Silk.NET.Core.Contexts
     /// </summary>
     public class DefaultNativeContext : INativeContext
     {
+        public static bool TryCreate(string name, out DefaultNativeContext context)
+        {
+            if(!UnmanagedLibrary.TryCreate(name, LibraryLoader.GetPlatformDefaultLoader(), PathResolver.Default, out UnmanagedLibrary library))
+            {
+                context = null;
+                return false;
+            }
+
+            context = new DefaultNativeContext(library);
+            return true;
+        }
+
         /// <summary>
         /// Creates a new native context for the given underlying library.
         /// </summary>

--- a/src/Core/Silk.NET.Core/Loader/SearchPathContainer.cs
+++ b/src/Core/Silk.NET.Core/Loader/SearchPathContainer.cs
@@ -47,40 +47,40 @@ namespace Silk.NET.Core.Loader
 #endif
 
         /// <summary>
-        /// Gets the library name to use on Windows 64-bit.
+        /// Gets the library names to use on Windows 64-bit.
         /// </summary>
-        public abstract string Windows64 { get; }
+        public abstract string[] Windows64 { get; }
 
         /// <summary>
-        /// Gets the library name to use on Windows 32-bit.
+        /// Gets the library names to use on Windows 32-bit.
         /// </summary>
-        public abstract string Windows86 { get; }
+        public abstract string[] Windows86 { get; }
 
         /// <summary>
-        /// Gets the library name to use on Linux.
+        /// Gets the library names to use on Linux.
         /// </summary>
-        public abstract string Linux { get; }
+        public abstract string[] Linux { get; }
 
         /// <summary>
-        /// Gets the library name to use on MacOS.
+        /// Gets the library names to use on MacOS.
         /// </summary>
-        public abstract string MacOS { get; }
+        public abstract string[] MacOS { get; }
 
         /// <summary>
-        /// Gets the library name to use on Android.
+        /// Gets the library names to use on Android.
         /// </summary>
-        public virtual string Android => Linux;
+        public virtual string[] Android => Linux;
 
         /// <summary>
-        /// Gets the library name to use on iOS.
+        /// Gets the library names to use on iOS.
         /// </summary>
-        public virtual string IOS => MacOS;
+        public virtual string[] IOS => MacOS;
 
         /// <summary>
-        /// Gets the library name to use on the current platform.
+        /// Gets the possible library names to use for the current platform.
         /// </summary>
-        /// <returns>The library name.</returns>
-        public string GetLibraryName() => Platform switch
+        /// <returns>The library names.</returns>
+        public string[] GetLibraryNames() => Platform switch
         {
             UnderlyingPlatform.Unknown => ThrowInvalidPlatform(),
             UnderlyingPlatform.Windows64 => Windows64,
@@ -92,7 +92,14 @@ namespace Silk.NET.Core.Loader
             _ => ThrowInvalidPlatform()
         };
         
-        private static string ThrowInvalidPlatform()
+        /// <summary>
+        /// Gets the library name to use on the current platform.
+        /// </summary>
+        /// <returns>The library name.</returns>
+        [Obsolete("This method is obsolete! Use GetLibraryNames")]
+        public string GetLibraryName() => GetLibraryNames()[0];
+
+        private static string[] ThrowInvalidPlatform()
         {
             throw new PlatformNotSupportedException("Invalid/unsupported operating system.");
         }

--- a/src/Core/Silk.NET.Core/Loader/UnmanagedLibrary.cs
+++ b/src/Core/Silk.NET.Core/Loader/UnmanagedLibrary.cs
@@ -50,6 +50,30 @@ namespace Silk.NET.Core.Loader
         }
 
         /// <summary>
+        ///     Constructs a new UnmanagedLibrary with only a loader and handle specified
+        /// </summary>
+        private UnmanagedLibrary(LibraryLoader loader, nint handle)
+        {
+            _loader = loader;
+            Handle = handle;
+        }
+
+        /// <summary>
+        ///     Tries to create a new UnmanagedLibrary, safely failing
+        /// </summary>
+        public static bool TryCreate(string name, LibraryLoader loader, PathResolver pathResolver, out UnmanagedLibrary library)
+        {
+            if(!loader.TryLoadNativeLibrary(name, pathResolver, out nint handle))
+            {
+                library = null;
+                return false;
+            }
+
+            library = new UnmanagedLibrary(loader, handle);
+            return true;
+        }
+
+        /// <summary>
         ///     Constructs a new NativeLibrary using the specified library loader.
         /// </summary>
         /// <param name="name">The name of the library to load.</param>

--- a/src/Core/Silk.NET.SilkTouch/NativeContextOverrideGeneration.cs
+++ b/src/Core/Silk.NET.SilkTouch/NativeContextOverrideGeneration.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -75,22 +75,23 @@ namespace Silk.NET.SilkTouch
                         ),
                         ArgumentList
                         (
-                            SingletonSeparatedList
+                            SeparatedList
                             (
-                                Argument
-                                (
-                                    IdentifierName("n")
-                                )
-                            ).Add
-                            (
-                                Argument
-                                (
-                                    LiteralExpression
+                                new []
+                                {
+                                    Argument
                                     (
-                                        SyntaxKind.StringLiteralExpression,
-                                        Literal(lib)
+                                        IdentifierName("n")
+                                    ),
+                                    Argument
+                                    (
+                                        LiteralExpression
+                                        (
+                                            SyntaxKind.StringLiteralExpression,
+                                            Literal(lib)
+                                        )
                                     )
-                                )
+                                }
                             )
                         )
                     ),
@@ -172,7 +173,7 @@ namespace Silk.NET.SilkTouch
             foreach (var attribute in attributes)
             {
                 if (attribute.AttributeClass is null) continue;
-                
+
                 if (_nativeContextAttributes.TryGetValue(attribute.AttributeClass, out var f))
                 {
                     var v = f(attribute.ConstructorArguments);

--- a/src/Lab/Experiments/TestLib/TestClass2-1.cs
+++ b/src/Lab/Experiments/TestLib/TestClass2-1.cs
@@ -51,6 +51,6 @@ namespace TestLib
 
         // public partial int GetWindowTextA(IntPtr hwnd, [Count(Parameter = "hwnd")] ref string str, int maxCount);
 
-        public TestClass2() : base(CreateDefaultContext("user32.dll")) { }
+        public TestClass2() : base(CreateDefaultContext(new[] { "user32.dll" })) { }
     }
 }

--- a/src/Microsoft/Silk.NET.DXGI/DXGI.cs
+++ b/src/Microsoft/Silk.NET.DXGI/DXGI.cs
@@ -12,7 +12,7 @@ namespace Silk.NET.DXGI
     {
         public static DXGI GetApi()
         {
-             return new DXGI(CreateDefaultContext(new DXGILibraryNameContainer().GetLibraryName()));
+             return new DXGI(CreateDefaultContext(new DXGILibraryNameContainer().GetLibraryNames()));
         }
 
         public bool TryGetExtension<T>(out T ext)

--- a/src/Microsoft/Silk.NET.DXGI/DXGILibraryNameContainer.cs
+++ b/src/Microsoft/Silk.NET.DXGI/DXGILibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.DXGI
     internal class DXGILibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libDXGI.so";
+        public override string[] Linux => new[] { "libDXGI.so" };
 
         /// <inheritdoc />
-        public override string MacOS => "libDXGI.dylib";
+        public override string[] MacOS => new[] { "libDXGI.dylib" };
 
         /// <inheritdoc />
-        public override string Android => "libDXGI.so";
+        public override string[] Android => new[] { "libDXGI.so" };
 
         /// <inheritdoc />
-        public override string IOS => "__Internal"; // __Internal relies on a SilkTouch override.
+        public override string[] IOS => new[] { "__Internal" }; // __Internal relies on a SilkTouch override.
 
         /// <inheritdoc />
-        public override string Windows64 => "DXGI.dll";
+        public override string[] Windows64 => new[] { "DXGI.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "DXGI.dll";
+        public override string[] Windows86 => new[] { "DXGI.dll" };
     }
 }

--- a/src/Microsoft/Silk.NET.DXVA/DXVA.cs
+++ b/src/Microsoft/Silk.NET.DXVA/DXVA.cs
@@ -17,7 +17,7 @@ namespace Silk.NET.DXVA
     {
         public static DXVA GetApi()
         {
-             return new(CreateDefaultContext(new DXVA2LibraryNameContainer().GetLibraryName()));
+             return new(CreateDefaultContext(new DXVA2LibraryNameContainer().GetLibraryNames()));
         }
     
         public bool TryGetExtension<T>(out T ext)

--- a/src/Microsoft/Silk.NET.DXVA/DXVA2LibraryNameContainer.cs
+++ b/src/Microsoft/Silk.NET.DXVA/DXVA2LibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.DXVA
     internal class DXVA2LibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libdxva2.so";
+        public override string[] Linux => new[] { "libdxva2.so" };
     
         /// <inheritdoc />
-        public override string MacOS => "libdxva2.dylib";
+        public override string[] MacOS => new[] { "libdxva2.dylib" };
     
         /// <inheritdoc />
-        public override string Android => "libdxva2.so";
+        public override string[] Android => new[] { "libdxva2.so" };
     
         /// <inheritdoc />
-        public override string IOS => "__Internal";
+        public override string[] IOS => new[] { "__Internal" };
     
         /// <inheritdoc />
-        public override string Windows64 => "dxva2.dll";
+        public override string[] Windows64 => new[] { "dxva2.dll" };
     
         /// <inheritdoc />
-        public override string Windows86 => "dxva2.dll";
+        public override string[] Windows86 => new[] { "dxva2.dll" };
     }
 }

--- a/src/Microsoft/Silk.NET.Direct2D/D2D.cs
+++ b/src/Microsoft/Silk.NET.Direct2D/D2D.cs
@@ -17,7 +17,7 @@ namespace Silk.NET.Direct2D
     {
         public static D2D GetApi()
         {
-             return new(CreateDefaultContext(new D2DLibraryNameContainer().GetLibraryName()));
+             return new(CreateDefaultContext(new D2DLibraryNameContainer().GetLibraryNames()));
         }
 
         public bool TryGetExtension<T>(out T ext)

--- a/src/Microsoft/Silk.NET.Direct2D/D2DLibraryNameContainer.cs
+++ b/src/Microsoft/Silk.NET.Direct2D/D2DLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.Direct2D
     internal class D2DLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libd2d1.so";
+        public override string[] Linux => new[] { "libd2d1.so" };
 
         /// <inheritdoc />
-        public override string MacOS => "libd2d1.dylib";
+        public override string[] MacOS => new[] { "libd2d1.dylib" };
 
         /// <inheritdoc />
-        public override string Android => "libd2d1.so";
+        public override string[] Android => new[] { "libd2d1.so" };
 
         /// <inheritdoc />
-        public override string IOS => "__Internal";
+        public override string[] IOS => new[] { "__Internal" };
 
         /// <inheritdoc />
-        public override string Windows64 => "d2d1.dll";
+        public override string[] Windows64 => new[] { "d2d1.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "d2d1.dll";
+        public override string[] Windows86 => new[] { "d2d1.dll" };
     }
 }

--- a/src/Microsoft/Silk.NET.Direct3D.Compilers/D3DCompiler.cs
+++ b/src/Microsoft/Silk.NET.Direct3D.Compilers/D3DCompiler.cs
@@ -12,7 +12,7 @@ namespace Silk.NET.Direct3D.Compilers
     {
         public static D3DCompiler GetApi()
         {
-             return new D3DCompiler(CreateDefaultContext(new D3DCompilerLibraryNameContainer().GetLibraryName()));
+             return new D3DCompiler(CreateDefaultContext(new D3DCompilerLibraryNameContainer().GetLibraryNames()));
         }
 
         public bool TryGetExtension<T>(out T ext)

--- a/src/Microsoft/Silk.NET.Direct3D.Compilers/D3DCompilerLibraryNameContainer.cs
+++ b/src/Microsoft/Silk.NET.Direct3D.Compilers/D3DCompilerLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.Direct3D.Compilers
     internal class D3DCompilerLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libD3DCompiler_47.so";
+        public override string[] Linux => new[] { "libD3DCompiler_47.so" };
 
         /// <inheritdoc />
-        public override string MacOS => "libD3DCompiler_47.dylib";
+        public override string[] MacOS => new[] { "libD3DCompiler_47.dylib" };
 
         /// <inheritdoc />
-        public override string Android => "libD3DCompiler_47.so";
+        public override string[] Android => new[] { "libD3DCompiler_47.so" };
 
         /// <inheritdoc />
-        public override string IOS => "__Internal";
+        public override string[] IOS => new[] { "__Internal" };
 
         /// <inheritdoc />
-        public override string Windows64 => "D3DCompiler_47.dll";
+        public override string[] Windows64 => new[] { "D3DCompiler_47.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "D3DCompiler_47.dll";
+        public override string[] Windows86 => new[] { "D3DCompiler_47.dll" };
     }
 }

--- a/src/Microsoft/Silk.NET.Direct3D.Compilers/DXC.cs
+++ b/src/Microsoft/Silk.NET.Direct3D.Compilers/DXC.cs
@@ -12,7 +12,7 @@ namespace Silk.NET.Direct3D.Compilers
     {
         public static DXC GetApi()
         {
-             return new DXC(CreateDefaultContext(new DXCLibraryNameContainer().GetLibraryName()));
+             return new DXC(CreateDefaultContext(new DXCLibraryNameContainer().GetLibraryNames()));
         }
 
         public bool TryGetExtension<T>(out T ext)

--- a/src/Microsoft/Silk.NET.Direct3D.Compilers/DXCLibraryNameContainer.cs
+++ b/src/Microsoft/Silk.NET.Direct3D.Compilers/DXCLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.Direct3D.Compilers
     internal class DXCLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libdxcompiler.so";
+        public override string[] Linux => new[] { "libdxcompiler.so" };
 
         /// <inheritdoc />
-        public override string MacOS => "libdxcompiler.dylib";
+        public override string[] MacOS => new[] { "libdxcompiler.dylib" };
 
         /// <inheritdoc />
-        public override string Android => "libdxcompiler.so";
+        public override string[] Android => new[] { "libdxcompiler.so" };
 
         /// <inheritdoc />
-        public override string IOS => "__Internal";
+        public override string[] IOS => new[] { "__Internal" };
 
         /// <inheritdoc />
-        public override string Windows64 => "dxcompiler.dll";
+        public override string[] Windows64 => new[] { "dxcompiler.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "dxcompiler.dll";
+        public override string[] Windows86 => new[] { "dxcompiler.dll" };
     }
 }

--- a/src/Microsoft/Silk.NET.Direct3D11/D3D11.cs
+++ b/src/Microsoft/Silk.NET.Direct3D11/D3D11.cs
@@ -12,7 +12,7 @@ namespace Silk.NET.Direct3D11
     {
         public static D3D11 GetApi()
         {
-             return new D3D11(CreateDefaultContext(new D3D11LibraryNameContainer().GetLibraryName()));
+             return new D3D11(CreateDefaultContext(new D3D11LibraryNameContainer().GetLibraryNames()));
         }
 
         public bool TryGetExtension<T>(out T ext)

--- a/src/Microsoft/Silk.NET.Direct3D11/D3D11LibraryNameContainer.cs
+++ b/src/Microsoft/Silk.NET.Direct3D11/D3D11LibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.Direct3D11
     internal class D3D11LibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libd3d11.so";
+        public override string[] Linux => new[] { "libd3d11.so" };
 
         /// <inheritdoc />
-        public override string MacOS => "libd3d11.dylib";
+        public override string[] MacOS => new[] { "libd3d11.dylib" };
 
         /// <inheritdoc />
-        public override string Android => "libd3d11.so";
+        public override string[] Android => new[] { "libd3d11.so" };
 
         /// <inheritdoc />
-        public override string IOS => "__Internal";
+        public override string[] IOS => new[] { "__Internal" };
 
         /// <inheritdoc />
-        public override string Windows64 => "d3d11.dll";
+        public override string[] Windows64 => new[] { "d3d11.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "d3d11.dll";
+        public override string[] Windows86 => new[] { "d3d11.dll" };
     }
 }

--- a/src/Microsoft/Silk.NET.Direct3D12/D3D12.cs
+++ b/src/Microsoft/Silk.NET.Direct3D12/D3D12.cs
@@ -12,7 +12,7 @@ namespace Silk.NET.Direct3D12
     {
         public static D3D12 GetApi()
         {
-             return new D3D12(CreateDefaultContext(new D3D12LibraryNameContainer().GetLibraryName()));
+             return new D3D12(CreateDefaultContext(new D3D12LibraryNameContainer().GetLibraryNames()));
         }
 
         public bool TryGetExtension<T>(out T ext)

--- a/src/Microsoft/Silk.NET.Direct3D12/D3D12LibraryNameContainer.cs
+++ b/src/Microsoft/Silk.NET.Direct3D12/D3D12LibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.Direct3D12
     internal class D3D12LibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libD3D12.so";
+        public override string[] Linux => new[] { "libD3D12.so" };
 
         /// <inheritdoc />
-        public override string MacOS => "libD3D12.dylib";
+        public override string[] MacOS => new[] { "libD3D12.dylib" };
 
         /// <inheritdoc />
-        public override string Android => "libD3D12.so";
+        public override string[] Android => new[] { "libD3D12.so" };
 
         /// <inheritdoc />
-        public override string IOS => "__Internal";
+        public override string[] IOS => new[] { "__Internal" };
 
         /// <inheritdoc />
-        public override string Windows64 => "D3D12.dll";
+        public override string[] Windows64 => new[] { "D3D12.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "D3D12.dll";
+        public override string[] Windows86 => new[] { "D3D12.dll" };
     }
 }

--- a/src/Microsoft/Silk.NET.Direct3D9/D3D9.cs
+++ b/src/Microsoft/Silk.NET.Direct3D9/D3D9.cs
@@ -12,7 +12,7 @@ namespace Silk.NET.Direct3D9
     {
         public static D3D9 GetApi()
         {
-             return new D3D9(CreateDefaultContext(new D3D9LibraryNameContainer().GetLibraryName()));
+             return new D3D9(CreateDefaultContext(new D3D9LibraryNameContainer().GetLibraryNames()));
         }
 
         public bool TryGetExtension<T>(out T ext)

--- a/src/Microsoft/Silk.NET.Direct3D9/D3D9LibraryNameContainer.cs
+++ b/src/Microsoft/Silk.NET.Direct3D9/D3D9LibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.Direct3D9
     internal class D3D9LibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libd3d9.so";
+        public override string[] Linux => new[] { "libd3d9.so" };
 
         /// <inheritdoc />
-        public override string MacOS => "libd3d9.dylib";
+        public override string[] MacOS => new[] { "libd3d9.dylib" };
 
         /// <inheritdoc />
-        public override string Android => "libd3d9.so";
+        public override string[] Android => new[] { "libd3d9.so" };
 
         /// <inheritdoc />
-        public override string IOS => "__Internal";
+        public override string[] IOS => new[] { "__Internal" };
 
         /// <inheritdoc />
-        public override string Windows64 => "d3d9.dll";
+        public override string[] Windows64 => new[] { "d3d9.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "d3d9.dll";
+        public override string[] Windows86 => new[] { "d3d9.dll" };
     }
 }

--- a/src/Microsoft/Silk.NET.DirectComposition/DComp.cs
+++ b/src/Microsoft/Silk.NET.DirectComposition/DComp.cs
@@ -17,7 +17,7 @@ namespace Silk.NET.DirectComposition
     {
         public static DComp GetApi()
         {
-             return new(CreateDefaultContext(new DCompLibraryNameContainer().GetLibraryName()));
+             return new(CreateDefaultContext(new DCompLibraryNameContainer().GetLibraryNames()));
         }
 
         public bool TryGetExtension<T>(out T ext)

--- a/src/Microsoft/Silk.NET.DirectComposition/DCompLibraryNameContainer.cs
+++ b/src/Microsoft/Silk.NET.DirectComposition/DCompLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.DirectComposition
     internal class DCompLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libDComp.so";
+        public override string[] Linux => new[] { "libDComp.so" };
 
         /// <inheritdoc />
-        public override string MacOS => "libDComp.dylib";
+        public override string[] MacOS => new[] { "libDComp.dylib" };
 
         /// <inheritdoc />
-        public override string Android => "libDComp.so";
+        public override string[] Android => new[] { "libDComp.so" };
 
         /// <inheritdoc />
-        public override string IOS => "__Internal";
+        public override string[] IOS => new[] { "__Internal" };
 
         /// <inheritdoc />
-        public override string Windows64 => "DComp.dll";
+        public override string[] Windows64 => new[] { "DComp.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "DComp.dll";
+        public override string[] Windows86 => new[] { "DComp.dll" };
     }
 }

--- a/src/Microsoft/Silk.NET.DirectStorage/DStorage.cs
+++ b/src/Microsoft/Silk.NET.DirectStorage/DStorage.cs
@@ -17,7 +17,7 @@ namespace Silk.NET.DirectStorage
     {
         public static DStorage GetApi()
         {
-             return new(CreateDefaultContext(new DStorageLibraryNameContainer().GetLibraryName()));
+             return new(CreateDefaultContext(new DStorageLibraryNameContainer().GetLibraryNames()));
         }
 
         public bool TryGetExtension<T>(out T ext)

--- a/src/Microsoft/Silk.NET.DirectStorage/DStorageLibraryNameContainer.cs
+++ b/src/Microsoft/Silk.NET.DirectStorage/DStorageLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.DirectStorage
     internal class DStorageLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libdstorage.so";
+        public override string[] Linux => new[] { "libdstorage.so" };
 
         /// <inheritdoc />
-        public override string MacOS => "libdstorage.dylib";
+        public override string[] MacOS => new[] { "libdstorage.dylib" };
 
         /// <inheritdoc />
-        public override string Android => "libdstorage.so";
+        public override string[] Android => new[] { "libdstorage.so" };
 
         /// <inheritdoc />
-        public override string IOS => "__Internal";
+        public override string[] IOS => new[] { "__Internal" };
 
         /// <inheritdoc />
-        public override string Windows64 => "dstorage.dll";
+        public override string[] Windows64 => new[] { "dstorage.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "dstorage.dll";
+        public override string[] Windows86 => new[] { "dstorage.dll" };
     }
 }

--- a/src/OpenAL/Silk.NET.OpenAL/AL/AL.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/AL/AL.cs
@@ -339,7 +339,7 @@ namespace Silk.NET.OpenAL
         {
             SearchPathContainer searchPaths = soft ? new OpenALSoftLibraryNameContainer() : new OpenALLibraryNameContainer();
             var ctx = new MultiNativeContext
-                (CreateDefaultContext(searchPaths.GetLibraryName()), null);
+                (CreateDefaultContext(searchPaths.GetLibraryNames()), null);
             var ret = new AL(ctx);
             ret._soft = soft;
             ret._searchPaths = searchPaths;

--- a/src/OpenAL/Silk.NET.OpenAL/AL/AL.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/AL/AL.cs
@@ -29,8 +29,7 @@ namespace Silk.NET.OpenAL
         public override partial bool IsExtensionPresent(string name);
 
         /// <inheritdoc />
-        public SearchPathContainer SearchPaths => _searchPaths ??= (_soft
-             ? new OpenALSoftLibraryNameContainer() : new OpenALLibraryNameContainer());
+        public SearchPathContainer SearchPaths => _searchPaths ??= new OpenALLibraryNameContainer(_soft);
 
         /// <inheritdoc />
         public partial nint GetProcAddress(string name);
@@ -333,11 +332,12 @@ namespace Silk.NET.OpenAL
         /// <summary>
         /// Gets an instance of the API.
         /// </summary>
-        /// <param name="soft">Use OpenAL Soft libraries.</param>
+        /// <param name="soft">Prefer OpenAL Soft libraries.</param>
         /// <returns>The instance.</returns>
         public static AL GetApi(bool soft = false)
         {
-            SearchPathContainer searchPaths = soft ? new OpenALSoftLibraryNameContainer() : new OpenALLibraryNameContainer();
+            SearchPathContainer searchPaths = new OpenALLibraryNameContainer(soft);
+            
             var ctx = new MultiNativeContext
                 (CreateDefaultContext(searchPaths.GetLibraryNames()), null);
             var ret = new AL(ctx);

--- a/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs
@@ -25,8 +25,7 @@ namespace Silk.NET.OpenAL
         {
         }
 
-        public SearchPathContainer SearchPaths => _searchPaths ??= (_soft
-             ? new OpenALSoftLibraryNameContainer() : new OpenALLibraryNameContainer());
+        public SearchPathContainer SearchPaths => _searchPaths ??= new OpenALLibraryNameContainer(_soft);
 
         public override unsafe bool IsExtensionPresent(string name)
             => IsExtensionPresent(GetContextsDevice(GetCurrentContext()), name);
@@ -85,11 +84,11 @@ namespace Silk.NET.OpenAL
         /// <summary>
         /// Gets an instance of the API.
         /// </summary>
-        /// <param name="soft">Use OpenAL Soft libraries.</param>
+        /// <param name="soft">Prefer OpenAL Soft libraries.</param>
         /// <returns>The instance.</returns>
         public static unsafe ALContext GetApi(bool soft = false)
         {
-            SearchPathContainer searchPaths = soft ? new OpenALSoftLibraryNameContainer() : new OpenALLibraryNameContainer();
+            SearchPathContainer searchPaths = new OpenALLibraryNameContainer(soft);
             var ctx = new MultiNativeContext
                 (CreateDefaultContext(searchPaths.GetLibraryNames()), null);
             var ret = new ALContext(ctx);

--- a/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs
@@ -91,7 +91,7 @@ namespace Silk.NET.OpenAL
         {
             SearchPathContainer searchPaths = soft ? new OpenALSoftLibraryNameContainer() : new OpenALLibraryNameContainer();
             var ctx = new MultiNativeContext
-                (CreateDefaultContext(searchPaths.GetLibraryName()), null);
+                (CreateDefaultContext(searchPaths.GetLibraryNames()), null);
             var ret = new ALContext(ctx);
             ret._soft = soft;
             ret._searchPaths = searchPaths;

--- a/src/OpenAL/Silk.NET.OpenAL/OpenALLibraryNameContainer.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/OpenALLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.OpenAL
     internal class OpenALLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libopenal.so.1";
+        public override string[] Linux => new[] { "libopenal.so.1" };
 
         /// <inheritdoc />
-        public override string MacOS => "/System/Library/Frameworks/OpenAL.framework/OpenAL";
+        public override string[] MacOS => new[] { "/System/Library/Frameworks/OpenAL.framework/OpenAL" };
 
         /// <inheritdoc />
-        public override string Android => Linux;
+        public override string[] Android => Linux;
 
         /// <inheritdoc />
-        public override string IOS => MacOS;
+        public override string[] IOS => MacOS;
 
         /// <inheritdoc />
-        public override string Windows86 => "openal32.dll";
+        public override string[] Windows86 => new[] { "openal32.dll" };
 
         /// <inheritdoc />
-        public override string Windows64 => "openal32.dll";
+        public override string[] Windows64 => new[] { "openal32.dll" };
     }
 }

--- a/src/OpenAL/Silk.NET.OpenAL/OpenALLibraryNameContainer.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/OpenALLibraryNameContainer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using Silk.NET.Core.Loader;
 
 namespace Silk.NET.OpenAL
@@ -10,11 +11,28 @@ namespace Silk.NET.OpenAL
     /// </summary>
     internal class OpenALLibraryNameContainer : SearchPathContainer
     {
-        /// <inheritdoc />
-        public override string[] Linux => new[] { "libopenal.so.1" };
+        private readonly bool _preferSoft;
+
+        private readonly SearchPathContainer _soft;
+        private readonly SearchPathContainer _native;
+
+        public OpenALLibraryNameContainer(bool preferSoft)
+        {
+            _preferSoft = preferSoft;
+
+            _soft = new OpenALSoftLibraryNameContainer();
+            _native = new OpenALNativeLibraryNameContainer();
+        }
 
         /// <inheritdoc />
-        public override string[] MacOS => new[] { "/System/Library/Frameworks/OpenAL.framework/OpenAL" };
+        public override string[] Linux => _preferSoft
+            ? _soft.Linux.Concat(_native.Linux).ToArray()
+            : _native.Linux.Concat(_soft.Linux).ToArray();
+
+        /// <inheritdoc />
+        public override string[] MacOS => _preferSoft
+            ? _soft.MacOS.Concat(_native.MacOS).ToArray()
+            : _native.MacOS.Concat(_soft.MacOS).ToArray();
 
         /// <inheritdoc />
         public override string[] Android => Linux;
@@ -23,9 +41,13 @@ namespace Silk.NET.OpenAL
         public override string[] IOS => MacOS;
 
         /// <inheritdoc />
-        public override string[] Windows86 => new[] { "openal32.dll" };
+        public override string[] Windows86 => _preferSoft
+            ? _soft.Windows86.Concat(_native.Windows86).ToArray()
+            : _native.Windows86.Concat(_soft.Windows86).ToArray();
 
         /// <inheritdoc />
-        public override string[] Windows64 => new[] { "openal32.dll" };
+        public override string[] Windows64 => _preferSoft
+            ? _soft.Windows64.Concat(_native.Windows64).ToArray()
+            : _native.Windows64.Concat(_soft.Windows64).ToArray();
     }
 }

--- a/src/OpenAL/Silk.NET.OpenAL/OpenALNativeLibraryNameContainer.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/OpenALNativeLibraryNameContainer.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Silk.NET.Core.Loader;
+
+namespace Silk.NET.OpenAL
+{
+    /// <summary>
+    /// Contains the library name of OpenAL.
+    /// </summary>
+    internal class OpenALNativeLibraryNameContainer : SearchPathContainer
+    {
+        /// <inheritdoc />
+        public override string[] Linux => new[] { "libopenal.so.1" };
+
+        /// <inheritdoc />
+        public override string[] MacOS => new[] { "/System/Library/Frameworks/OpenAL.framework/OpenAL" };
+
+        /// <inheritdoc />
+        public override string[] Android => Linux;
+
+        /// <inheritdoc />
+        public override string[] IOS => MacOS;
+
+        /// <inheritdoc />
+        public override string[] Windows86 => new[] { "openal32.dll" };
+
+        /// <inheritdoc />
+        public override string[] Windows64 => new[] { "openal32.dll" };
+    }
+}

--- a/src/OpenAL/Silk.NET.OpenAL/OpenALSoftLibraryNameContainer.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/OpenALSoftLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.OpenAL
     internal class OpenALSoftLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libopenal.so";
+        public override string[] Linux => new[] { "libopenal.so" };
 
         /// <inheritdoc />
-        public override string MacOS => "libopenal.dylib";
+        public override string[] MacOS => new[] { "libopenal.dylib" };
 
         /// <inheritdoc />
-        public override string Android => Linux;
+        public override string[] Android => Linux;
 
         /// <inheritdoc />
-        public override string IOS => MacOS;
+        public override string[] IOS => MacOS;
 
         /// <inheritdoc />
-        public override string Windows86 => "soft_oal.dll";
+        public override string[] Windows86 => new[] { "soft_oal.dll" };
 
         /// <inheritdoc />
-        public override string Windows64 => "soft_oal.dll";
+        public override string[] Windows64 => new[] { "soft_oal.dll" };
     }
 }

--- a/src/OpenCL/Silk.NET.OpenCL/CL.cs
+++ b/src/OpenCL/Silk.NET.OpenCL/CL.cs
@@ -11,7 +11,7 @@ namespace Silk.NET.OpenCL
     {
         public static CL GetApi()
         {
-             return new CL(CreateDefaultContext(new OpenCLLibraryNameContainer().GetLibraryName()));
+             return new CL(CreateDefaultContext(new OpenCLLibraryNameContainer().GetLibraryNames()));
         }
 
         public bool TryGetExtension<T>(out T ext)

--- a/src/OpenCL/Silk.NET.OpenCL/OpenCLLibraryNameContainer.cs
+++ b/src/OpenCL/Silk.NET.OpenCL/OpenCLLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.OpenCL
     internal class OpenCLLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libOpenCL.so.1";
+        public override string[] Linux => new[] { "libOpenCL.so.1" };
 
         /// <inheritdoc />
-        public override string MacOS => "/System/Library/Frameworks/OpenCL.framework/OpenCL";
+        public override string[] MacOS => new[] { "/System/Library/Frameworks/OpenCL.framework/OpenCL" };
 
         /// <inheritdoc />
-        public override string Android => "libOpenCL.so";
+        public override string[] Android => new[] { "libOpenCL.so" };
 
         /// <inheritdoc />
-        public override string IOS => "/System/Library/Frameworks/OpenCL.framework/OpenCL";
+        public override string[] IOS => new[] { "/System/Library/Frameworks/OpenCL.framework/OpenCL" };
 
         /// <inheritdoc />
-        public override string Windows64 => "opencl.dll";
+        public override string[] Windows64 => new[] { "opencl.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "opencl.dll";
+        public override string[] Windows86 => new[] { "opencl.dll" };
     }
 }

--- a/src/OpenGL/Silk.NET.OpenGL.Legacy/OpenGLLibraryNameContainer.cs
+++ b/src/OpenGL/Silk.NET.OpenGL.Legacy/OpenGLLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.OpenGL.Legacy
     internal class OpenGLLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libGL.so.1";
+        public override string[] Linux => new[] { "libGL.so.1" };
 
         /// <inheritdoc />
-        public override string MacOS => "/System/Library/Frameworks/OpenGL.framework/OpenGL";
+        public override string[] MacOS => new[] { "/System/Library/Frameworks/OpenGL.framework/OpenGL" };
 
         /// <inheritdoc />
-        public override string Android => "libGL.so.1";
+        public override string[] Android => new[] { "libGL.so.1" };
 
         /// <inheritdoc />
-        public override string IOS => "/System/Library/Frameworks/OpenGL.framework/OpenGL";
+        public override string[] IOS => new[] { "/System/Library/Frameworks/OpenGL.framework/OpenGL" };
 
         /// <inheritdoc />
-        public override string Windows64 => "opengl32.dll";
+        public override string[] Windows64 => new[] { "opengl32.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "opengl32.dll";
+        public override string[] Windows86 => new[] { "opengl32.dll" };
     }
 }

--- a/src/OpenGL/Silk.NET.OpenGL/GLCoreLibraryNameContainer.cs
+++ b/src/OpenGL/Silk.NET.OpenGL/GLCoreLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.OpenGL
     internal class GLCoreLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libGL.so.1";
+        public override string[] Linux => new[] { "libGL.so.1" };
 
         /// <inheritdoc />
-        public override string MacOS => "/System/Library/Frameworks/OpenGL.framework/OpenGL";
+        public override string[] MacOS => new[] { "/System/Library/Frameworks/OpenGL.framework/OpenGL" };
 
         /// <inheritdoc />
-        public override string Android => "libGL.so.1";
+        public override string[] Android => new[] { "libGL.so.1" };
 
         /// <inheritdoc />
-        public override string IOS => "/System/Library/Frameworks/OpenGL.framework/OpenGL";
+        public override string[] IOS => new[] { "/System/Library/Frameworks/OpenGL.framework/OpenGL" };
 
         /// <inheritdoc />
-        public override string Windows64 => "opengl32.dll";
+        public override string[] Windows64 => new[] { "opengl32.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "opengl32.dll";
+        public override string[] Windows86 => new[] { "opengl32.dll" };
     }
 }

--- a/src/OpenGL/Silk.NET.OpenGLES/OpenGLESLibraryNameContainer.cs
+++ b/src/OpenGL/Silk.NET.OpenGLES/OpenGLESLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.OpenGLES
     internal class OpenGLESLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libGLESv2.so";
+        public override string[] Linux => new[] { "libGLESv2.so" };
 
         /// <inheritdoc />
-        public override string MacOS => "/System/Library/Frameworks/OpenGLES.framework/OpenGLES";
+        public override string[] MacOS => new[] { "/System/Library/Frameworks/OpenGLES.framework/OpenGLES" };
 
         /// <inheritdoc />
-        public override string Android => "libGLESv2.so";
+        public override string[] Android => new[] { "libGLESv2.so" };
 
         /// <inheritdoc />
-        public override string IOS => "/System/Library/Frameworks/OpenGLES.framework/OpenGLES";
+        public override string[] IOS => new[] { "/System/Library/Frameworks/OpenGLES.framework/OpenGLES" };
 
         /// <inheritdoc />
-        public override string Windows64 => "libGLESv2.dll";
+        public override string[] Windows64 => new[] { "libGLESv2.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "libGLESv2.dll";
+        public override string[] Windows86 => new[] { "libGLESv2.dll" };
     }
 }

--- a/src/OpenXR/Silk.NET.OpenXR/OpenXRLibraryNameContainer.cs
+++ b/src/OpenXR/Silk.NET.OpenXR/OpenXRLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.OpenXR
     internal class OpenXRLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libopenxr_loader.so.1";
+        public override string[] Linux => new[] { "libopenxr_loader.so.1" };
 
         /// <inheritdoc />
-        public override string MacOS => "null";
+        public override string[] MacOS => new[] { "null" };
 
         /// <inheritdoc />
-        public override string Android => "libopenxr_loader.so.1";
+        public override string[] Android => new[] { "libopenxr_loader.so.1" };
 
         /// <inheritdoc />
-        public override string IOS => "__Internal";
+        public override string[] IOS => new[] { "__Internal" };
 
         /// <inheritdoc />
-        public override string Windows64 => "openxr_loader.dll";
+        public override string[] Windows64 => new[] { "openxr_loader.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "openxr_loader.dll";
+        public override string[] Windows86 => new[] { "openxr_loader.dll" };
     }
 }

--- a/src/OpenXR/Silk.NET.OpenXR/XR.cs
+++ b/src/OpenXR/Silk.NET.OpenXR/XR.cs
@@ -24,7 +24,7 @@ namespace Silk.NET.OpenXR
         }
         public static XR GetApi()
         {
-            return new XR(CreateDefaultContext(new OpenXRLibraryNameContainer().GetLibraryName()));
+            return new XR(CreateDefaultContext(new OpenXRLibraryNameContainer().GetLibraryNames()));
         }
 
         [Obsolete("Use IsInstanceExtensionPresent instead.", true)]

--- a/src/Vulkan/Silk.NET.Vulkan/Vk.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/Vk.cs
@@ -56,7 +56,7 @@ namespace Silk.NET.Vulkan
         public static Vk GetApi()
         {
             var ctx = new MultiNativeContext
-                (CreateDefaultContext(new VulkanLibraryNameContainer().GetLibraryName()), null);
+                (CreateDefaultContext(new VulkanLibraryNameContainer().GetLibraryNames()), null);
             var ret = new Vk(ctx);
             ctx.Contexts[1] = new LamdaNativeContext
             (

--- a/src/Vulkan/Silk.NET.Vulkan/VulkanLibraryNameContainer.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/VulkanLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.Vulkan
     internal class VulkanLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libvulkan.so.1";
+        public override string[] Linux => new[] { "libvulkan.so.1" };
 
         /// <inheritdoc />
-        public override string MacOS => "libvulkan.dylib";
+        public override string[] MacOS => new[] { "libvulkan.dylib" };
 
         /// <inheritdoc />
-        public override string Android => "libvulkan.so";
+        public override string[] Android => new[] { "libvulkan.so" };
 
         /// <inheritdoc />
-        public override string IOS => "__Internal";
+        public override string[] IOS => new[] { "__Internal" };
 
         /// <inheritdoc />
-        public override string Windows64 => "vulkan-1.dll";
+        public override string[] Windows64 => new[] { "vulkan-1.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "vulkan-1.dll";
+        public override string[] Windows86 => new[] { "vulkan-1.dll" };
     }
 }

--- a/src/WebGPU/Silk.NET.WebGPU/WebGPU.cs
+++ b/src/WebGPU/Silk.NET.WebGPU/WebGPU.cs
@@ -17,7 +17,7 @@ namespace Silk.NET.WebGPU
     {
         public static WebGPU GetApi()
         {
-             return new(CreateDefaultContext(new WebGPULibraryNameContainer().GetLibraryName()));
+             return new(CreateDefaultContext(new WebGPULibraryNameContainer().GetLibraryNames()));
         }
 
         [Obsolete("Use TryGetDeviceExtension!")]

--- a/src/WebGPU/Silk.NET.WebGPU/WebGPULibraryNameContainer.cs
+++ b/src/WebGPU/Silk.NET.WebGPU/WebGPULibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.WebGPU
     internal class WebGPULibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libwgpu_native.so";
+        public override string[] Linux => new[] { "libwgpu_native.so" };
 
         /// <inheritdoc />
-        public override string MacOS => "libwgpu_native.dylib";
+        public override string[] MacOS => new[] { "libwgpu_native.dylib" };
 
         /// <inheritdoc />
-        public override string Android => "libwgpu_native.so";
+        public override string[] Android => new[] { "libwgpu_native.so" };
 
         /// <inheritdoc />
-        public override string IOS => "";
+        public override string[] IOS => new[] { "__Internal" };
 
         /// <inheritdoc />
-        public override string Windows64 => "libwgpu_native.dll";
+        public override string[] Windows64 => new[] { "libwgpu_native.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "libwgpu_native.dll";
+        public override string[] Windows86 => new[] { "libwgpu_native.dll" };
     }
 }

--- a/src/Windowing/Silk.NET.GLFW/Glfw.cs
+++ b/src/Windowing/Silk.NET.GLFW/Glfw.cs
@@ -3949,7 +3949,7 @@ namespace Silk.NET.GLFW
         /// <returns>The instance.</returns>
         public static Glfw GetApi()
         {
-            return new Glfw(CreateDefaultContext(new GlfwLibraryNameContainer().GetLibraryName()));
+            return new Glfw(CreateDefaultContext(new GlfwLibraryNameContainer().GetLibraryNames()));
         }
 
         /// <inheritdoc />

--- a/src/Windowing/Silk.NET.GLFW/GlfwLibraryNameContainer.cs
+++ b/src/Windowing/Silk.NET.GLFW/GlfwLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.GLFW
     internal class GlfwLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libglfw.so.3.3";
+        public override string[] Linux => new[] { "libglfw.so.3.3" };
 
         /// <inheritdoc />
-        public override string MacOS => "libglfw.3.dylib";
+        public override string[] MacOS => new[] { "libglfw.3.dylib" };
 
         /// <inheritdoc />
-        public override string Android => Linux;
+        public override string[] Android => Linux;
 
         /// <inheritdoc />
-        public override string IOS => MacOS;
+        public override string[] IOS => MacOS;
 
         /// <inheritdoc />
-        public override string Windows64 => "glfw3.dll";
+        public override string[] Windows64 => new[] { "glfw3.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "glfw3.dll";
+        public override string[] Windows86 => new[] { "glfw3.dll" };
     }
 }

--- a/src/Windowing/Silk.NET.SDL/SDLLibraryNameContainer.cs
+++ b/src/Windowing/Silk.NET.SDL/SDLLibraryNameContainer.cs
@@ -11,21 +11,21 @@ namespace Silk.NET.SDL
     internal class SDLLibraryNameContainer : SearchPathContainer
     {
         /// <inheritdoc />
-        public override string Linux => "libSDL2-2.0.so";
+        public override string[] Linux => new[] { "libSDL2-2.0.so" };
 
         /// <inheritdoc />
-        public override string MacOS => "libSDL2-2.0.dylib";
+        public override string[] MacOS => new[] { "libSDL2-2.0.dylib" };
 
         /// <inheritdoc />
-        public override string Android => "libSDL2.so";
+        public override string[] Android => new[] { "libSDL2.so" };
 
         /// <inheritdoc />
-        public override string IOS => "__Internal";
+        public override string[] IOS => new[] { "__Internal" };
 
         /// <inheritdoc />
-        public override string Windows64 => "SDL2.dll";
+        public override string[] Windows64 => new[] { "SDL2.dll" };
 
         /// <inheritdoc />
-        public override string Windows86 => "SDL2.dll";
+        public override string[] Windows86 => new[] { "SDL2.dll" };
     }
 }

--- a/src/Windowing/Silk.NET.SDL/Sdl.cs
+++ b/src/Windowing/Silk.NET.SDL/Sdl.cs
@@ -628,7 +628,7 @@ namespace Silk.NET.SDL
             return new SdlException(str);
         }
 
-        public static Sdl GetApi() => new Sdl(CreateDefaultContext(new SDLLibraryNameContainer().GetLibraryName()));
+        public static Sdl GetApi() => new Sdl(CreateDefaultContext(new SDLLibraryNameContainer().GetLibraryNames()));
         public override bool IsExtensionPresent(string extension) => GLExtensionSupported(extension) == SdlBool.True;
     }
 }


### PR DESCRIPTION
# Summary of the PR
Closes #1333 
Allows passing multiple library paths to CreateDefaultContext, and add multiple library path support into SearchPathContainer

# Related issues, Discord discussions, or proposals
Links go here.

# Further Comments
This also brings into consideration the possibility cleaning up of places such as OpenAL, so that it tries the native OpenAL, then later tries OpenAL-soft, instead of the "choose one or the other" that we have now, 
@Perksey should the `AL.GetApi(bool)` be deprecated with `ObsoleteAttribute` and the new non-deprecated behaviour be `Native Platform -> Soft`? 