### PR TITLE
Vulkan: Add MoltenVK and portability to MacOS library names

### DIFF
--- a/src/Vulkan/Silk.NET.Vulkan/VulkanLibraryNameContainer.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/VulkanLibraryNameContainer.cs
@@ -14,7 +14,7 @@ namespace Silk.NET.Vulkan
         public override string[] Linux => new[] { "libvulkan.so.1" };
 
         /// <inheritdoc />
-        public override string[] MacOS => new[] { "libvulkan.dylib" };
+        public override string[] MacOS => new[] { "libvulkan.dylib", "libMoltenVK.dylib", "libportability.dylib" };
 
         /// <inheritdoc />
         public override string[] Android => new[] { "libvulkan.so" };

--- a/src/Vulkan/Silk.NET.Vulkan/VulkanLibraryNameContainer.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/VulkanLibraryNameContainer.cs
@@ -14,7 +14,7 @@ namespace Silk.NET.Vulkan
         public override string[] Linux => new[] { "libvulkan.so.1" };
 
         /// <inheritdoc />
-        public override string[] MacOS => new[] { "libvulkan.dylib", "libMoltenVK.dylib", "libportability.dylib" };
+        public override string[] MacOS => new[] { "libvulkan.dylib", "libMoltenVK.dylib" };
 
         /// <inheritdoc />
         public override string[] Android => new[] { "libvulkan.so" };


### PR DESCRIPTION
# Related issues, Discord discussions, or proposals
https://github.com/dotnet/Silk.NET/pull/1197#discussion_r1168295230

# Further Comments
MoltenVK is (obviously) above portability, and while gfx-rs/portability is dead development wise, there are maybe people who want to package it with their app and use it for whatever reason, or end users who want to use it with some app, so lets shove it at the end of the libnames to check, since we are able to, and it shouldnt hurt anything, given the loader and Molten VK are prioritized