### PR TITLE
Further chain improvements

### DIFF
--- a/src/Vulkan/Silk.NET.Vulkan/Chain.g.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/Chain.g.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // ReSharper disable StaticMemberInGenericType
@@ -6909,6 +6909,8 @@ public interface IChain<TChain> : IDisposable, IReadOnlyList<IChainable>
     /// The first structure in the structure chain.
     /// </summary>
     TChain Head { get; }
+
+    ref TChain HeadRef { get; }
 }
 
 /// <summary>
@@ -6956,6 +6958,8 @@ public unsafe sealed class Chain<TChain> : Chain, IEquatable<Chain<TChain>>, ICh
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain}"/> with 1 items from an existing memory block.
@@ -7251,6 +7255,8 @@ public interface IChain<TChain, T1> : IChain<TChain>
     /// Structure no. 2 in the structure chain.
     /// </summary>
     T1 Item1 { get; }
+
+    ref T1 Item1Ref { get; }
 }
 
 /// <summary>
@@ -7311,6 +7317,8 @@ public unsafe sealed class Chain<TChain, T1> : Chain, IEquatable<Chain<TChain, T
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -7331,6 +7339,8 @@ public unsafe sealed class Chain<TChain, T1> : Chain, IEquatable<Chain<TChain, T
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1}"/> with 2 items from an existing memory block.
@@ -7738,6 +7748,8 @@ public interface IChain<TChain, T1, T2> : IChain<TChain, T1>
     /// Structure no. 3 in the structure chain.
     /// </summary>
     T2 Item2 { get; }
+
+    ref T2 Item2Ref { get; }
 }
 
 /// <summary>
@@ -7810,6 +7822,8 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -7831,6 +7845,8 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
         }
     }
 
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -7851,6 +7867,8 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2}"/> with 3 items from an existing memory block.
@@ -8292,6 +8310,8 @@ public interface IChain<TChain, T1, T2, T3> : IChain<TChain, T1, T2>
     /// Structure no. 4 in the structure chain.
     /// </summary>
     T3 Item3 { get; }
+
+    ref T3 Item3Ref { get; }
 }
 
 /// <summary>
@@ -8376,6 +8396,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -8396,6 +8418,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -8418,6 +8442,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
         }
     }
 
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -8438,6 +8464,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3}"/> with 4 items from an existing memory block.
@@ -8913,6 +8941,8 @@ public interface IChain<TChain, T1, T2, T3, T4> : IChain<TChain, T1, T2, T3>
     /// Structure no. 5 in the structure chain.
     /// </summary>
     T4 Item4 { get; }
+
+    ref T4 Item4Ref { get; }
 }
 
 /// <summary>
@@ -9009,6 +9039,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -9029,6 +9061,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9051,6 +9085,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
         }
     }
 
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -9072,6 +9108,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
         }
     }
 
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -9092,6 +9130,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4}"/> with 5 items from an existing memory block.
@@ -9601,6 +9641,8 @@ public interface IChain<TChain, T1, T2, T3, T4, T5> : IChain<TChain, T1, T2, T3,
     /// Structure no. 6 in the structure chain.
     /// </summary>
     T5 Item5 { get; }
+
+    ref T5 Item5Ref { get; }
 }
 
 /// <summary>
@@ -9709,6 +9751,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -9729,6 +9773,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9751,6 +9797,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
         }
     }
 
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -9771,6 +9819,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9793,6 +9843,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
         }
     }
 
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -9813,6 +9865,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5}"/> with 6 items from an existing memory block.
@@ -10356,6 +10410,8 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6> : IChain<TChain, T1, T2,
     /// Structure no. 7 in the structure chain.
     /// </summary>
     T6 Item6 { get; }
+
+    ref T6 Item6Ref { get; }
 }
 
 /// <summary>
@@ -10476,6 +10532,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -10496,6 +10554,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10518,6 +10578,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
         }
     }
 
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -10538,6 +10600,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10560,6 +10624,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
         }
     }
 
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -10581,6 +10647,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
         }
     }
 
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -10601,6 +10669,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6}"/> with 7 items from an existing memory block.
@@ -11178,6 +11248,8 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7> : IChain<TChain, T1,
     /// Structure no. 8 in the structure chain.
     /// </summary>
     T7 Item7 { get; }
+
+    ref T7 Item7Ref { get; }
 }
 
 /// <summary>
@@ -11310,6 +11382,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -11330,6 +11404,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11352,6 +11428,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
         }
     }
 
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -11372,6 +11450,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11394,6 +11474,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
         }
     }
 
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -11414,6 +11496,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11436,6 +11520,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
         }
     }
 
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -11456,6 +11542,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7}"/> with 8 items from an existing memory block.
@@ -12067,6 +12155,8 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : IChain<TChain,
     /// Structure no. 9 in the structure chain.
     /// </summary>
     T8 Item8 { get; }
+
+    ref T8 Item8Ref { get; }
 }
 
 /// <summary>
@@ -12211,6 +12301,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -12231,6 +12323,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12253,6 +12347,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
         }
     }
 
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -12273,6 +12369,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12295,6 +12393,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
         }
     }
 
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -12315,6 +12415,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12337,6 +12439,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
         }
     }
 
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -12358,6 +12462,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
         }
     }
 
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -12378,6 +12484,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8}"/> with 9 items from an existing memory block.
@@ -13023,6 +13131,8 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IChain<TCh
     /// Structure no. 10 in the structure chain.
     /// </summary>
     T9 Item9 { get; }
+
+    ref T9 Item9Ref { get; }
 }
 
 /// <summary>
@@ -13179,6 +13289,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -13199,6 +13311,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13221,6 +13335,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
         }
     }
 
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -13241,6 +13357,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13263,6 +13381,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
         }
     }
 
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -13283,6 +13403,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13305,6 +13427,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
         }
     }
 
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -13325,6 +13449,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13347,6 +13473,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
         }
     }
 
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -13367,6 +13495,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9}"/> with 10 items from an existing memory block.
@@ -14046,6 +14176,8 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IChai
     /// Structure no. 11 in the structure chain.
     /// </summary>
     T10 Item10 { get; }
+
+    ref T10 Item10Ref { get; }
 }
 
 /// <summary>
@@ -14214,6 +14346,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -14234,6 +14368,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14256,6 +14392,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -14276,6 +14414,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14298,6 +14438,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -14318,6 +14460,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14340,6 +14484,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -14360,6 +14506,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14382,6 +14530,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -14403,6 +14553,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -14423,6 +14575,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10}"/> with 11 items from an existing memory block.
@@ -15136,6 +15290,8 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : 
     /// Structure no. 12 in the structure chain.
     /// </summary>
     T11 Item11 { get; }
+
+    ref T11 Item11Ref { get; }
 }
 
 /// <summary>
@@ -15316,6 +15472,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -15336,6 +15494,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15358,6 +15518,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -15378,6 +15540,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15400,6 +15564,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -15420,6 +15586,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15442,6 +15610,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -15462,6 +15632,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15484,6 +15656,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -15504,6 +15678,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15526,6 +15702,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -15546,6 +15724,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11}"/> with 12 items from an existing memory block.
@@ -16293,6 +16473,8 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// Structure no. 13 in the structure chain.
     /// </summary>
     T12 Item12 { get; }
+
+    ref T12 Item12Ref { get; }
 }
 
 /// <summary>
@@ -16485,6 +16667,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -16505,6 +16689,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16527,6 +16713,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -16547,6 +16735,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16569,6 +16759,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -16589,6 +16781,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16611,6 +16805,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -16631,6 +16827,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16653,6 +16851,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -16673,6 +16873,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16695,6 +16897,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -16716,6 +16920,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -16736,6 +16942,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12}"/> with 13 items from an existing memory block.
@@ -17517,6 +17725,8 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// Structure no. 14 in the structure chain.
     /// </summary>
     T13 Item13 { get; }
+
+    ref T13 Item13Ref { get; }
 }
 
 /// <summary>
@@ -17721,6 +17931,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -17741,6 +17953,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17763,6 +17977,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -17783,6 +17999,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17805,6 +18023,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -17825,6 +18045,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17847,6 +18069,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -17867,6 +18091,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17889,6 +18115,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -17909,6 +18137,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17931,6 +18161,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -17951,6 +18183,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17973,6 +18207,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -17993,6 +18229,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13}"/> with 14 items from an existing memory block.
@@ -18808,6 +19046,8 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// Structure no. 15 in the structure chain.
     /// </summary>
     T14 Item14 { get; }
+
+    ref T14 Item14Ref { get; }
 }
 
 /// <summary>
@@ -19024,6 +19264,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -19044,6 +19286,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19066,6 +19310,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -19086,6 +19332,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19108,6 +19356,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -19128,6 +19378,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19150,6 +19402,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -19170,6 +19424,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19192,6 +19448,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -19212,6 +19470,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19234,6 +19494,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -19254,6 +19516,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19276,6 +19540,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -19297,6 +19563,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -19317,6 +19585,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T14 Item14Ref => ref Unsafe.AsRef<T14>(Item14Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14}"/> with 15 items from an existing memory block.
@@ -20166,6 +20436,8 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// Structure no. 16 in the structure chain.
     /// </summary>
     T15 Item15 { get; }
+
+    ref T15 Item15Ref { get; }
 }
 
 /// <summary>
@@ -20394,6 +20666,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -20414,6 +20688,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -20436,6 +20712,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -20456,6 +20734,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -20478,6 +20758,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -20498,6 +20780,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -20520,6 +20804,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -20540,6 +20826,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -20562,6 +20850,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -20582,6 +20872,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -20604,6 +20896,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -20624,6 +20918,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -20646,6 +20942,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -20666,6 +20964,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -20688,6 +20988,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    public ref T14 Item14Ref => ref Unsafe.AsRef<T14>(Item14Ptr);
+
     /// <summary>
     /// Gets a pointer to the second item in the chain.
     /// </summary>
@@ -20708,6 +21010,8 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T15 Item15Ref => ref Unsafe.AsRef<T15>(Item15Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15}"/> with 16 items from an existing memory block.

--- a/src/Vulkan/Silk.NET.Vulkan/Chain.g.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/Chain.g.cs
@@ -6910,6 +6910,9 @@ public interface IChain<TChain> : IDisposable, IReadOnlyList<IChainable>
     /// </summary>
     TChain Head { get; set; }
 
+    /// <summary>
+    /// A reference to the first structure in the chain.
+    /// </summary>
     ref TChain HeadRef { get; }
 }
 
@@ -6959,6 +6962,9 @@ public unsafe sealed class Chain<TChain> : Chain, IEquatable<Chain<TChain>>, ICh
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -7254,8 +7260,11 @@ public interface IChain<TChain, T1> : IChain<TChain>
     /// <summary>
     /// Structure no. 2 in the structure chain.
     /// </summary>
-    T1 Item1 { get; set; }
+    T1 Item1 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 2 in the structure chain.
+    /// </summary>
     ref T1 Item1Ref { get; }
 }
 
@@ -7317,6 +7326,9 @@ public unsafe sealed class Chain<TChain, T1> : Chain, IEquatable<Chain<TChain, T
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -7339,7 +7351,9 @@ public unsafe sealed class Chain<TChain, T1> : Chain, IEquatable<Chain<TChain, T
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -7747,8 +7761,11 @@ public interface IChain<TChain, T1, T2> : IChain<TChain, T1>
     /// <summary>
     /// Structure no. 3 in the structure chain.
     /// </summary>
-    T2 Item2 { get; set; }
+    T2 Item2 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 3 in the structure chain.
+    /// </summary>
     ref T2 Item2Ref { get; }
 }
 
@@ -7822,6 +7839,9 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -7844,7 +7864,9 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -7867,7 +7889,9 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
@@ -8309,8 +8333,11 @@ public interface IChain<TChain, T1, T2, T3> : IChain<TChain, T1, T2>
     /// <summary>
     /// Structure no. 4 in the structure chain.
     /// </summary>
-    T3 Item3 { get; set; }
+    T3 Item3 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 4 in the structure chain.
+    /// </summary>
     ref T3 Item3Ref { get; }
 }
 
@@ -8396,6 +8423,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -8418,7 +8448,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -8441,7 +8473,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
@@ -8464,7 +8498,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
@@ -8940,8 +8976,11 @@ public interface IChain<TChain, T1, T2, T3, T4> : IChain<TChain, T1, T2, T3>
     /// <summary>
     /// Structure no. 5 in the structure chain.
     /// </summary>
-    T4 Item4 { get; set; }
+    T4 Item4 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 5 in the structure chain.
+    /// </summary>
     ref T4 Item4Ref { get; }
 }
 
@@ -9039,6 +9078,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -9061,7 +9103,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -9084,7 +9128,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
@@ -9107,7 +9153,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
@@ -9130,7 +9178,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
@@ -9640,8 +9690,11 @@ public interface IChain<TChain, T1, T2, T3, T4, T5> : IChain<TChain, T1, T2, T3,
     /// <summary>
     /// Structure no. 6 in the structure chain.
     /// </summary>
-    T5 Item5 { get; set; }
+    T5 Item5 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 6 in the structure chain.
+    /// </summary>
     ref T5 Item5Ref { get; }
 }
 
@@ -9751,6 +9804,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -9773,7 +9829,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -9796,7 +9854,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
@@ -9819,7 +9879,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
@@ -9842,7 +9904,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
@@ -9865,7 +9929,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
@@ -10409,8 +10475,11 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6> : IChain<TChain, T1, T2,
     /// <summary>
     /// Structure no. 7 in the structure chain.
     /// </summary>
-    T6 Item6 { get; set; }
+    T6 Item6 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 7 in the structure chain.
+    /// </summary>
     ref T6 Item6Ref { get; }
 }
 
@@ -10532,6 +10601,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -10554,7 +10626,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -10577,7 +10651,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
@@ -10600,7 +10676,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
@@ -10623,7 +10701,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
@@ -10646,7 +10726,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
@@ -10669,7 +10751,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
@@ -11247,8 +11331,11 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7> : IChain<TChain, T1,
     /// <summary>
     /// Structure no. 8 in the structure chain.
     /// </summary>
-    T7 Item7 { get; set; }
+    T7 Item7 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 8 in the structure chain.
+    /// </summary>
     ref T7 Item7Ref { get; }
 }
 
@@ -11382,6 +11469,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -11404,7 +11494,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -11427,7 +11519,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
@@ -11450,7 +11544,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
@@ -11473,7 +11569,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
@@ -11496,7 +11594,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
@@ -11519,7 +11619,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
@@ -11542,7 +11644,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
@@ -12154,8 +12258,11 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : IChain<TChain,
     /// <summary>
     /// Structure no. 9 in the structure chain.
     /// </summary>
-    T8 Item8 { get; set; }
+    T8 Item8 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 9 in the structure chain.
+    /// </summary>
     ref T8 Item8Ref { get; }
 }
 
@@ -12301,6 +12408,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -12323,7 +12433,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -12346,7 +12458,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
@@ -12369,7 +12483,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
@@ -12392,7 +12508,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
@@ -12415,7 +12533,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
@@ -12438,7 +12558,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
@@ -12461,7 +12583,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
@@ -12484,7 +12608,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
@@ -13130,8 +13256,11 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IChain<TCh
     /// <summary>
     /// Structure no. 10 in the structure chain.
     /// </summary>
-    T9 Item9 { get; set; }
+    T9 Item9 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 10 in the structure chain.
+    /// </summary>
     ref T9 Item9Ref { get; }
 }
 
@@ -13289,6 +13418,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -13311,7 +13443,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -13334,7 +13468,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
@@ -13357,7 +13493,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
@@ -13380,7 +13518,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
@@ -13403,7 +13543,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
@@ -13426,7 +13568,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
@@ -13449,7 +13593,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
@@ -13472,7 +13618,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
@@ -13495,7 +13643,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
@@ -14175,8 +14325,11 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IChai
     /// <summary>
     /// Structure no. 11 in the structure chain.
     /// </summary>
-    T10 Item10 { get; set; }
+    T10 Item10 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 11 in the structure chain.
+    /// </summary>
     ref T10 Item10Ref { get; }
 }
 
@@ -14346,6 +14499,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -14368,7 +14524,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -14391,7 +14549,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
@@ -14414,7 +14574,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
@@ -14437,7 +14599,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
@@ -14460,7 +14624,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
@@ -14483,7 +14649,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
@@ -14506,7 +14674,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
@@ -14529,7 +14699,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
@@ -14552,7 +14724,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
@@ -14575,7 +14749,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
@@ -15289,8 +15465,11 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : 
     /// <summary>
     /// Structure no. 12 in the structure chain.
     /// </summary>
-    T11 Item11 { get; set; }
+    T11 Item11 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 12 in the structure chain.
+    /// </summary>
     ref T11 Item11Ref { get; }
 }
 
@@ -15472,6 +15651,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -15494,7 +15676,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -15517,7 +15701,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
@@ -15540,7 +15726,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
@@ -15563,7 +15751,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
@@ -15586,7 +15776,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
@@ -15609,7 +15801,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
@@ -15632,7 +15826,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
@@ -15655,7 +15851,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
@@ -15678,7 +15876,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
@@ -15701,7 +15901,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
@@ -15724,7 +15926,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
@@ -16472,8 +16676,11 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 13 in the structure chain.
     /// </summary>
-    T12 Item12 { get; set; }
+    T12 Item12 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 13 in the structure chain.
+    /// </summary>
     ref T12 Item12Ref { get; }
 }
 
@@ -16667,6 +16874,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -16689,7 +16899,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -16712,7 +16924,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
@@ -16735,7 +16949,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
@@ -16758,7 +16974,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
@@ -16781,7 +16999,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
@@ -16804,7 +17024,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
@@ -16827,7 +17049,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
@@ -16850,7 +17074,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
@@ -16873,7 +17099,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
@@ -16896,7 +17124,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
@@ -16919,7 +17149,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
@@ -16942,7 +17174,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
@@ -17724,8 +17958,11 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 14 in the structure chain.
     /// </summary>
-    T13 Item13 { get; set; }
+    T13 Item13 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 14 in the structure chain.
+    /// </summary>
     ref T13 Item13Ref { get; }
 }
 
@@ -17931,6 +18168,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -17953,7 +18193,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -17976,7 +18218,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
@@ -17999,7 +18243,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
@@ -18022,7 +18268,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
@@ -18045,7 +18293,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
@@ -18068,7 +18318,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
@@ -18091,7 +18343,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
@@ -18114,7 +18368,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
@@ -18137,7 +18393,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
@@ -18160,7 +18418,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
@@ -18183,7 +18443,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
@@ -18206,7 +18468,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
@@ -18229,7 +18493,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
 
     /// <summary>
@@ -19045,8 +19311,11 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 15 in the structure chain.
     /// </summary>
-    T14 Item14 { get; set; }
+    T14 Item14 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 15 in the structure chain.
+    /// </summary>
     ref T14 Item14Ref { get; }
 }
 
@@ -19264,6 +19533,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -19286,7 +19558,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -19309,7 +19583,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
@@ -19332,7 +19608,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
@@ -19355,7 +19633,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
@@ -19378,7 +19658,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
@@ -19401,7 +19683,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
@@ -19424,7 +19708,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
@@ -19447,7 +19733,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
@@ -19470,7 +19758,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
@@ -19493,7 +19783,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
@@ -19516,7 +19808,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
@@ -19539,7 +19833,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
@@ -19562,7 +19858,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
 
     /// <summary>
@@ -19585,7 +19883,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T14 Item14Ref => ref Unsafe.AsRef<T14>(Item14Ptr);
 
     /// <summary>
@@ -20435,8 +20735,11 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 16 in the structure chain.
     /// </summary>
-    T15 Item15 { get; set; }
+    T15 Item15 { get; set; } 
 
+    /// <summary>
+    /// A reference to structure no. 16 in the structure chain.
+    /// </summary>
     ref T15 Item15Ref { get; }
 }
 
@@ -20666,6 +20969,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
@@ -20688,7 +20994,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
@@ -20711,7 +21019,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
@@ -20734,7 +21044,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
@@ -20757,7 +21069,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
@@ -20780,7 +21094,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
@@ -20803,7 +21119,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
@@ -20826,7 +21144,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
@@ -20849,7 +21169,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
@@ -20872,7 +21194,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
@@ -20895,7 +21219,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
@@ -20918,7 +21244,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
@@ -20941,7 +21269,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
@@ -20964,7 +21294,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
 
     /// <summary>
@@ -20987,7 +21319,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T14 Item14Ref => ref Unsafe.AsRef<T14>(Item14Ptr);
 
     /// <summary>
@@ -21010,7 +21344,9 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T15 Item15Ref => ref Unsafe.AsRef<T15>(Item15Ptr);
 
     /// <summary>

--- a/src/Vulkan/Silk.NET.Vulkan/Chain.g.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/Chain.g.cs
@@ -6908,7 +6908,12 @@ public interface IChain<TChain> : IDisposable, IReadOnlyList<IChainable>
     /// <summary>
     /// The first structure in the structure chain.
     /// </summary>
-    ref TChain Head { get; }
+    TChain Head { get; set; }
+
+    /// <summary>
+    /// A reference to the first structure in the chain.
+    /// </summary>
+    ref TChain HeadRef { get; }
 }
 
 /// <summary>
@@ -6944,7 +6949,23 @@ public unsafe sealed class Chain<TChain> : Chain, IEquatable<Chain<TChain>>, ICh
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain}"/> with 1 items from an existing memory block.
@@ -7239,7 +7260,12 @@ public interface IChain<TChain, T1> : IChain<TChain>
     /// <summary>
     /// Structure no. 2 in the structure chain.
     /// </summary>
-    ref T1 Item1 { get; }
+    T1 Item1 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 2 in the structure chain.
+    /// </summary>
+    ref T1 Item1Ref { get; }
 }
 
 /// <summary>
@@ -7287,7 +7313,23 @@ public unsafe sealed class Chain<TChain, T1> : Chain, IEquatable<Chain<TChain, T
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -7297,7 +7339,22 @@ public unsafe sealed class Chain<TChain, T1> : Chain, IEquatable<Chain<TChain, T
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1}"/> with 2 items from an existing memory block.
@@ -7704,7 +7761,12 @@ public interface IChain<TChain, T1, T2> : IChain<TChain, T1>
     /// <summary>
     /// Structure no. 3 in the structure chain.
     /// </summary>
-    ref T2 Item2 { get; }
+    T2 Item2 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 3 in the structure chain.
+    /// </summary>
+    ref T2 Item2Ref { get; }
 }
 
 /// <summary>
@@ -7764,7 +7826,23 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -7774,7 +7852,22 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -7784,7 +7877,22 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public T2 Item2
+    {
+        get => Unsafe.AsRef<T2>(Item2Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item2Ptr;
+            var nextPtr = ptr->PNext;
+            *((T2*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2}"/> with 3 items from an existing memory block.
@@ -8225,7 +8333,12 @@ public interface IChain<TChain, T1, T2, T3> : IChain<TChain, T1, T2>
     /// <summary>
     /// Structure no. 4 in the structure chain.
     /// </summary>
-    ref T3 Item3 { get; }
+    T3 Item3 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 4 in the structure chain.
+    /// </summary>
+    ref T3 Item3Ref { get; }
 }
 
 /// <summary>
@@ -8297,7 +8410,23 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -8307,7 +8436,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -8317,7 +8461,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public T2 Item2
+    {
+        get => Unsafe.AsRef<T2>(Item2Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item2Ptr;
+            var nextPtr = ptr->PNext;
+            *((T2*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -8327,7 +8486,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public T3 Item3
+    {
+        get => Unsafe.AsRef<T3>(Item3Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item3Ptr;
+            var nextPtr = ptr->PNext;
+            *((T3*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3}"/> with 4 items from an existing memory block.
@@ -8802,7 +8976,12 @@ public interface IChain<TChain, T1, T2, T3, T4> : IChain<TChain, T1, T2, T3>
     /// <summary>
     /// Structure no. 5 in the structure chain.
     /// </summary>
-    ref T4 Item4 { get; }
+    T4 Item4 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 5 in the structure chain.
+    /// </summary>
+    ref T4 Item4Ref { get; }
 }
 
 /// <summary>
@@ -8886,7 +9065,23 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -8896,7 +9091,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -8906,7 +9116,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public T2 Item2
+    {
+        get => Unsafe.AsRef<T2>(Item2Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item2Ptr;
+            var nextPtr = ptr->PNext;
+            *((T2*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -8916,7 +9141,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public T3 Item3
+    {
+        get => Unsafe.AsRef<T3>(Item3Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item3Ptr;
+            var nextPtr = ptr->PNext;
+            *((T3*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -8926,7 +9166,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public T4 Item4
+    {
+        get => Unsafe.AsRef<T4>(Item4Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item4Ptr;
+            var nextPtr = ptr->PNext;
+            *((T4*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4}"/> with 5 items from an existing memory block.
@@ -9435,7 +9690,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5> : IChain<TChain, T1, T2, T3,
     /// <summary>
     /// Structure no. 6 in the structure chain.
     /// </summary>
-    ref T5 Item5 { get; }
+    T5 Item5 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 6 in the structure chain.
+    /// </summary>
+    ref T5 Item5Ref { get; }
 }
 
 /// <summary>
@@ -9531,7 +9791,23 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9541,7 +9817,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9551,7 +9842,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public T2 Item2
+    {
+        get => Unsafe.AsRef<T2>(Item2Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item2Ptr;
+            var nextPtr = ptr->PNext;
+            *((T2*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9561,7 +9867,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public T3 Item3
+    {
+        get => Unsafe.AsRef<T3>(Item3Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item3Ptr;
+            var nextPtr = ptr->PNext;
+            *((T3*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9571,7 +9892,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public T4 Item4
+    {
+        get => Unsafe.AsRef<T4>(Item4Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item4Ptr;
+            var nextPtr = ptr->PNext;
+            *((T4*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9581,7 +9917,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public T5 Item5
+    {
+        get => Unsafe.AsRef<T5>(Item5Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item5Ptr;
+            var nextPtr = ptr->PNext;
+            *((T5*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5}"/> with 6 items from an existing memory block.
@@ -10124,7 +10475,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6> : IChain<TChain, T1, T2,
     /// <summary>
     /// Structure no. 7 in the structure chain.
     /// </summary>
-    ref T6 Item6 { get; }
+    T6 Item6 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 7 in the structure chain.
+    /// </summary>
+    ref T6 Item6Ref { get; }
 }
 
 /// <summary>
@@ -10232,7 +10588,23 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10242,7 +10614,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10252,7 +10639,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public T2 Item2
+    {
+        get => Unsafe.AsRef<T2>(Item2Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item2Ptr;
+            var nextPtr = ptr->PNext;
+            *((T2*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10262,7 +10664,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public T3 Item3
+    {
+        get => Unsafe.AsRef<T3>(Item3Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item3Ptr;
+            var nextPtr = ptr->PNext;
+            *((T3*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10272,7 +10689,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public T4 Item4
+    {
+        get => Unsafe.AsRef<T4>(Item4Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item4Ptr;
+            var nextPtr = ptr->PNext;
+            *((T4*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10282,7 +10714,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public T5 Item5
+    {
+        get => Unsafe.AsRef<T5>(Item5Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item5Ptr;
+            var nextPtr = ptr->PNext;
+            *((T5*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10292,7 +10739,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public T6 Item6
+    {
+        get => Unsafe.AsRef<T6>(Item6Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item6Ptr;
+            var nextPtr = ptr->PNext;
+            *((T6*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6}"/> with 7 items from an existing memory block.
@@ -10869,7 +11331,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7> : IChain<TChain, T1,
     /// <summary>
     /// Structure no. 8 in the structure chain.
     /// </summary>
-    ref T7 Item7 { get; }
+    T7 Item7 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 8 in the structure chain.
+    /// </summary>
+    ref T7 Item7Ref { get; }
 }
 
 /// <summary>
@@ -10989,7 +11456,23 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10999,7 +11482,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11009,7 +11507,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public T2 Item2
+    {
+        get => Unsafe.AsRef<T2>(Item2Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item2Ptr;
+            var nextPtr = ptr->PNext;
+            *((T2*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11019,7 +11532,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public T3 Item3
+    {
+        get => Unsafe.AsRef<T3>(Item3Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item3Ptr;
+            var nextPtr = ptr->PNext;
+            *((T3*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11029,7 +11557,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public T4 Item4
+    {
+        get => Unsafe.AsRef<T4>(Item4Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item4Ptr;
+            var nextPtr = ptr->PNext;
+            *((T4*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11039,7 +11582,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public T5 Item5
+    {
+        get => Unsafe.AsRef<T5>(Item5Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item5Ptr;
+            var nextPtr = ptr->PNext;
+            *((T5*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11049,7 +11607,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public T6 Item6
+    {
+        get => Unsafe.AsRef<T6>(Item6Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item6Ptr;
+            var nextPtr = ptr->PNext;
+            *((T6*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11059,7 +11632,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public T7 Item7
+    {
+        get => Unsafe.AsRef<T7>(Item7Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item7Ptr;
+            var nextPtr = ptr->PNext;
+            *((T7*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7}"/> with 8 items from an existing memory block.
@@ -11670,7 +12258,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : IChain<TChain,
     /// <summary>
     /// Structure no. 9 in the structure chain.
     /// </summary>
-    ref T8 Item8 { get; }
+    T8 Item8 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 9 in the structure chain.
+    /// </summary>
+    ref T8 Item8Ref { get; }
 }
 
 /// <summary>
@@ -11802,7 +12395,23 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11812,7 +12421,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11822,7 +12446,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public T2 Item2
+    {
+        get => Unsafe.AsRef<T2>(Item2Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item2Ptr;
+            var nextPtr = ptr->PNext;
+            *((T2*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11832,7 +12471,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public T3 Item3
+    {
+        get => Unsafe.AsRef<T3>(Item3Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item3Ptr;
+            var nextPtr = ptr->PNext;
+            *((T3*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11842,7 +12496,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public T4 Item4
+    {
+        get => Unsafe.AsRef<T4>(Item4Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item4Ptr;
+            var nextPtr = ptr->PNext;
+            *((T4*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11852,7 +12521,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public T5 Item5
+    {
+        get => Unsafe.AsRef<T5>(Item5Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item5Ptr;
+            var nextPtr = ptr->PNext;
+            *((T5*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11862,7 +12546,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public T6 Item6
+    {
+        get => Unsafe.AsRef<T6>(Item6Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item6Ptr;
+            var nextPtr = ptr->PNext;
+            *((T6*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11872,7 +12571,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public T7 Item7
+    {
+        get => Unsafe.AsRef<T7>(Item7Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item7Ptr;
+            var nextPtr = ptr->PNext;
+            *((T7*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11882,7 +12596,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public T8 Item8
+    {
+        get => Unsafe.AsRef<T8>(Item8Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item8Ptr;
+            var nextPtr = ptr->PNext;
+            *((T8*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8}"/> with 9 items from an existing memory block.
@@ -12527,7 +13256,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IChain<TCh
     /// <summary>
     /// Structure no. 10 in the structure chain.
     /// </summary>
-    ref T9 Item9 { get; }
+    T9 Item9 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 10 in the structure chain.
+    /// </summary>
+    ref T9 Item9Ref { get; }
 }
 
 /// <summary>
@@ -12671,7 +13405,23 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12681,7 +13431,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12691,7 +13456,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public T2 Item2
+    {
+        get => Unsafe.AsRef<T2>(Item2Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item2Ptr;
+            var nextPtr = ptr->PNext;
+            *((T2*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12701,7 +13481,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public T3 Item3
+    {
+        get => Unsafe.AsRef<T3>(Item3Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item3Ptr;
+            var nextPtr = ptr->PNext;
+            *((T3*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12711,7 +13506,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public T4 Item4
+    {
+        get => Unsafe.AsRef<T4>(Item4Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item4Ptr;
+            var nextPtr = ptr->PNext;
+            *((T4*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12721,7 +13531,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public T5 Item5
+    {
+        get => Unsafe.AsRef<T5>(Item5Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item5Ptr;
+            var nextPtr = ptr->PNext;
+            *((T5*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12731,7 +13556,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public T6 Item6
+    {
+        get => Unsafe.AsRef<T6>(Item6Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item6Ptr;
+            var nextPtr = ptr->PNext;
+            *((T6*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12741,7 +13581,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public T7 Item7
+    {
+        get => Unsafe.AsRef<T7>(Item7Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item7Ptr;
+            var nextPtr = ptr->PNext;
+            *((T7*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12751,7 +13606,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public T8 Item8
+    {
+        get => Unsafe.AsRef<T8>(Item8Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item8Ptr;
+            var nextPtr = ptr->PNext;
+            *((T8*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12761,7 +13631,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #9 in the chain.
     /// </summary>
-    public ref T9 Item9 => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public T9 Item9
+    {
+        get => Unsafe.AsRef<T9>(Item9Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item9Ptr;
+            var nextPtr = ptr->PNext;
+            *((T9*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9}"/> with 10 items from an existing memory block.
@@ -13440,7 +14325,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IChai
     /// <summary>
     /// Structure no. 11 in the structure chain.
     /// </summary>
-    ref T10 Item10 { get; }
+    T10 Item10 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 11 in the structure chain.
+    /// </summary>
+    ref T10 Item10Ref { get; }
 }
 
 /// <summary>
@@ -13596,7 +14486,23 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13606,7 +14512,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13616,7 +14537,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public T2 Item2
+    {
+        get => Unsafe.AsRef<T2>(Item2Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item2Ptr;
+            var nextPtr = ptr->PNext;
+            *((T2*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13626,7 +14562,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public T3 Item3
+    {
+        get => Unsafe.AsRef<T3>(Item3Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item3Ptr;
+            var nextPtr = ptr->PNext;
+            *((T3*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13636,7 +14587,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public T4 Item4
+    {
+        get => Unsafe.AsRef<T4>(Item4Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item4Ptr;
+            var nextPtr = ptr->PNext;
+            *((T4*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13646,7 +14612,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public T5 Item5
+    {
+        get => Unsafe.AsRef<T5>(Item5Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item5Ptr;
+            var nextPtr = ptr->PNext;
+            *((T5*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13656,7 +14637,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public T6 Item6
+    {
+        get => Unsafe.AsRef<T6>(Item6Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item6Ptr;
+            var nextPtr = ptr->PNext;
+            *((T6*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13666,7 +14662,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public T7 Item7
+    {
+        get => Unsafe.AsRef<T7>(Item7Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item7Ptr;
+            var nextPtr = ptr->PNext;
+            *((T7*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13676,7 +14687,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public T8 Item8
+    {
+        get => Unsafe.AsRef<T8>(Item8Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item8Ptr;
+            var nextPtr = ptr->PNext;
+            *((T8*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13686,7 +14712,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #9 in the chain.
     /// </summary>
-    public ref T9 Item9 => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public T9 Item9
+    {
+        get => Unsafe.AsRef<T9>(Item9Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item9Ptr;
+            var nextPtr = ptr->PNext;
+            *((T9*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13696,7 +14737,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #10 in the chain.
     /// </summary>
-    public ref T10 Item10 => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public T10 Item10
+    {
+        get => Unsafe.AsRef<T10>(Item10Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item10Ptr;
+            var nextPtr = ptr->PNext;
+            *((T10*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10}"/> with 11 items from an existing memory block.
@@ -14409,7 +15465,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : 
     /// <summary>
     /// Structure no. 12 in the structure chain.
     /// </summary>
-    ref T11 Item11 { get; }
+    T11 Item11 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 12 in the structure chain.
+    /// </summary>
+    ref T11 Item11Ref { get; }
 }
 
 /// <summary>
@@ -14577,7 +15638,23 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14587,7 +15664,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14597,7 +15689,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public T2 Item2
+    {
+        get => Unsafe.AsRef<T2>(Item2Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item2Ptr;
+            var nextPtr = ptr->PNext;
+            *((T2*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14607,7 +15714,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public T3 Item3
+    {
+        get => Unsafe.AsRef<T3>(Item3Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item3Ptr;
+            var nextPtr = ptr->PNext;
+            *((T3*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14617,7 +15739,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public T4 Item4
+    {
+        get => Unsafe.AsRef<T4>(Item4Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item4Ptr;
+            var nextPtr = ptr->PNext;
+            *((T4*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14627,7 +15764,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public T5 Item5
+    {
+        get => Unsafe.AsRef<T5>(Item5Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item5Ptr;
+            var nextPtr = ptr->PNext;
+            *((T5*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14637,7 +15789,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public T6 Item6
+    {
+        get => Unsafe.AsRef<T6>(Item6Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item6Ptr;
+            var nextPtr = ptr->PNext;
+            *((T6*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14647,7 +15814,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public T7 Item7
+    {
+        get => Unsafe.AsRef<T7>(Item7Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item7Ptr;
+            var nextPtr = ptr->PNext;
+            *((T7*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14657,7 +15839,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public T8 Item8
+    {
+        get => Unsafe.AsRef<T8>(Item8Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item8Ptr;
+            var nextPtr = ptr->PNext;
+            *((T8*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14667,7 +15864,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #9 in the chain.
     /// </summary>
-    public ref T9 Item9 => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public T9 Item9
+    {
+        get => Unsafe.AsRef<T9>(Item9Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item9Ptr;
+            var nextPtr = ptr->PNext;
+            *((T9*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14677,7 +15889,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #10 in the chain.
     /// </summary>
-    public ref T10 Item10 => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public T10 Item10
+    {
+        get => Unsafe.AsRef<T10>(Item10Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item10Ptr;
+            var nextPtr = ptr->PNext;
+            *((T10*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14687,7 +15914,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #11 in the chain.
     /// </summary>
-    public ref T11 Item11 => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public T11 Item11
+    {
+        get => Unsafe.AsRef<T11>(Item11Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item11Ptr;
+            var nextPtr = ptr->PNext;
+            *((T11*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11}"/> with 12 items from an existing memory block.
@@ -15434,7 +16676,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 13 in the structure chain.
     /// </summary>
-    ref T12 Item12 { get; }
+    T12 Item12 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 13 in the structure chain.
+    /// </summary>
+    ref T12 Item12Ref { get; }
 }
 
 /// <summary>
@@ -15614,7 +16861,23 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15624,7 +16887,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15634,7 +16912,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public T2 Item2
+    {
+        get => Unsafe.AsRef<T2>(Item2Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item2Ptr;
+            var nextPtr = ptr->PNext;
+            *((T2*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15644,7 +16937,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public T3 Item3
+    {
+        get => Unsafe.AsRef<T3>(Item3Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item3Ptr;
+            var nextPtr = ptr->PNext;
+            *((T3*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15654,7 +16962,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public T4 Item4
+    {
+        get => Unsafe.AsRef<T4>(Item4Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item4Ptr;
+            var nextPtr = ptr->PNext;
+            *((T4*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15664,7 +16987,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public T5 Item5
+    {
+        get => Unsafe.AsRef<T5>(Item5Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item5Ptr;
+            var nextPtr = ptr->PNext;
+            *((T5*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15674,7 +17012,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public T6 Item6
+    {
+        get => Unsafe.AsRef<T6>(Item6Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item6Ptr;
+            var nextPtr = ptr->PNext;
+            *((T6*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15684,7 +17037,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public T7 Item7
+    {
+        get => Unsafe.AsRef<T7>(Item7Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item7Ptr;
+            var nextPtr = ptr->PNext;
+            *((T7*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15694,7 +17062,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public T8 Item8
+    {
+        get => Unsafe.AsRef<T8>(Item8Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item8Ptr;
+            var nextPtr = ptr->PNext;
+            *((T8*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15704,7 +17087,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #9 in the chain.
     /// </summary>
-    public ref T9 Item9 => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public T9 Item9
+    {
+        get => Unsafe.AsRef<T9>(Item9Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item9Ptr;
+            var nextPtr = ptr->PNext;
+            *((T9*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15714,7 +17112,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #10 in the chain.
     /// </summary>
-    public ref T10 Item10 => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public T10 Item10
+    {
+        get => Unsafe.AsRef<T10>(Item10Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item10Ptr;
+            var nextPtr = ptr->PNext;
+            *((T10*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15724,7 +17137,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #11 in the chain.
     /// </summary>
-    public ref T11 Item11 => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public T11 Item11
+    {
+        get => Unsafe.AsRef<T11>(Item11Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item11Ptr;
+            var nextPtr = ptr->PNext;
+            *((T11*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15734,7 +17162,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #12 in the chain.
     /// </summary>
-    public ref T12 Item12 => ref Unsafe.AsRef<T12>(Item12Ptr);
+    public T12 Item12
+    {
+        get => Unsafe.AsRef<T12>(Item12Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item12Ptr;
+            var nextPtr = ptr->PNext;
+            *((T12*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12}"/> with 13 items from an existing memory block.
@@ -16515,7 +17958,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 14 in the structure chain.
     /// </summary>
-    ref T13 Item13 { get; }
+    T13 Item13 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 14 in the structure chain.
+    /// </summary>
+    ref T13 Item13Ref { get; }
 }
 
 /// <summary>
@@ -16707,7 +18155,23 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16717,7 +18181,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16727,7 +18206,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public T2 Item2
+    {
+        get => Unsafe.AsRef<T2>(Item2Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item2Ptr;
+            var nextPtr = ptr->PNext;
+            *((T2*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16737,7 +18231,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public T3 Item3
+    {
+        get => Unsafe.AsRef<T3>(Item3Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item3Ptr;
+            var nextPtr = ptr->PNext;
+            *((T3*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16747,7 +18256,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public T4 Item4
+    {
+        get => Unsafe.AsRef<T4>(Item4Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item4Ptr;
+            var nextPtr = ptr->PNext;
+            *((T4*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16757,7 +18281,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public T5 Item5
+    {
+        get => Unsafe.AsRef<T5>(Item5Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item5Ptr;
+            var nextPtr = ptr->PNext;
+            *((T5*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16767,7 +18306,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public T6 Item6
+    {
+        get => Unsafe.AsRef<T6>(Item6Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item6Ptr;
+            var nextPtr = ptr->PNext;
+            *((T6*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16777,7 +18331,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public T7 Item7
+    {
+        get => Unsafe.AsRef<T7>(Item7Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item7Ptr;
+            var nextPtr = ptr->PNext;
+            *((T7*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16787,7 +18356,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public T8 Item8
+    {
+        get => Unsafe.AsRef<T8>(Item8Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item8Ptr;
+            var nextPtr = ptr->PNext;
+            *((T8*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16797,7 +18381,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #9 in the chain.
     /// </summary>
-    public ref T9 Item9 => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public T9 Item9
+    {
+        get => Unsafe.AsRef<T9>(Item9Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item9Ptr;
+            var nextPtr = ptr->PNext;
+            *((T9*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16807,7 +18406,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #10 in the chain.
     /// </summary>
-    public ref T10 Item10 => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public T10 Item10
+    {
+        get => Unsafe.AsRef<T10>(Item10Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item10Ptr;
+            var nextPtr = ptr->PNext;
+            *((T10*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16817,7 +18431,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #11 in the chain.
     /// </summary>
-    public ref T11 Item11 => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public T11 Item11
+    {
+        get => Unsafe.AsRef<T11>(Item11Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item11Ptr;
+            var nextPtr = ptr->PNext;
+            *((T11*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16827,7 +18456,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #12 in the chain.
     /// </summary>
-    public ref T12 Item12 => ref Unsafe.AsRef<T12>(Item12Ptr);
+    public T12 Item12
+    {
+        get => Unsafe.AsRef<T12>(Item12Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item12Ptr;
+            var nextPtr = ptr->PNext;
+            *((T12*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16837,7 +18481,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #13 in the chain.
     /// </summary>
-    public ref T13 Item13 => ref Unsafe.AsRef<T13>(Item13Ptr);
+    public T13 Item13
+    {
+        get => Unsafe.AsRef<T13>(Item13Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item13Ptr;
+            var nextPtr = ptr->PNext;
+            *((T13*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13}"/> with 14 items from an existing memory block.
@@ -17652,7 +19311,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 15 in the structure chain.
     /// </summary>
-    ref T14 Item14 { get; }
+    T14 Item14 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 15 in the structure chain.
+    /// </summary>
+    ref T14 Item14Ref { get; }
 }
 
 /// <summary>
@@ -17856,7 +19520,23 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17866,7 +19546,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17876,7 +19571,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public T2 Item2
+    {
+        get => Unsafe.AsRef<T2>(Item2Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item2Ptr;
+            var nextPtr = ptr->PNext;
+            *((T2*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17886,7 +19596,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public T3 Item3
+    {
+        get => Unsafe.AsRef<T3>(Item3Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item3Ptr;
+            var nextPtr = ptr->PNext;
+            *((T3*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17896,7 +19621,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public T4 Item4
+    {
+        get => Unsafe.AsRef<T4>(Item4Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item4Ptr;
+            var nextPtr = ptr->PNext;
+            *((T4*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17906,7 +19646,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public T5 Item5
+    {
+        get => Unsafe.AsRef<T5>(Item5Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item5Ptr;
+            var nextPtr = ptr->PNext;
+            *((T5*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17916,7 +19671,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public T6 Item6
+    {
+        get => Unsafe.AsRef<T6>(Item6Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item6Ptr;
+            var nextPtr = ptr->PNext;
+            *((T6*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17926,7 +19696,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public T7 Item7
+    {
+        get => Unsafe.AsRef<T7>(Item7Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item7Ptr;
+            var nextPtr = ptr->PNext;
+            *((T7*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17936,7 +19721,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public T8 Item8
+    {
+        get => Unsafe.AsRef<T8>(Item8Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item8Ptr;
+            var nextPtr = ptr->PNext;
+            *((T8*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17946,7 +19746,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #9 in the chain.
     /// </summary>
-    public ref T9 Item9 => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public T9 Item9
+    {
+        get => Unsafe.AsRef<T9>(Item9Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item9Ptr;
+            var nextPtr = ptr->PNext;
+            *((T9*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17956,7 +19771,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #10 in the chain.
     /// </summary>
-    public ref T10 Item10 => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public T10 Item10
+    {
+        get => Unsafe.AsRef<T10>(Item10Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item10Ptr;
+            var nextPtr = ptr->PNext;
+            *((T10*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17966,7 +19796,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #11 in the chain.
     /// </summary>
-    public ref T11 Item11 => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public T11 Item11
+    {
+        get => Unsafe.AsRef<T11>(Item11Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item11Ptr;
+            var nextPtr = ptr->PNext;
+            *((T11*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17976,7 +19821,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #12 in the chain.
     /// </summary>
-    public ref T12 Item12 => ref Unsafe.AsRef<T12>(Item12Ptr);
+    public T12 Item12
+    {
+        get => Unsafe.AsRef<T12>(Item12Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item12Ptr;
+            var nextPtr = ptr->PNext;
+            *((T12*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17986,7 +19846,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #13 in the chain.
     /// </summary>
-    public ref T13 Item13 => ref Unsafe.AsRef<T13>(Item13Ptr);
+    public T13 Item13
+    {
+        get => Unsafe.AsRef<T13>(Item13Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item13Ptr;
+            var nextPtr = ptr->PNext;
+            *((T13*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17996,7 +19871,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #14 in the chain.
     /// </summary>
-    public ref T14 Item14 => ref Unsafe.AsRef<T14>(Item14Ptr);
+    public T14 Item14
+    {
+        get => Unsafe.AsRef<T14>(Item14Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item14Ptr;
+            var nextPtr = ptr->PNext;
+            *((T14*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T14 Item14Ref => ref Unsafe.AsRef<T14>(Item14Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14}"/> with 15 items from an existing memory block.
@@ -18845,7 +20735,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 16 in the structure chain.
     /// </summary>
-    ref T15 Item15 { get; }
+    T15 Item15 { get; set; } 
+
+    /// <summary>
+    /// A reference to structure no. 16 in the structure chain.
+    /// </summary>
+    ref T15 Item15Ref { get; }
 }
 
 /// <summary>
@@ -19061,7 +20956,23 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19071,7 +20982,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public T1 Item1
+    {
+        get => Unsafe.AsRef<T1>(Item1Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item1Ptr;
+            var nextPtr = ptr->PNext;
+            *((T1*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19081,7 +21007,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public T2 Item2
+    {
+        get => Unsafe.AsRef<T2>(Item2Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item2Ptr;
+            var nextPtr = ptr->PNext;
+            *((T2*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19091,7 +21032,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public T3 Item3
+    {
+        get => Unsafe.AsRef<T3>(Item3Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item3Ptr;
+            var nextPtr = ptr->PNext;
+            *((T3*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19101,7 +21057,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public T4 Item4
+    {
+        get => Unsafe.AsRef<T4>(Item4Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item4Ptr;
+            var nextPtr = ptr->PNext;
+            *((T4*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19111,7 +21082,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public T5 Item5
+    {
+        get => Unsafe.AsRef<T5>(Item5Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item5Ptr;
+            var nextPtr = ptr->PNext;
+            *((T5*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19121,7 +21107,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public T6 Item6
+    {
+        get => Unsafe.AsRef<T6>(Item6Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item6Ptr;
+            var nextPtr = ptr->PNext;
+            *((T6*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19131,7 +21132,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public T7 Item7
+    {
+        get => Unsafe.AsRef<T7>(Item7Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item7Ptr;
+            var nextPtr = ptr->PNext;
+            *((T7*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19141,7 +21157,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public T8 Item8
+    {
+        get => Unsafe.AsRef<T8>(Item8Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item8Ptr;
+            var nextPtr = ptr->PNext;
+            *((T8*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19151,7 +21182,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #9 in the chain.
     /// </summary>
-    public ref T9 Item9 => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public T9 Item9
+    {
+        get => Unsafe.AsRef<T9>(Item9Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item9Ptr;
+            var nextPtr = ptr->PNext;
+            *((T9*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19161,7 +21207,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #10 in the chain.
     /// </summary>
-    public ref T10 Item10 => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public T10 Item10
+    {
+        get => Unsafe.AsRef<T10>(Item10Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item10Ptr;
+            var nextPtr = ptr->PNext;
+            *((T10*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19171,7 +21232,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #11 in the chain.
     /// </summary>
-    public ref T11 Item11 => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public T11 Item11
+    {
+        get => Unsafe.AsRef<T11>(Item11Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item11Ptr;
+            var nextPtr = ptr->PNext;
+            *((T11*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19181,7 +21257,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #12 in the chain.
     /// </summary>
-    public ref T12 Item12 => ref Unsafe.AsRef<T12>(Item12Ptr);
+    public T12 Item12
+    {
+        get => Unsafe.AsRef<T12>(Item12Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item12Ptr;
+            var nextPtr = ptr->PNext;
+            *((T12*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19191,7 +21282,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #13 in the chain.
     /// </summary>
-    public ref T13 Item13 => ref Unsafe.AsRef<T13>(Item13Ptr);
+    public T13 Item13
+    {
+        get => Unsafe.AsRef<T13>(Item13Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item13Ptr;
+            var nextPtr = ptr->PNext;
+            *((T13*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19201,7 +21307,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #14 in the chain.
     /// </summary>
-    public ref T14 Item14 => ref Unsafe.AsRef<T14>(Item14Ptr);
+    public T14 Item14
+    {
+        get => Unsafe.AsRef<T14>(Item14Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item14Ptr;
+            var nextPtr = ptr->PNext;
+            *((T14*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T14 Item14Ref => ref Unsafe.AsRef<T14>(Item14Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19211,7 +21332,22 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #15 in the chain.
     /// </summary>
-    public ref T15 Item15 => ref Unsafe.AsRef<T15>(Item15Ptr);
+    public T15 Item15
+    {
+        get => Unsafe.AsRef<T15>(Item15Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item15Ptr;
+            var nextPtr = ptr->PNext;
+            *((T15*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T15 Item15Ref => ref Unsafe.AsRef<T15>(Item15Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15}"/> with 16 items from an existing memory block.

--- a/src/Vulkan/Silk.NET.Vulkan/Chain.g.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/Chain.g.cs
@@ -6908,12 +6908,7 @@ public interface IChain<TChain> : IDisposable, IReadOnlyList<IChainable>
     /// <summary>
     /// The first structure in the structure chain.
     /// </summary>
-    TChain Head { get; set; }
-
-    /// <summary>
-    /// A reference to the first structure in the chain.
-    /// </summary>
-    ref TChain HeadRef { get; }
+    ref TChain Head { get; }
 }
 
 /// <summary>
@@ -6949,23 +6944,7 @@ public unsafe sealed class Chain<TChain> : Chain, IEquatable<Chain<TChain>>, ICh
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain}"/> with 1 items from an existing memory block.
@@ -7260,12 +7239,7 @@ public interface IChain<TChain, T1> : IChain<TChain>
     /// <summary>
     /// Structure no. 2 in the structure chain.
     /// </summary>
-    T1 Item1 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 2 in the structure chain.
-    /// </summary>
-    ref T1 Item1Ref { get; }
+    ref T1 Item1 { get; }
 }
 
 /// <summary>
@@ -7313,23 +7287,7 @@ public unsafe sealed class Chain<TChain, T1> : Chain, IEquatable<Chain<TChain, T
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -7339,22 +7297,7 @@ public unsafe sealed class Chain<TChain, T1> : Chain, IEquatable<Chain<TChain, T
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1}"/> with 2 items from an existing memory block.
@@ -7761,12 +7704,7 @@ public interface IChain<TChain, T1, T2> : IChain<TChain, T1>
     /// <summary>
     /// Structure no. 3 in the structure chain.
     /// </summary>
-    T2 Item2 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 3 in the structure chain.
-    /// </summary>
-    ref T2 Item2Ref { get; }
+    ref T2 Item2 { get; }
 }
 
 /// <summary>
@@ -7826,23 +7764,7 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -7852,22 +7774,7 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -7877,22 +7784,7 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public T2 Item2
-    {
-        get => Unsafe.AsRef<T2>(Item2Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item2Ptr;
-            var nextPtr = ptr->PNext;
-            *((T2*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2}"/> with 3 items from an existing memory block.
@@ -8333,12 +8225,7 @@ public interface IChain<TChain, T1, T2, T3> : IChain<TChain, T1, T2>
     /// <summary>
     /// Structure no. 4 in the structure chain.
     /// </summary>
-    T3 Item3 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 4 in the structure chain.
-    /// </summary>
-    ref T3 Item3Ref { get; }
+    ref T3 Item3 { get; }
 }
 
 /// <summary>
@@ -8410,23 +8297,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -8436,22 +8307,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -8461,22 +8317,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public T2 Item2
-    {
-        get => Unsafe.AsRef<T2>(Item2Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item2Ptr;
-            var nextPtr = ptr->PNext;
-            *((T2*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -8486,22 +8327,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public T3 Item3
-    {
-        get => Unsafe.AsRef<T3>(Item3Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item3Ptr;
-            var nextPtr = ptr->PNext;
-            *((T3*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3}"/> with 4 items from an existing memory block.
@@ -8976,12 +8802,7 @@ public interface IChain<TChain, T1, T2, T3, T4> : IChain<TChain, T1, T2, T3>
     /// <summary>
     /// Structure no. 5 in the structure chain.
     /// </summary>
-    T4 Item4 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 5 in the structure chain.
-    /// </summary>
-    ref T4 Item4Ref { get; }
+    ref T4 Item4 { get; }
 }
 
 /// <summary>
@@ -9065,23 +8886,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9091,22 +8896,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9116,22 +8906,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public T2 Item2
-    {
-        get => Unsafe.AsRef<T2>(Item2Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item2Ptr;
-            var nextPtr = ptr->PNext;
-            *((T2*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9141,22 +8916,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public T3 Item3
-    {
-        get => Unsafe.AsRef<T3>(Item3Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item3Ptr;
-            var nextPtr = ptr->PNext;
-            *((T3*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9166,22 +8926,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public T4 Item4
-    {
-        get => Unsafe.AsRef<T4>(Item4Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item4Ptr;
-            var nextPtr = ptr->PNext;
-            *((T4*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4}"/> with 5 items from an existing memory block.
@@ -9690,12 +9435,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5> : IChain<TChain, T1, T2, T3,
     /// <summary>
     /// Structure no. 6 in the structure chain.
     /// </summary>
-    T5 Item5 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 6 in the structure chain.
-    /// </summary>
-    ref T5 Item5Ref { get; }
+    ref T5 Item5 { get; }
 }
 
 /// <summary>
@@ -9791,23 +9531,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9817,22 +9541,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9842,22 +9551,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public T2 Item2
-    {
-        get => Unsafe.AsRef<T2>(Item2Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item2Ptr;
-            var nextPtr = ptr->PNext;
-            *((T2*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9867,22 +9561,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public T3 Item3
-    {
-        get => Unsafe.AsRef<T3>(Item3Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item3Ptr;
-            var nextPtr = ptr->PNext;
-            *((T3*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9892,22 +9571,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public T4 Item4
-    {
-        get => Unsafe.AsRef<T4>(Item4Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item4Ptr;
-            var nextPtr = ptr->PNext;
-            *((T4*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9917,22 +9581,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public T5 Item5
-    {
-        get => Unsafe.AsRef<T5>(Item5Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item5Ptr;
-            var nextPtr = ptr->PNext;
-            *((T5*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5}"/> with 6 items from an existing memory block.
@@ -10475,12 +10124,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6> : IChain<TChain, T1, T2,
     /// <summary>
     /// Structure no. 7 in the structure chain.
     /// </summary>
-    T6 Item6 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 7 in the structure chain.
-    /// </summary>
-    ref T6 Item6Ref { get; }
+    ref T6 Item6 { get; }
 }
 
 /// <summary>
@@ -10588,23 +10232,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10614,22 +10242,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10639,22 +10252,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public T2 Item2
-    {
-        get => Unsafe.AsRef<T2>(Item2Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item2Ptr;
-            var nextPtr = ptr->PNext;
-            *((T2*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10664,22 +10262,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public T3 Item3
-    {
-        get => Unsafe.AsRef<T3>(Item3Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item3Ptr;
-            var nextPtr = ptr->PNext;
-            *((T3*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10689,22 +10272,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public T4 Item4
-    {
-        get => Unsafe.AsRef<T4>(Item4Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item4Ptr;
-            var nextPtr = ptr->PNext;
-            *((T4*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10714,22 +10282,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public T5 Item5
-    {
-        get => Unsafe.AsRef<T5>(Item5Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item5Ptr;
-            var nextPtr = ptr->PNext;
-            *((T5*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10739,22 +10292,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public T6 Item6
-    {
-        get => Unsafe.AsRef<T6>(Item6Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item6Ptr;
-            var nextPtr = ptr->PNext;
-            *((T6*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6}"/> with 7 items from an existing memory block.
@@ -11331,12 +10869,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7> : IChain<TChain, T1,
     /// <summary>
     /// Structure no. 8 in the structure chain.
     /// </summary>
-    T7 Item7 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 8 in the structure chain.
-    /// </summary>
-    ref T7 Item7Ref { get; }
+    ref T7 Item7 { get; }
 }
 
 /// <summary>
@@ -11456,23 +10989,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11482,22 +10999,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11507,22 +11009,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public T2 Item2
-    {
-        get => Unsafe.AsRef<T2>(Item2Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item2Ptr;
-            var nextPtr = ptr->PNext;
-            *((T2*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11532,22 +11019,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public T3 Item3
-    {
-        get => Unsafe.AsRef<T3>(Item3Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item3Ptr;
-            var nextPtr = ptr->PNext;
-            *((T3*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11557,22 +11029,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public T4 Item4
-    {
-        get => Unsafe.AsRef<T4>(Item4Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item4Ptr;
-            var nextPtr = ptr->PNext;
-            *((T4*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11582,22 +11039,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public T5 Item5
-    {
-        get => Unsafe.AsRef<T5>(Item5Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item5Ptr;
-            var nextPtr = ptr->PNext;
-            *((T5*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11607,22 +11049,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public T6 Item6
-    {
-        get => Unsafe.AsRef<T6>(Item6Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item6Ptr;
-            var nextPtr = ptr->PNext;
-            *((T6*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11632,22 +11059,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public T7 Item7
-    {
-        get => Unsafe.AsRef<T7>(Item7Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item7Ptr;
-            var nextPtr = ptr->PNext;
-            *((T7*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7}"/> with 8 items from an existing memory block.
@@ -12258,12 +11670,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : IChain<TChain,
     /// <summary>
     /// Structure no. 9 in the structure chain.
     /// </summary>
-    T8 Item8 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 9 in the structure chain.
-    /// </summary>
-    ref T8 Item8Ref { get; }
+    ref T8 Item8 { get; }
 }
 
 /// <summary>
@@ -12395,23 +11802,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12421,22 +11812,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12446,22 +11822,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public T2 Item2
-    {
-        get => Unsafe.AsRef<T2>(Item2Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item2Ptr;
-            var nextPtr = ptr->PNext;
-            *((T2*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12471,22 +11832,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public T3 Item3
-    {
-        get => Unsafe.AsRef<T3>(Item3Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item3Ptr;
-            var nextPtr = ptr->PNext;
-            *((T3*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12496,22 +11842,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public T4 Item4
-    {
-        get => Unsafe.AsRef<T4>(Item4Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item4Ptr;
-            var nextPtr = ptr->PNext;
-            *((T4*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12521,22 +11852,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public T5 Item5
-    {
-        get => Unsafe.AsRef<T5>(Item5Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item5Ptr;
-            var nextPtr = ptr->PNext;
-            *((T5*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12546,22 +11862,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public T6 Item6
-    {
-        get => Unsafe.AsRef<T6>(Item6Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item6Ptr;
-            var nextPtr = ptr->PNext;
-            *((T6*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12571,22 +11872,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public T7 Item7
-    {
-        get => Unsafe.AsRef<T7>(Item7Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item7Ptr;
-            var nextPtr = ptr->PNext;
-            *((T7*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12596,22 +11882,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public T8 Item8
-    {
-        get => Unsafe.AsRef<T8>(Item8Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item8Ptr;
-            var nextPtr = ptr->PNext;
-            *((T8*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8}"/> with 9 items from an existing memory block.
@@ -13256,12 +12527,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IChain<TCh
     /// <summary>
     /// Structure no. 10 in the structure chain.
     /// </summary>
-    T9 Item9 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 10 in the structure chain.
-    /// </summary>
-    ref T9 Item9Ref { get; }
+    ref T9 Item9 { get; }
 }
 
 /// <summary>
@@ -13405,23 +12671,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13431,22 +12681,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13456,22 +12691,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public T2 Item2
-    {
-        get => Unsafe.AsRef<T2>(Item2Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item2Ptr;
-            var nextPtr = ptr->PNext;
-            *((T2*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13481,22 +12701,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public T3 Item3
-    {
-        get => Unsafe.AsRef<T3>(Item3Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item3Ptr;
-            var nextPtr = ptr->PNext;
-            *((T3*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13506,22 +12711,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public T4 Item4
-    {
-        get => Unsafe.AsRef<T4>(Item4Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item4Ptr;
-            var nextPtr = ptr->PNext;
-            *((T4*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13531,22 +12721,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public T5 Item5
-    {
-        get => Unsafe.AsRef<T5>(Item5Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item5Ptr;
-            var nextPtr = ptr->PNext;
-            *((T5*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13556,22 +12731,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public T6 Item6
-    {
-        get => Unsafe.AsRef<T6>(Item6Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item6Ptr;
-            var nextPtr = ptr->PNext;
-            *((T6*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13581,22 +12741,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public T7 Item7
-    {
-        get => Unsafe.AsRef<T7>(Item7Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item7Ptr;
-            var nextPtr = ptr->PNext;
-            *((T7*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13606,22 +12751,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public T8 Item8
-    {
-        get => Unsafe.AsRef<T8>(Item8Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item8Ptr;
-            var nextPtr = ptr->PNext;
-            *((T8*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13631,22 +12761,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets or sets item #9 in the chain.
     /// </summary>
-    public T9 Item9
-    {
-        get => Unsafe.AsRef<T9>(Item9Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item9Ptr;
-            var nextPtr = ptr->PNext;
-            *((T9*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public ref T9 Item9 => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9}"/> with 10 items from an existing memory block.
@@ -14325,12 +13440,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IChai
     /// <summary>
     /// Structure no. 11 in the structure chain.
     /// </summary>
-    T10 Item10 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 11 in the structure chain.
-    /// </summary>
-    ref T10 Item10Ref { get; }
+    ref T10 Item10 { get; }
 }
 
 /// <summary>
@@ -14486,23 +13596,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14512,22 +13606,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14537,22 +13616,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public T2 Item2
-    {
-        get => Unsafe.AsRef<T2>(Item2Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item2Ptr;
-            var nextPtr = ptr->PNext;
-            *((T2*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14562,22 +13626,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public T3 Item3
-    {
-        get => Unsafe.AsRef<T3>(Item3Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item3Ptr;
-            var nextPtr = ptr->PNext;
-            *((T3*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14587,22 +13636,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public T4 Item4
-    {
-        get => Unsafe.AsRef<T4>(Item4Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item4Ptr;
-            var nextPtr = ptr->PNext;
-            *((T4*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14612,22 +13646,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public T5 Item5
-    {
-        get => Unsafe.AsRef<T5>(Item5Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item5Ptr;
-            var nextPtr = ptr->PNext;
-            *((T5*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14637,22 +13656,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public T6 Item6
-    {
-        get => Unsafe.AsRef<T6>(Item6Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item6Ptr;
-            var nextPtr = ptr->PNext;
-            *((T6*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14662,22 +13666,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public T7 Item7
-    {
-        get => Unsafe.AsRef<T7>(Item7Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item7Ptr;
-            var nextPtr = ptr->PNext;
-            *((T7*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14687,22 +13676,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public T8 Item8
-    {
-        get => Unsafe.AsRef<T8>(Item8Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item8Ptr;
-            var nextPtr = ptr->PNext;
-            *((T8*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14712,22 +13686,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #9 in the chain.
     /// </summary>
-    public T9 Item9
-    {
-        get => Unsafe.AsRef<T9>(Item9Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item9Ptr;
-            var nextPtr = ptr->PNext;
-            *((T9*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public ref T9 Item9 => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14737,22 +13696,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #10 in the chain.
     /// </summary>
-    public T10 Item10
-    {
-        get => Unsafe.AsRef<T10>(Item10Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item10Ptr;
-            var nextPtr = ptr->PNext;
-            *((T10*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public ref T10 Item10 => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10}"/> with 11 items from an existing memory block.
@@ -15465,12 +14409,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : 
     /// <summary>
     /// Structure no. 12 in the structure chain.
     /// </summary>
-    T11 Item11 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 12 in the structure chain.
-    /// </summary>
-    ref T11 Item11Ref { get; }
+    ref T11 Item11 { get; }
 }
 
 /// <summary>
@@ -15638,23 +14577,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15664,22 +14587,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15689,22 +14597,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public T2 Item2
-    {
-        get => Unsafe.AsRef<T2>(Item2Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item2Ptr;
-            var nextPtr = ptr->PNext;
-            *((T2*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15714,22 +14607,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public T3 Item3
-    {
-        get => Unsafe.AsRef<T3>(Item3Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item3Ptr;
-            var nextPtr = ptr->PNext;
-            *((T3*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15739,22 +14617,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public T4 Item4
-    {
-        get => Unsafe.AsRef<T4>(Item4Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item4Ptr;
-            var nextPtr = ptr->PNext;
-            *((T4*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15764,22 +14627,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public T5 Item5
-    {
-        get => Unsafe.AsRef<T5>(Item5Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item5Ptr;
-            var nextPtr = ptr->PNext;
-            *((T5*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15789,22 +14637,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public T6 Item6
-    {
-        get => Unsafe.AsRef<T6>(Item6Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item6Ptr;
-            var nextPtr = ptr->PNext;
-            *((T6*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15814,22 +14647,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public T7 Item7
-    {
-        get => Unsafe.AsRef<T7>(Item7Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item7Ptr;
-            var nextPtr = ptr->PNext;
-            *((T7*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15839,22 +14657,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public T8 Item8
-    {
-        get => Unsafe.AsRef<T8>(Item8Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item8Ptr;
-            var nextPtr = ptr->PNext;
-            *((T8*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15864,22 +14667,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #9 in the chain.
     /// </summary>
-    public T9 Item9
-    {
-        get => Unsafe.AsRef<T9>(Item9Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item9Ptr;
-            var nextPtr = ptr->PNext;
-            *((T9*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public ref T9 Item9 => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15889,22 +14677,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #10 in the chain.
     /// </summary>
-    public T10 Item10
-    {
-        get => Unsafe.AsRef<T10>(Item10Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item10Ptr;
-            var nextPtr = ptr->PNext;
-            *((T10*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public ref T10 Item10 => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15914,22 +14687,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #11 in the chain.
     /// </summary>
-    public T11 Item11
-    {
-        get => Unsafe.AsRef<T11>(Item11Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item11Ptr;
-            var nextPtr = ptr->PNext;
-            *((T11*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public ref T11 Item11 => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11}"/> with 12 items from an existing memory block.
@@ -16676,12 +15434,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 13 in the structure chain.
     /// </summary>
-    T12 Item12 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 13 in the structure chain.
-    /// </summary>
-    ref T12 Item12Ref { get; }
+    ref T12 Item12 { get; }
 }
 
 /// <summary>
@@ -16861,23 +15614,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16887,22 +15624,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16912,22 +15634,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public T2 Item2
-    {
-        get => Unsafe.AsRef<T2>(Item2Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item2Ptr;
-            var nextPtr = ptr->PNext;
-            *((T2*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16937,22 +15644,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public T3 Item3
-    {
-        get => Unsafe.AsRef<T3>(Item3Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item3Ptr;
-            var nextPtr = ptr->PNext;
-            *((T3*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16962,22 +15654,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public T4 Item4
-    {
-        get => Unsafe.AsRef<T4>(Item4Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item4Ptr;
-            var nextPtr = ptr->PNext;
-            *((T4*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16987,22 +15664,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public T5 Item5
-    {
-        get => Unsafe.AsRef<T5>(Item5Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item5Ptr;
-            var nextPtr = ptr->PNext;
-            *((T5*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17012,22 +15674,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public T6 Item6
-    {
-        get => Unsafe.AsRef<T6>(Item6Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item6Ptr;
-            var nextPtr = ptr->PNext;
-            *((T6*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17037,22 +15684,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public T7 Item7
-    {
-        get => Unsafe.AsRef<T7>(Item7Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item7Ptr;
-            var nextPtr = ptr->PNext;
-            *((T7*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17062,22 +15694,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public T8 Item8
-    {
-        get => Unsafe.AsRef<T8>(Item8Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item8Ptr;
-            var nextPtr = ptr->PNext;
-            *((T8*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17087,22 +15704,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #9 in the chain.
     /// </summary>
-    public T9 Item9
-    {
-        get => Unsafe.AsRef<T9>(Item9Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item9Ptr;
-            var nextPtr = ptr->PNext;
-            *((T9*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public ref T9 Item9 => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17112,22 +15714,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #10 in the chain.
     /// </summary>
-    public T10 Item10
-    {
-        get => Unsafe.AsRef<T10>(Item10Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item10Ptr;
-            var nextPtr = ptr->PNext;
-            *((T10*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public ref T10 Item10 => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17137,22 +15724,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #11 in the chain.
     /// </summary>
-    public T11 Item11
-    {
-        get => Unsafe.AsRef<T11>(Item11Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item11Ptr;
-            var nextPtr = ptr->PNext;
-            *((T11*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public ref T11 Item11 => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17162,22 +15734,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #12 in the chain.
     /// </summary>
-    public T12 Item12
-    {
-        get => Unsafe.AsRef<T12>(Item12Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item12Ptr;
-            var nextPtr = ptr->PNext;
-            *((T12*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
+    public ref T12 Item12 => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12}"/> with 13 items from an existing memory block.
@@ -17958,12 +16515,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 14 in the structure chain.
     /// </summary>
-    T13 Item13 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 14 in the structure chain.
-    /// </summary>
-    ref T13 Item13Ref { get; }
+    ref T13 Item13 { get; }
 }
 
 /// <summary>
@@ -18155,23 +16707,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18181,22 +16717,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18206,22 +16727,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public T2 Item2
-    {
-        get => Unsafe.AsRef<T2>(Item2Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item2Ptr;
-            var nextPtr = ptr->PNext;
-            *((T2*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18231,22 +16737,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public T3 Item3
-    {
-        get => Unsafe.AsRef<T3>(Item3Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item3Ptr;
-            var nextPtr = ptr->PNext;
-            *((T3*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18256,22 +16747,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public T4 Item4
-    {
-        get => Unsafe.AsRef<T4>(Item4Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item4Ptr;
-            var nextPtr = ptr->PNext;
-            *((T4*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18281,22 +16757,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public T5 Item5
-    {
-        get => Unsafe.AsRef<T5>(Item5Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item5Ptr;
-            var nextPtr = ptr->PNext;
-            *((T5*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18306,22 +16767,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public T6 Item6
-    {
-        get => Unsafe.AsRef<T6>(Item6Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item6Ptr;
-            var nextPtr = ptr->PNext;
-            *((T6*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18331,22 +16777,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public T7 Item7
-    {
-        get => Unsafe.AsRef<T7>(Item7Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item7Ptr;
-            var nextPtr = ptr->PNext;
-            *((T7*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18356,22 +16787,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public T8 Item8
-    {
-        get => Unsafe.AsRef<T8>(Item8Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item8Ptr;
-            var nextPtr = ptr->PNext;
-            *((T8*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18381,22 +16797,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #9 in the chain.
     /// </summary>
-    public T9 Item9
-    {
-        get => Unsafe.AsRef<T9>(Item9Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item9Ptr;
-            var nextPtr = ptr->PNext;
-            *((T9*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public ref T9 Item9 => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18406,22 +16807,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #10 in the chain.
     /// </summary>
-    public T10 Item10
-    {
-        get => Unsafe.AsRef<T10>(Item10Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item10Ptr;
-            var nextPtr = ptr->PNext;
-            *((T10*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public ref T10 Item10 => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18431,22 +16817,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #11 in the chain.
     /// </summary>
-    public T11 Item11
-    {
-        get => Unsafe.AsRef<T11>(Item11Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item11Ptr;
-            var nextPtr = ptr->PNext;
-            *((T11*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public ref T11 Item11 => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18456,22 +16827,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #12 in the chain.
     /// </summary>
-    public T12 Item12
-    {
-        get => Unsafe.AsRef<T12>(Item12Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item12Ptr;
-            var nextPtr = ptr->PNext;
-            *((T12*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
+    public ref T12 Item12 => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18481,22 +16837,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #13 in the chain.
     /// </summary>
-    public T13 Item13
-    {
-        get => Unsafe.AsRef<T13>(Item13Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item13Ptr;
-            var nextPtr = ptr->PNext;
-            *((T13*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
+    public ref T13 Item13 => ref Unsafe.AsRef<T13>(Item13Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13}"/> with 14 items from an existing memory block.
@@ -19311,12 +17652,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 15 in the structure chain.
     /// </summary>
-    T14 Item14 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 15 in the structure chain.
-    /// </summary>
-    ref T14 Item14Ref { get; }
+    ref T14 Item14 { get; }
 }
 
 /// <summary>
@@ -19520,23 +17856,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19546,22 +17866,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19571,22 +17876,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public T2 Item2
-    {
-        get => Unsafe.AsRef<T2>(Item2Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item2Ptr;
-            var nextPtr = ptr->PNext;
-            *((T2*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19596,22 +17886,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public T3 Item3
-    {
-        get => Unsafe.AsRef<T3>(Item3Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item3Ptr;
-            var nextPtr = ptr->PNext;
-            *((T3*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19621,22 +17896,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public T4 Item4
-    {
-        get => Unsafe.AsRef<T4>(Item4Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item4Ptr;
-            var nextPtr = ptr->PNext;
-            *((T4*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19646,22 +17906,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public T5 Item5
-    {
-        get => Unsafe.AsRef<T5>(Item5Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item5Ptr;
-            var nextPtr = ptr->PNext;
-            *((T5*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19671,22 +17916,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public T6 Item6
-    {
-        get => Unsafe.AsRef<T6>(Item6Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item6Ptr;
-            var nextPtr = ptr->PNext;
-            *((T6*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19696,22 +17926,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public T7 Item7
-    {
-        get => Unsafe.AsRef<T7>(Item7Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item7Ptr;
-            var nextPtr = ptr->PNext;
-            *((T7*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19721,22 +17936,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public T8 Item8
-    {
-        get => Unsafe.AsRef<T8>(Item8Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item8Ptr;
-            var nextPtr = ptr->PNext;
-            *((T8*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19746,22 +17946,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #9 in the chain.
     /// </summary>
-    public T9 Item9
-    {
-        get => Unsafe.AsRef<T9>(Item9Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item9Ptr;
-            var nextPtr = ptr->PNext;
-            *((T9*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public ref T9 Item9 => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19771,22 +17956,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #10 in the chain.
     /// </summary>
-    public T10 Item10
-    {
-        get => Unsafe.AsRef<T10>(Item10Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item10Ptr;
-            var nextPtr = ptr->PNext;
-            *((T10*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public ref T10 Item10 => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19796,22 +17966,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #11 in the chain.
     /// </summary>
-    public T11 Item11
-    {
-        get => Unsafe.AsRef<T11>(Item11Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item11Ptr;
-            var nextPtr = ptr->PNext;
-            *((T11*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public ref T11 Item11 => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19821,22 +17976,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #12 in the chain.
     /// </summary>
-    public T12 Item12
-    {
-        get => Unsafe.AsRef<T12>(Item12Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item12Ptr;
-            var nextPtr = ptr->PNext;
-            *((T12*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
+    public ref T12 Item12 => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19846,22 +17986,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #13 in the chain.
     /// </summary>
-    public T13 Item13
-    {
-        get => Unsafe.AsRef<T13>(Item13Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item13Ptr;
-            var nextPtr = ptr->PNext;
-            *((T13*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
+    public ref T13 Item13 => ref Unsafe.AsRef<T13>(Item13Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19871,22 +17996,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #14 in the chain.
     /// </summary>
-    public T14 Item14
-    {
-        get => Unsafe.AsRef<T14>(Item14Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item14Ptr;
-            var nextPtr = ptr->PNext;
-            *((T14*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T14 Item14Ref => ref Unsafe.AsRef<T14>(Item14Ptr);
+    public ref T14 Item14 => ref Unsafe.AsRef<T14>(Item14Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14}"/> with 15 items from an existing memory block.
@@ -20735,12 +18845,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 16 in the structure chain.
     /// </summary>
-    T15 Item15 { get; set; } 
-
-    /// <summary>
-    /// A reference to structure no. 16 in the structure chain.
-    /// </summary>
-    ref T15 Item15Ref { get; }
+    ref T15 Item15 { get; }
 }
 
 /// <summary>
@@ -20956,23 +19061,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -20982,22 +19071,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #1 in the chain.
     /// </summary>
-    public T1 Item1
-    {
-        get => Unsafe.AsRef<T1>(Item1Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item1Ptr;
-            var nextPtr = ptr->PNext;
-            *((T1*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref T1 Item1 => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21007,22 +19081,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #2 in the chain.
     /// </summary>
-    public T2 Item2
-    {
-        get => Unsafe.AsRef<T2>(Item2Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item2Ptr;
-            var nextPtr = ptr->PNext;
-            *((T2*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref T2 Item2 => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21032,22 +19091,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #3 in the chain.
     /// </summary>
-    public T3 Item3
-    {
-        get => Unsafe.AsRef<T3>(Item3Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item3Ptr;
-            var nextPtr = ptr->PNext;
-            *((T3*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref T3 Item3 => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21057,22 +19101,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #4 in the chain.
     /// </summary>
-    public T4 Item4
-    {
-        get => Unsafe.AsRef<T4>(Item4Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item4Ptr;
-            var nextPtr = ptr->PNext;
-            *((T4*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref T4 Item4 => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21082,22 +19111,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #5 in the chain.
     /// </summary>
-    public T5 Item5
-    {
-        get => Unsafe.AsRef<T5>(Item5Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item5Ptr;
-            var nextPtr = ptr->PNext;
-            *((T5*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref T5 Item5 => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21107,22 +19121,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #6 in the chain.
     /// </summary>
-    public T6 Item6
-    {
-        get => Unsafe.AsRef<T6>(Item6Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item6Ptr;
-            var nextPtr = ptr->PNext;
-            *((T6*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref T6 Item6 => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21132,22 +19131,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #7 in the chain.
     /// </summary>
-    public T7 Item7
-    {
-        get => Unsafe.AsRef<T7>(Item7Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item7Ptr;
-            var nextPtr = ptr->PNext;
-            *((T7*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref T7 Item7 => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21157,22 +19141,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #8 in the chain.
     /// </summary>
-    public T8 Item8
-    {
-        get => Unsafe.AsRef<T8>(Item8Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item8Ptr;
-            var nextPtr = ptr->PNext;
-            *((T8*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref T8 Item8 => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21182,22 +19151,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #9 in the chain.
     /// </summary>
-    public T9 Item9
-    {
-        get => Unsafe.AsRef<T9>(Item9Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item9Ptr;
-            var nextPtr = ptr->PNext;
-            *((T9*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public ref T9 Item9 => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21207,22 +19161,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #10 in the chain.
     /// </summary>
-    public T10 Item10
-    {
-        get => Unsafe.AsRef<T10>(Item10Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item10Ptr;
-            var nextPtr = ptr->PNext;
-            *((T10*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public ref T10 Item10 => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21232,22 +19171,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #11 in the chain.
     /// </summary>
-    public T11 Item11
-    {
-        get => Unsafe.AsRef<T11>(Item11Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item11Ptr;
-            var nextPtr = ptr->PNext;
-            *((T11*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public ref T11 Item11 => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21257,22 +19181,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #12 in the chain.
     /// </summary>
-    public T12 Item12
-    {
-        get => Unsafe.AsRef<T12>(Item12Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item12Ptr;
-            var nextPtr = ptr->PNext;
-            *((T12*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
+    public ref T12 Item12 => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21282,22 +19191,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #13 in the chain.
     /// </summary>
-    public T13 Item13
-    {
-        get => Unsafe.AsRef<T13>(Item13Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item13Ptr;
-            var nextPtr = ptr->PNext;
-            *((T13*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
+    public ref T13 Item13 => ref Unsafe.AsRef<T13>(Item13Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21307,22 +19201,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #14 in the chain.
     /// </summary>
-    public T14 Item14
-    {
-        get => Unsafe.AsRef<T14>(Item14Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item14Ptr;
-            var nextPtr = ptr->PNext;
-            *((T14*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T14 Item14Ref => ref Unsafe.AsRef<T14>(Item14Ptr);
+    public ref T14 Item14 => ref Unsafe.AsRef<T14>(Item14Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21332,22 +19211,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets or sets item #15 in the chain.
     /// </summary>
-    public T15 Item15
-    {
-        get => Unsafe.AsRef<T15>(Item15Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item15Ptr;
-            var nextPtr = ptr->PNext;
-            *((T15*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T15 Item15Ref => ref Unsafe.AsRef<T15>(Item15Ptr);
+    public ref T15 Item15 => ref Unsafe.AsRef<T15>(Item15Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15}"/> with 16 items from an existing memory block.

--- a/src/Vulkan/Silk.NET.Vulkan/Chain.g.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/Chain.g.cs
@@ -6913,7 +6913,7 @@ public interface IChain<TChain> : IDisposable, IReadOnlyList<IChainable>
     /// <summary>
     /// A reference to the first structure in the chain.
     /// </summary>
-    ref TChain HeadRef { get; }
+    ref readonly TChain HeadRef { get; }
 }
 
 /// <summary>
@@ -6965,7 +6965,7 @@ public unsafe sealed class Chain<TChain> : Chain, IEquatable<Chain<TChain>>, ICh
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain}"/> with 1 items from an existing memory block.
@@ -7260,12 +7260,12 @@ public interface IChain<TChain, T1> : IChain<TChain>
     /// <summary>
     /// Structure no. 2 in the structure chain.
     /// </summary>
-    T1 Item1 { get; set; } 
+    T1 Item1 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 2 in the structure chain.
     /// </summary>
-    ref T1 Item1Ref { get; }
+    ref readonly T1 Item1Ref { get; }
 }
 
 /// <summary>
@@ -7329,7 +7329,7 @@ public unsafe sealed class Chain<TChain, T1> : Chain, IEquatable<Chain<TChain, T
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -7354,7 +7354,7 @@ public unsafe sealed class Chain<TChain, T1> : Chain, IEquatable<Chain<TChain, T
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1}"/> with 2 items from an existing memory block.
@@ -7761,12 +7761,12 @@ public interface IChain<TChain, T1, T2> : IChain<TChain, T1>
     /// <summary>
     /// Structure no. 3 in the structure chain.
     /// </summary>
-    T2 Item2 { get; set; } 
+    T2 Item2 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 3 in the structure chain.
     /// </summary>
-    ref T2 Item2Ref { get; }
+    ref readonly T2 Item2Ref { get; }
 }
 
 /// <summary>
@@ -7842,7 +7842,7 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -7867,7 +7867,7 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -7892,7 +7892,7 @@ public unsafe sealed class Chain<TChain, T1, T2> : Chain, IEquatable<Chain<TChai
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref readonly T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2}"/> with 3 items from an existing memory block.
@@ -8333,12 +8333,12 @@ public interface IChain<TChain, T1, T2, T3> : IChain<TChain, T1, T2>
     /// <summary>
     /// Structure no. 4 in the structure chain.
     /// </summary>
-    T3 Item3 { get; set; } 
+    T3 Item3 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 4 in the structure chain.
     /// </summary>
-    ref T3 Item3Ref { get; }
+    ref readonly T3 Item3Ref { get; }
 }
 
 /// <summary>
@@ -8426,7 +8426,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -8451,7 +8451,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -8476,7 +8476,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref readonly T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -8501,7 +8501,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3> : Chain, IEquatable<Chain<T
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref readonly T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3}"/> with 4 items from an existing memory block.
@@ -8976,12 +8976,12 @@ public interface IChain<TChain, T1, T2, T3, T4> : IChain<TChain, T1, T2, T3>
     /// <summary>
     /// Structure no. 5 in the structure chain.
     /// </summary>
-    T4 Item4 { get; set; } 
+    T4 Item4 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 5 in the structure chain.
     /// </summary>
-    ref T4 Item4Ref { get; }
+    ref readonly T4 Item4Ref { get; }
 }
 
 /// <summary>
@@ -9081,7 +9081,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9106,7 +9106,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9131,7 +9131,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref readonly T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9156,7 +9156,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref readonly T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9181,7 +9181,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4> : Chain, IEquatable<Cha
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref readonly T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4}"/> with 5 items from an existing memory block.
@@ -9690,12 +9690,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5> : IChain<TChain, T1, T2, T3,
     /// <summary>
     /// Structure no. 6 in the structure chain.
     /// </summary>
-    T5 Item5 { get; set; } 
+    T5 Item5 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 6 in the structure chain.
     /// </summary>
-    ref T5 Item5Ref { get; }
+    ref readonly T5 Item5Ref { get; }
 }
 
 /// <summary>
@@ -9807,7 +9807,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9832,7 +9832,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9857,7 +9857,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref readonly T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9882,7 +9882,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref readonly T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9907,7 +9907,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref readonly T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -9932,7 +9932,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5> : Chain, IEquatable
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref readonly T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5}"/> with 6 items from an existing memory block.
@@ -10475,12 +10475,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6> : IChain<TChain, T1, T2,
     /// <summary>
     /// Structure no. 7 in the structure chain.
     /// </summary>
-    T6 Item6 { get; set; } 
+    T6 Item6 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 7 in the structure chain.
     /// </summary>
-    ref T6 Item6Ref { get; }
+    ref readonly T6 Item6Ref { get; }
 }
 
 /// <summary>
@@ -10604,7 +10604,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10629,7 +10629,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10654,7 +10654,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref readonly T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10679,7 +10679,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref readonly T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10704,7 +10704,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref readonly T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10729,7 +10729,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref readonly T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -10754,7 +10754,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6> : Chain, IEquat
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref readonly T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6}"/> with 7 items from an existing memory block.
@@ -11331,12 +11331,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7> : IChain<TChain, T1,
     /// <summary>
     /// Structure no. 8 in the structure chain.
     /// </summary>
-    T7 Item7 { get; set; } 
+    T7 Item7 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 8 in the structure chain.
     /// </summary>
-    ref T7 Item7Ref { get; }
+    ref readonly T7 Item7Ref { get; }
 }
 
 /// <summary>
@@ -11472,7 +11472,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11497,7 +11497,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11522,7 +11522,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref readonly T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11547,7 +11547,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref readonly T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11572,7 +11572,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref readonly T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11597,7 +11597,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref readonly T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11622,7 +11622,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref readonly T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -11647,7 +11647,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7> : Chain, IE
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref readonly T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7}"/> with 8 items from an existing memory block.
@@ -12258,12 +12258,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : IChain<TChain,
     /// <summary>
     /// Structure no. 9 in the structure chain.
     /// </summary>
-    T8 Item8 { get; set; } 
+    T8 Item8 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 9 in the structure chain.
     /// </summary>
-    ref T8 Item8Ref { get; }
+    ref readonly T8 Item8Ref { get; }
 }
 
 /// <summary>
@@ -12411,7 +12411,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12436,7 +12436,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12461,7 +12461,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref readonly T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12486,7 +12486,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref readonly T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12511,7 +12511,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref readonly T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12536,7 +12536,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref readonly T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12561,7 +12561,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref readonly T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12586,7 +12586,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref readonly T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -12611,7 +12611,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : Chain
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref readonly T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8}"/> with 9 items from an existing memory block.
@@ -13256,12 +13256,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IChain<TCh
     /// <summary>
     /// Structure no. 10 in the structure chain.
     /// </summary>
-    T9 Item9 { get; set; } 
+    T9 Item9 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 10 in the structure chain.
     /// </summary>
-    ref T9 Item9Ref { get; }
+    ref readonly T9 Item9Ref { get; }
 }
 
 /// <summary>
@@ -13421,7 +13421,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13446,7 +13446,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13471,7 +13471,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref readonly T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13496,7 +13496,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref readonly T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13521,7 +13521,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref readonly T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13546,7 +13546,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref readonly T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13571,7 +13571,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref readonly T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13596,7 +13596,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref readonly T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13621,7 +13621,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref readonly T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -13646,7 +13646,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : C
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public ref readonly T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9}"/> with 10 items from an existing memory block.
@@ -14325,12 +14325,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IChai
     /// <summary>
     /// Structure no. 11 in the structure chain.
     /// </summary>
-    T10 Item10 { get; set; } 
+    T10 Item10 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 11 in the structure chain.
     /// </summary>
-    ref T10 Item10Ref { get; }
+    ref readonly T10 Item10Ref { get; }
 }
 
 /// <summary>
@@ -14502,7 +14502,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14527,7 +14527,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14552,7 +14552,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref readonly T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14577,7 +14577,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref readonly T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14602,7 +14602,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref readonly T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14627,7 +14627,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref readonly T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14652,7 +14652,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref readonly T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14677,7 +14677,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref readonly T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14702,7 +14702,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref readonly T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14727,7 +14727,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public ref readonly T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -14752,7 +14752,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public ref readonly T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10}"/> with 11 items from an existing memory block.
@@ -15465,12 +15465,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : 
     /// <summary>
     /// Structure no. 12 in the structure chain.
     /// </summary>
-    T11 Item11 { get; set; } 
+    T11 Item11 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 12 in the structure chain.
     /// </summary>
-    ref T11 Item11Ref { get; }
+    ref readonly T11 Item11Ref { get; }
 }
 
 /// <summary>
@@ -15654,7 +15654,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15679,7 +15679,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15704,7 +15704,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref readonly T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15729,7 +15729,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref readonly T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15754,7 +15754,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref readonly T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15779,7 +15779,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref readonly T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15804,7 +15804,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref readonly T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15829,7 +15829,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref readonly T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15854,7 +15854,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref readonly T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15879,7 +15879,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public ref readonly T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15904,7 +15904,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public ref readonly T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -15929,7 +15929,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public ref readonly T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11}"/> with 12 items from an existing memory block.
@@ -16676,12 +16676,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 13 in the structure chain.
     /// </summary>
-    T12 Item12 { get; set; } 
+    T12 Item12 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 13 in the structure chain.
     /// </summary>
-    ref T12 Item12Ref { get; }
+    ref readonly T12 Item12Ref { get; }
 }
 
 /// <summary>
@@ -16877,7 +16877,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16902,7 +16902,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16927,7 +16927,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref readonly T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16952,7 +16952,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref readonly T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -16977,7 +16977,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref readonly T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17002,7 +17002,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref readonly T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17027,7 +17027,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref readonly T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17052,7 +17052,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref readonly T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17077,7 +17077,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref readonly T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17102,7 +17102,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public ref readonly T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17127,7 +17127,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public ref readonly T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17152,7 +17152,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public ref readonly T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -17177,7 +17177,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
+    public ref readonly T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12}"/> with 13 items from an existing memory block.
@@ -17958,12 +17958,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 14 in the structure chain.
     /// </summary>
-    T13 Item13 { get; set; } 
+    T13 Item13 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 14 in the structure chain.
     /// </summary>
-    ref T13 Item13Ref { get; }
+    ref readonly T13 Item13Ref { get; }
 }
 
 /// <summary>
@@ -18171,7 +18171,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18196,7 +18196,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18221,7 +18221,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref readonly T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18246,7 +18246,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref readonly T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18271,7 +18271,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref readonly T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18296,7 +18296,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref readonly T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18321,7 +18321,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref readonly T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18346,7 +18346,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref readonly T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18371,7 +18371,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref readonly T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18396,7 +18396,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public ref readonly T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18421,7 +18421,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public ref readonly T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18446,7 +18446,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public ref readonly T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18471,7 +18471,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
+    public ref readonly T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -18496,7 +18496,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
+    public ref readonly T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13}"/> with 14 items from an existing memory block.
@@ -19311,12 +19311,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 15 in the structure chain.
     /// </summary>
-    T14 Item14 { get; set; } 
+    T14 Item14 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 15 in the structure chain.
     /// </summary>
-    ref T14 Item14Ref { get; }
+    ref readonly T14 Item14Ref { get; }
 }
 
 /// <summary>
@@ -19536,7 +19536,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19561,7 +19561,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19586,7 +19586,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref readonly T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19611,7 +19611,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref readonly T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19636,7 +19636,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref readonly T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19661,7 +19661,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref readonly T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19686,7 +19686,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref readonly T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19711,7 +19711,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref readonly T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19736,7 +19736,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref readonly T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19761,7 +19761,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public ref readonly T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19786,7 +19786,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public ref readonly T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19811,7 +19811,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public ref readonly T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19836,7 +19836,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
+    public ref readonly T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19861,7 +19861,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
+    public ref readonly T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -19886,7 +19886,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T14 Item14Ref => ref Unsafe.AsRef<T14>(Item14Ptr);
+    public ref readonly T14 Item14Ref => ref Unsafe.AsRef<T14>(Item14Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14}"/> with 15 items from an existing memory block.
@@ -20735,12 +20735,12 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 16 in the structure chain.
     /// </summary>
-    T15 Item15 { get; set; } 
+    T15 Item15 { get; set; }
 
     /// <summary>
     /// A reference to structure no. 16 in the structure chain.
     /// </summary>
-    ref T15 Item15Ref { get; }
+    ref readonly T15 Item15Ref { get; }
 }
 
 /// <summary>
@@ -20972,7 +20972,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -20997,7 +20997,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
+    public ref readonly T1 Item1Ref => ref Unsafe.AsRef<T1>(Item1Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21022,7 +21022,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
+    public ref readonly T2 Item2Ref => ref Unsafe.AsRef<T2>(Item2Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21047,7 +21047,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
+    public ref readonly T3 Item3Ref => ref Unsafe.AsRef<T3>(Item3Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21072,7 +21072,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
+    public ref readonly T4 Item4Ref => ref Unsafe.AsRef<T4>(Item4Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21097,7 +21097,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
+    public ref readonly T5 Item5Ref => ref Unsafe.AsRef<T5>(Item5Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21122,7 +21122,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
+    public ref readonly T6 Item6Ref => ref Unsafe.AsRef<T6>(Item6Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21147,7 +21147,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
+    public ref readonly T7 Item7Ref => ref Unsafe.AsRef<T7>(Item7Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21172,7 +21172,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
+    public ref readonly T8 Item8Ref => ref Unsafe.AsRef<T8>(Item8Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21197,7 +21197,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
+    public ref readonly T9 Item9Ref => ref Unsafe.AsRef<T9>(Item9Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21222,7 +21222,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
+    public ref readonly T10 Item10Ref => ref Unsafe.AsRef<T10>(Item10Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21247,7 +21247,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
+    public ref readonly T11 Item11Ref => ref Unsafe.AsRef<T11>(Item11Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21272,7 +21272,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
+    public ref readonly T12 Item12Ref => ref Unsafe.AsRef<T12>(Item12Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21297,7 +21297,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
+    public ref readonly T13 Item13Ref => ref Unsafe.AsRef<T13>(Item13Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21322,7 +21322,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T14 Item14Ref => ref Unsafe.AsRef<T14>(Item14Ptr);
+    public ref readonly T14 Item14Ref => ref Unsafe.AsRef<T14>(Item14Ptr);
 
     /// <summary>
     /// Gets a pointer to the second item in the chain.
@@ -21347,7 +21347,7 @@ public unsafe sealed class Chain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T15 Item15Ref => ref Unsafe.AsRef<T15>(Item15Ptr);
+    public ref readonly T15 Item15Ref => ref Unsafe.AsRef<T15>(Item15Ptr);
 
     /// <summary>
     /// Creates a new <see cref="Chain{TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15}"/> with 16 items from an existing memory block.

--- a/src/Vulkan/Silk.NET.Vulkan/Chain.g.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/Chain.g.cs
@@ -6908,7 +6908,7 @@ public interface IChain<TChain> : IDisposable, IReadOnlyList<IChainable>
     /// <summary>
     /// The first structure in the structure chain.
     /// </summary>
-    TChain Head { get; }
+    TChain Head { get; set; }
 
     ref TChain HeadRef { get; }
 }
@@ -7254,7 +7254,7 @@ public interface IChain<TChain, T1> : IChain<TChain>
     /// <summary>
     /// Structure no. 2 in the structure chain.
     /// </summary>
-    T1 Item1 { get; }
+    T1 Item1 { get; set; }
 
     ref T1 Item1Ref { get; }
 }
@@ -7747,7 +7747,7 @@ public interface IChain<TChain, T1, T2> : IChain<TChain, T1>
     /// <summary>
     /// Structure no. 3 in the structure chain.
     /// </summary>
-    T2 Item2 { get; }
+    T2 Item2 { get; set; }
 
     ref T2 Item2Ref { get; }
 }
@@ -8309,7 +8309,7 @@ public interface IChain<TChain, T1, T2, T3> : IChain<TChain, T1, T2>
     /// <summary>
     /// Structure no. 4 in the structure chain.
     /// </summary>
-    T3 Item3 { get; }
+    T3 Item3 { get; set; }
 
     ref T3 Item3Ref { get; }
 }
@@ -8940,7 +8940,7 @@ public interface IChain<TChain, T1, T2, T3, T4> : IChain<TChain, T1, T2, T3>
     /// <summary>
     /// Structure no. 5 in the structure chain.
     /// </summary>
-    T4 Item4 { get; }
+    T4 Item4 { get; set; }
 
     ref T4 Item4Ref { get; }
 }
@@ -9640,7 +9640,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5> : IChain<TChain, T1, T2, T3,
     /// <summary>
     /// Structure no. 6 in the structure chain.
     /// </summary>
-    T5 Item5 { get; }
+    T5 Item5 { get; set; }
 
     ref T5 Item5Ref { get; }
 }
@@ -10409,7 +10409,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6> : IChain<TChain, T1, T2,
     /// <summary>
     /// Structure no. 7 in the structure chain.
     /// </summary>
-    T6 Item6 { get; }
+    T6 Item6 { get; set; }
 
     ref T6 Item6Ref { get; }
 }
@@ -11247,7 +11247,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7> : IChain<TChain, T1,
     /// <summary>
     /// Structure no. 8 in the structure chain.
     /// </summary>
-    T7 Item7 { get; }
+    T7 Item7 { get; set; }
 
     ref T7 Item7Ref { get; }
 }
@@ -12154,7 +12154,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8> : IChain<TChain,
     /// <summary>
     /// Structure no. 9 in the structure chain.
     /// </summary>
-    T8 Item8 { get; }
+    T8 Item8 { get; set; }
 
     ref T8 Item8Ref { get; }
 }
@@ -13130,7 +13130,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IChain<TCh
     /// <summary>
     /// Structure no. 10 in the structure chain.
     /// </summary>
-    T9 Item9 { get; }
+    T9 Item9 { get; set; }
 
     ref T9 Item9Ref { get; }
 }
@@ -14175,7 +14175,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IChai
     /// <summary>
     /// Structure no. 11 in the structure chain.
     /// </summary>
-    T10 Item10 { get; }
+    T10 Item10 { get; set; }
 
     ref T10 Item10Ref { get; }
 }
@@ -15289,7 +15289,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : 
     /// <summary>
     /// Structure no. 12 in the structure chain.
     /// </summary>
-    T11 Item11 { get; }
+    T11 Item11 { get; set; }
 
     ref T11 Item11Ref { get; }
 }
@@ -16472,7 +16472,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 13 in the structure chain.
     /// </summary>
-    T12 Item12 { get; }
+    T12 Item12 { get; set; }
 
     ref T12 Item12Ref { get; }
 }
@@ -17724,7 +17724,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 14 in the structure chain.
     /// </summary>
-    T13 Item13 { get; }
+    T13 Item13 { get; set; }
 
     ref T13 Item13Ref { get; }
 }
@@ -19045,7 +19045,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 15 in the structure chain.
     /// </summary>
-    T14 Item14 { get; }
+    T14 Item14 { get; set; }
 
     ref T14 Item14Ref { get; }
 }
@@ -20435,7 +20435,7 @@ public interface IChain<TChain, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
     /// <summary>
     /// Structure no. 16 in the structure chain.
     /// </summary>
-    T15 Item15 { get; }
+    T15 Item15 { get; set; }
 
     ref T15 Item15Ref { get; }
 }

--- a/src/Vulkan/Silk.NET.Vulkan/Chain.g.tt
+++ b/src/Vulkan/Silk.NET.Vulkan/Chain.g.tt
@@ -357,7 +357,7 @@ public interface IChain<<#= tList #>> : <#= iBaseList #>
     /// <summary>
     /// The first structure in the structure chain.
     /// </summary>
-    TChain Head { get; }
+    TChain Head { get; set; }
 
     ref TChain HeadRef { get; }
 <#
@@ -368,7 +368,7 @@ public interface IChain<<#= tList #>> : <#= iBaseList #>
     /// <summary>
     /// Structure no. <#= i #> in the structure chain.
     /// </summary>
-    T<#= iM1 #> Item<#= iM1 #> { get; }
+    T<#= iM1 #> Item<#= iM1 #> { get; set; }
 
     ref T<#= iM1 #> Item<#= iM1 #>Ref { get; }
 <#

--- a/src/Vulkan/Silk.NET.Vulkan/Chain.g.tt
+++ b/src/Vulkan/Silk.NET.Vulkan/Chain.g.tt
@@ -357,12 +357,7 @@ public interface IChain<<#= tList #>> : <#= iBaseList #>
     /// <summary>
     /// The first structure in the structure chain.
     /// </summary>
-    TChain Head { get; set; }
-
-    /// <summary>
-    /// A reference to the first structure in the chain.
-    /// </summary>
-    ref TChain HeadRef { get; }
+    ref TChain Head { get; }
 <#
     }
     else
@@ -371,12 +366,7 @@ public interface IChain<<#= tList #>> : <#= iBaseList #>
     /// <summary>
     /// Structure no. <#= i #> in the structure chain.
     /// </summary>
-    T<#= iM1 #> Item<#= iM1 #> { get; set; }
-
-    /// <summary>
-    /// A reference to structure no. <#= i #> in the structure chain.
-    /// </summary>
-    ref T<#= iM1 #> Item<#= iM1 #>Ref { get; }
+    ref T<#= iM1 #> Item<#= iM1 #> { get; }
 <#
     }
 #>
@@ -432,23 +422,7 @@ public unsafe sealed class Chain<<#= tList #>> : Chain, IEquatable<Chain<<#= tLi
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public TChain Head
-    {
-        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
-        set
-        {
-            value.StructureType();
-            var ptr = (BaseInStructure*) _headPtr;
-            var nextPtr = ptr->PNext;
-            *((TChain*)_headPtr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-
-    /// <summary>
-    /// Gets a reference to the head of the chain.
-    /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 <#
         for (var j = 1; j < i; j++)
         {
@@ -462,22 +436,7 @@ public unsafe sealed class Chain<<#= tList #>> : Chain, IEquatable<Chain<<#= tLi
     /// <summary>
     /// Gets or sets item #<#= j #> in the chain.
     /// </summary>
-    public T<#= j #> Item<#= j #>
-    {
-        get => Unsafe.AsRef<T<#= j #>>(Item<#= j #>Ptr);
-        set
-        {
-            value.StructureType();
-            var ptr = Item<#= j #>Ptr;
-            var nextPtr = ptr->PNext;
-            *((T<#= j #>*)ptr) = value;
-            ptr->PNext = nextPtr;
-        }
-    }
-    /// <summary>
-    /// Gets a reference to the second item in the chain.
-    /// </summary>
-    public ref T<#= j #> Item<#= j #>Ref => ref Unsafe.AsRef<T<#= j #>>(Item<#= j #>Ptr);
+    public ref T<#= j #> Item<#= j #> => ref Unsafe.AsRef<T<#= j #>>(Item<#= j #>Ptr);
 <#
         } // for (int j = 1; j < i; j++) {
 #>

--- a/src/Vulkan/Silk.NET.Vulkan/Chain.g.tt
+++ b/src/Vulkan/Silk.NET.Vulkan/Chain.g.tt
@@ -358,6 +358,8 @@ public interface IChain<<#= tList #>> : <#= iBaseList #>
     /// The first structure in the structure chain.
     /// </summary>
     TChain Head { get; }
+
+    ref TChain HeadRef { get; }
 <#
     }
     else
@@ -367,6 +369,8 @@ public interface IChain<<#= tList #>> : <#= iBaseList #>
     /// Structure no. <#= i #> in the structure chain.
     /// </summary>
     T<#= iM1 #> Item<#= iM1 #> { get; }
+
+    ref T<#= iM1 #> Item<#= iM1 #>Ref { get; }
 <#
     }
 #>
@@ -434,6 +438,8 @@ public unsafe sealed class Chain<<#= tList #>> : Chain, IEquatable<Chain<<#= tLi
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 <#
         for (var j = 1; j < i; j++)
         {
@@ -459,6 +465,8 @@ public unsafe sealed class Chain<<#= tList #>> : Chain, IEquatable<Chain<<#= tLi
             ptr->PNext = nextPtr;
         }
     }
+
+    public ref T<#= j #> Item<#= j #>Ref => ref Unsafe.AsRef<T<#= j #>>(Item<#= j #>Ptr);
 <#
         } // for (int j = 1; j < i; j++) {
 #>

--- a/src/Vulkan/Silk.NET.Vulkan/Chain.g.tt
+++ b/src/Vulkan/Silk.NET.Vulkan/Chain.g.tt
@@ -357,7 +357,12 @@ public interface IChain<<#= tList #>> : <#= iBaseList #>
     /// <summary>
     /// The first structure in the structure chain.
     /// </summary>
-    ref TChain Head { get; }
+    TChain Head { get; set; }
+
+    /// <summary>
+    /// A reference to the first structure in the chain.
+    /// </summary>
+    ref TChain HeadRef { get; }
 <#
     }
     else
@@ -366,7 +371,12 @@ public interface IChain<<#= tList #>> : <#= iBaseList #>
     /// <summary>
     /// Structure no. <#= i #> in the structure chain.
     /// </summary>
-    ref T<#= iM1 #> Item<#= iM1 #> { get; }
+    T<#= iM1 #> Item<#= iM1 #> { get; set; }
+
+    /// <summary>
+    /// A reference to structure no. <#= i #> in the structure chain.
+    /// </summary>
+    ref T<#= iM1 #> Item<#= iM1 #>Ref { get; }
 <#
     }
 #>
@@ -422,7 +432,23 @@ public unsafe sealed class Chain<<#= tList #>> : Chain, IEquatable<Chain<<#= tLi
     /// <summary>
     /// Gets or sets the head of the chain.
     /// </summary>
-    public ref TChain Head => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public TChain Head
+    {
+        get => Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+        set
+        {
+            value.StructureType();
+            var ptr = (BaseInStructure*) _headPtr;
+            var nextPtr = ptr->PNext;
+            *((TChain*)_headPtr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
+    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 <#
         for (var j = 1; j < i; j++)
         {
@@ -436,7 +462,22 @@ public unsafe sealed class Chain<<#= tList #>> : Chain, IEquatable<Chain<<#= tLi
     /// <summary>
     /// Gets or sets item #<#= j #> in the chain.
     /// </summary>
-    public ref T<#= j #> Item<#= j #> => ref Unsafe.AsRef<T<#= j #>>(Item<#= j #>Ptr);
+    public T<#= j #> Item<#= j #>
+    {
+        get => Unsafe.AsRef<T<#= j #>>(Item<#= j #>Ptr);
+        set
+        {
+            value.StructureType();
+            var ptr = Item<#= j #>Ptr;
+            var nextPtr = ptr->PNext;
+            *((T<#= j #>*)ptr) = value;
+            ptr->PNext = nextPtr;
+        }
+    }
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
+    public ref T<#= j #> Item<#= j #>Ref => ref Unsafe.AsRef<T<#= j #>>(Item<#= j #>Ptr);
 <#
         } // for (int j = 1; j < i; j++) {
 #>

--- a/src/Vulkan/Silk.NET.Vulkan/Chain.g.tt
+++ b/src/Vulkan/Silk.NET.Vulkan/Chain.g.tt
@@ -359,6 +359,9 @@ public interface IChain<<#= tList #>> : <#= iBaseList #>
     /// </summary>
     TChain Head { get; set; }
 
+    /// <summary>
+    /// A reference to the first structure in the chain.
+    /// </summary>
     ref TChain HeadRef { get; }
 <#
     }
@@ -370,6 +373,9 @@ public interface IChain<<#= tList #>> : <#= iBaseList #>
     /// </summary>
     T<#= iM1 #> Item<#= iM1 #> { get; set; }
 
+    /// <summary>
+    /// A reference to structure no. <#= i #> in the structure chain.
+    /// </summary>
     ref T<#= iM1 #> Item<#= iM1 #>Ref { get; }
 <#
     }
@@ -439,6 +445,9 @@ public unsafe sealed class Chain<<#= tList #>> : Chain, IEquatable<Chain<<#= tLi
         }
     }
 
+    /// <summary>
+    /// Gets a reference to the head of the chain.
+    /// </summary>
     public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 <#
         for (var j = 1; j < i; j++)
@@ -465,7 +474,9 @@ public unsafe sealed class Chain<<#= tList #>> : Chain, IEquatable<Chain<<#= tLi
             ptr->PNext = nextPtr;
         }
     }
-
+    /// <summary>
+    /// Gets a reference to the second item in the chain.
+    /// </summary>
     public ref T<#= j #> Item<#= j #>Ref => ref Unsafe.AsRef<T<#= j #>>(Item<#= j #>Ptr);
 <#
         } // for (int j = 1; j < i; j++) {

--- a/src/Vulkan/Silk.NET.Vulkan/Chain.g.tt
+++ b/src/Vulkan/Silk.NET.Vulkan/Chain.g.tt
@@ -362,7 +362,7 @@ public interface IChain<<#= tList #>> : <#= iBaseList #>
     /// <summary>
     /// A reference to the first structure in the chain.
     /// </summary>
-    ref TChain HeadRef { get; }
+    ref readonly TChain HeadRef { get; }
 <#
     }
     else
@@ -376,7 +376,7 @@ public interface IChain<<#= tList #>> : <#= iBaseList #>
     /// <summary>
     /// A reference to structure no. <#= i #> in the structure chain.
     /// </summary>
-    ref T<#= iM1 #> Item<#= iM1 #>Ref { get; }
+    ref readonly T<#= iM1 #> Item<#= iM1 #>Ref { get; }
 <#
     }
 #>
@@ -448,7 +448,7 @@ public unsafe sealed class Chain<<#= tList #>> : Chain, IEquatable<Chain<<#= tLi
     /// <summary>
     /// Gets a reference to the head of the chain.
     /// </summary>
-    public ref TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
+    public ref readonly TChain HeadRef => ref Unsafe.AsRef<TChain>((BaseInStructure*) _headPtr);
 <#
         for (var j = 1; j < i; j++)
         {
@@ -477,7 +477,7 @@ public unsafe sealed class Chain<<#= tList #>> : Chain, IEquatable<Chain<<#= tLi
     /// <summary>
     /// Gets a reference to the second item in the chain.
     /// </summary>
-    public ref T<#= j #> Item<#= j #>Ref => ref Unsafe.AsRef<T<#= j #>>(Item<#= j #>Ptr);
+    public ref readonly T<#= j #> Item<#= j #>Ref => ref Unsafe.AsRef<T<#= j #>>(Item<#= j #>Ptr);
 <#
         } // for (int j = 1; j < i; j++) {
 #>


### PR DESCRIPTION
# Summary of the PR
Adds HeadRef and ItemNRef to the managed Chain types in Silk.NET.Vulkan to support easier modification of properties on chain elements, as well as pulling the setters up to the interfaces.
