### PR TITLE
New experimental feed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,8 @@ on:
     # all branches
     paths-ignore:
       - 'documentation/**'
-  merge_group:
-      types: [checks_requested]
-      
+permissions:
+  packages: write
 jobs:
   Build:
     # This will:
@@ -79,9 +78,9 @@ jobs:
     - name: Sign Packages
       if: ${{ github.repository == 'dotnet/Silk.NET' && startsWith(github.ref, 'refs/tags/') }}
       run: .\build.cmd SignPackages --akv-certificate ${{ secrets.AKV_CERTIFICATE }} --akv-client-id ${{ secrets.AKV_CLIENT_ID }} --akv-client-secret ${{ secrets.AKV_CLIENT_SECRET }} --akv-tenant ${{ secrets.AKV_TENANT }} --akv-vault-url ${{ secrets.AKV_VAULT_URL }}
-    - name: Push to Azure Experimental Feed
+    - name: Push to Experimental Feed
       if: ${{ github.repository == 'dotnet/Silk.NET' && github.event_name != 'pull_request' }}
-      run: .\build.cmd PushToNuGet --skip Clean Restore Compile Pack --nuget-feed https://pkgs.dev.azure.com/UltzOS/Silk.NET/_packaging/Experimental/nuget/v3/index.json --nuget-username ${{ secrets.AZDO_ARTIFACTS_USERNAME }} --nuget-password ${{ secrets.AZDO_ARTIFACTS_TOKEN }} --nuget-api-key az
+      run: .\build.cmd PushToNuGet --skip Clean Restore Compile Pack --nuget-feed https://dotnet.github.io/Silk.NET/nuget/experimental/index.json --nuget-username ${{ secrets.EXP_NUGET_USERNAME }} --nuget-password ${{ secrets.EXP_NUGET_PASSWORD }} --nuget-api-key ${{ secrets.EXP_NUGET_PASSWORD }}
     - name: Push to GitHub Packages
       if: ${{ github.repository == 'dotnet/Silk.NET' && github.event_name != 'pull_request' }}
       run: .\build.cmd PushToNuGet --skip Clean Restore Compile Pack --nuget-feed https://nuget.pkg.github.com/dotnet/index.json --nuget-api-key ${{ secrets.GITHUB_TOKEN }}

--- a/src/Website/Silk.NET.Statiq/Program.cs
+++ b/src/Website/Silk.NET.Statiq/Program.cs
@@ -46,7 +46,8 @@ public static class Program
                                 new NormalizedPath("_theme/lib").GetRelativePath(x.Path.GetRelativeInputPath())
                             )
                         ),
-                        new CopyFiles("images/**/*")
+                        new CopyFiles("images/**/*"),
+                        new CopyFiles("nuget/**/index.json")
                     )
             )
             .BuildPipeline

--- a/website/docs/silk.net/experimental-feed.md
+++ b/website/docs/silk.net/experimental-feed.md
@@ -37,7 +37,7 @@ In order to use the experimental feed, you must change this project file slightl
 ```xml
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <!-- Add the experimental feed as a restore source -->
     <RestoreSources>$(RestoreSources);https://dotnet.github.io/Silk.NET/nuget/experimental/index.json</RestoreSources>
   </PropertyGroup>

--- a/website/docs/silk.net/experimental-feed.md
+++ b/website/docs/silk.net/experimental-feed.md
@@ -22,7 +22,7 @@ Right now, your project should look something like this:
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/website/docs/silk.net/experimental-feed.md
+++ b/website/docs/silk.net/experimental-feed.md
@@ -1,0 +1,66 @@
+---
+{
+    "TableOfContents": {
+        "Name": "Experimental Feed",
+        "Url": "experimental-feed.html"
+    }
+}
+---
+
+# Experimental Feed
+
+<?# Warning "The experimental feed is not recommended for use for anything beyond playing around with the new features. We don't officially support these builds as they may be unstable, and should not be used in production." /?>
+
+<?# Note "Changes in the experimental feed happen rapidly. We recommend joining the [Silk.NET Discord server](https://discord.gg/DTHHXRt) so that you can keep up with development." /?>
+
+## Configure your project
+
+Right now, your project should look something like this:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Silk.NET" Version="1.4.0" />
+  </ItemGroup>
+
+</Project>
+```
+
+In order to use the experimental feed, you must change this project file slightly. Add the following line to your project:
+
+```xml
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <!-- Add the experimental feed as a restore source -->
+    <RestoreSources>$(RestoreSources);https://dotnet.github.io/Silk.NET/nuget/experimental/index.json</RestoreSources>
+  </PropertyGroup>
+```
+
+## Install an experimental version
+
+Now .NET has access to the experimental feed, it's time to install an experimental package. Check for the latest version on our [GitLab Package Registry](https://gitlab.com/silkdotnet/Silk.NET/-/packages).
+
+At the time of writing, the latest version is `2.0.0-build97.0`. Now to install this package, you can use your IDE's built-in NuGet client, `dotnet package add`, or just modify the project file again like so:
+
+```xml
+  <ItemGroup>
+    <PackageReference Include="Silk.NET" Version="2.0.0-build97.0" />
+  </ItemGroup>
+```
+
+<?# Warning "Experimental Feed builds may be deleted without warning at the Silk.NET team's discretion." /?>
+
+Now you have access to bleeding-edge experimental builds of Silk.NET. Have fun!
+
+## GitHub Packages
+
+`https://dotnet.github.io/Silk.NET/nuget/experimental/index.json` shall always track the most up-to-date anonymous-access experimental feed. However, as an alternative, GitHub Packages can be used which requires authentication.
+
+To add this to your NuGet client, use URL `https://nuget.pkg.github.com/dotnet/index.json` in the configuration described in [the GitHub documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry). The latest packages for this feed can be viewed [here](https://github.com/orgs/dotnet/packages?repo_name=Silk.NET).

--- a/website/docs/silk.net/index.md
+++ b/website/docs/silk.net/index.md
@@ -4,7 +4,8 @@
         "Name": "Miscellaneous",
         "Url": "index.html",
         "Children": [
-            { "Url": "::faq.md" }
+            { "Url": "::faq.md" },
+            { "Url": "::experimental-feed.md" }
         ],
         "Metadata": {
             "theme.silk.nav.big_dropdown.icon.class": "icon icon-shape bg-gradient-danger rounded-circle text-white",

--- a/website/nuget/experimental/index.json
+++ b/website/nuget/experimental/index.json
@@ -1,0 +1,50 @@
+{
+  "version": "3.0.0",
+  "resources": [
+    {
+      "@id": "https://gitlab.com/api/v4/projects/47661606/packages/nuget/query",
+      "@type": "SearchQueryService",
+      "comment": "Filter and search for packages by keyword."
+    },
+    {
+      "@id": "https://gitlab.com/api/v4/projects/47661606/packages/nuget/query",
+      "@type": "SearchQueryService/3.0.0-beta",
+      "comment": "Filter and search for packages by keyword."
+    },
+    {
+      "@id": "https://gitlab.com/api/v4/projects/47661606/packages/nuget/query",
+      "@type": "SearchQueryService/3.0.0-rc",
+      "comment": "Filter and search for packages by keyword."
+    },
+    {
+      "@id": "https://gitlab.com/api/v4/projects/47661606/packages/nuget/metadata",
+      "@type": "RegistrationsBaseUrl",
+      "comment": "Get package metadata."
+    },
+    {
+      "@id": "https://gitlab.com/api/v4/projects/47661606/packages/nuget/metadata",
+      "@type": "RegistrationsBaseUrl/3.0.0-beta",
+      "comment": "Get package metadata."
+    },
+    {
+      "@id": "https://gitlab.com/api/v4/projects/47661606/packages/nuget/metadata",
+      "@type": "RegistrationsBaseUrl/3.0.0-rc",
+      "comment": "Get package metadata."
+    },
+    {
+      "@id": "https://gitlab.com/api/v4/projects/47661606/packages/nuget/download",
+      "@type": "PackageBaseAddress/3.0.0",
+      "comment": "Get package content (.nupkg)."
+    },
+    {
+      "@id": "https://gitlab.com/api/v4/projects/47661606/packages/nuget",
+      "@type": "PackagePublish/2.0.0",
+      "comment": "Push and delete (or unlist) packages."
+    },
+    {
+      "@id": "https://gitlab.com/api/v4/projects/47661606/packages/nuget/symbolpackage",
+      "@type": "SymbolPackagePublish/4.9.0",
+      "comment": "Push symbol packages."
+    }
+  ]
+}


### PR DESCRIPTION
The experimental builds are now hosted on GitLab herein. This is because it has a 250GB limit instead of the "2GB" one we have with Azure Artifacts (though we were using ~7.5GB somehow?)

The feed URL is https://dotnet.github.io/Silk.NET/nuget/experimental/index.json - this is https://gitlab.com/api/v4/projects/47661606/packages/nuget/index.json but mirrored to our site so we can give a URL to our users that we have control over, meaning future switches between experimental feed hosts are seamless.

This also adds back the documentation page on the experimental feed that was never ported over from docs.ultz.co.uk