### PR TITLE
Fix missing "this" keyword in ToSystem and ToGeneric for 4d vector

### DIFF
--- a/src/Maths/Silk.NET.Maths/PublicAPI/net5.0/PublicAPI.Shipped.txt
+++ b/src/Maths/Silk.NET.Maths/PublicAPI/net5.0/PublicAPI.Shipped.txt
@@ -1246,6 +1246,7 @@ static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Pl
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Quaternion value) -> Silk.NET.Maths.Quaternion<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector2 value) -> Silk.NET.Maths.Vector2D<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector3 value) -> Silk.NET.Maths.Vector3D<float>
+static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector4 value) -> Silk.NET.Maths.Vector4D<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(Silk.NET.Maths.Vector4D<float> value) -> System.Numerics.Vector4
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Matrix3X2<float> value) -> System.Numerics.Matrix3x2
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Matrix4X4<float> value) -> System.Numerics.Matrix4x4
@@ -1253,6 +1254,7 @@ static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Plan
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Quaternion<float> value) -> System.Numerics.Quaternion
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector2D<float> value) -> System.Numerics.Vector2
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector3D<float> value) -> System.Numerics.Vector3
+static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector4D<float> value) -> System.Numerics.Vector4
 static Silk.NET.Maths.Vector2D.Abs<T>(Silk.NET.Maths.Vector2D<T> value) -> Silk.NET.Maths.Vector2D<T>
 static Silk.NET.Maths.Vector2D.Add<T>(Silk.NET.Maths.Vector2D<T> left, Silk.NET.Maths.Vector2D<T> right) -> Silk.NET.Maths.Vector2D<T>
 static Silk.NET.Maths.Vector2D.Clamp<T>(Silk.NET.Maths.Vector2D<T> value1, Silk.NET.Maths.Vector2D<T> min, Silk.NET.Maths.Vector2D<T> max) -> Silk.NET.Maths.Vector2D<T>

--- a/src/Maths/Silk.NET.Maths/PublicAPI/net6.0-android/PublicAPI.Shipped.txt
+++ b/src/Maths/Silk.NET.Maths/PublicAPI/net6.0-android/PublicAPI.Shipped.txt
@@ -1246,6 +1246,7 @@ static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Pl
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Quaternion value) -> Silk.NET.Maths.Quaternion<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector2 value) -> Silk.NET.Maths.Vector2D<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector3 value) -> Silk.NET.Maths.Vector3D<float>
+static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector4 value) -> Silk.NET.Maths.Vector4D<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(Silk.NET.Maths.Vector4D<float> value) -> System.Numerics.Vector4
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Matrix3X2<float> value) -> System.Numerics.Matrix3x2
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Matrix4X4<float> value) -> System.Numerics.Matrix4x4
@@ -1253,6 +1254,7 @@ static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Plan
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Quaternion<float> value) -> System.Numerics.Quaternion
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector2D<float> value) -> System.Numerics.Vector2
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector3D<float> value) -> System.Numerics.Vector3
+static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector4D<float> value) -> System.Numerics.Vector4
 static Silk.NET.Maths.Vector2D.Abs<T>(Silk.NET.Maths.Vector2D<T> value) -> Silk.NET.Maths.Vector2D<T>
 static Silk.NET.Maths.Vector2D.Add<T>(Silk.NET.Maths.Vector2D<T> left, Silk.NET.Maths.Vector2D<T> right) -> Silk.NET.Maths.Vector2D<T>
 static Silk.NET.Maths.Vector2D.Clamp<T>(Silk.NET.Maths.Vector2D<T> value1, Silk.NET.Maths.Vector2D<T> min, Silk.NET.Maths.Vector2D<T> max) -> Silk.NET.Maths.Vector2D<T>

--- a/src/Maths/Silk.NET.Maths/PublicAPI/net6.0-ios/PublicAPI.Shipped.txt
+++ b/src/Maths/Silk.NET.Maths/PublicAPI/net6.0-ios/PublicAPI.Shipped.txt
@@ -1246,6 +1246,7 @@ static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Pl
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Quaternion value) -> Silk.NET.Maths.Quaternion<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector2 value) -> Silk.NET.Maths.Vector2D<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector3 value) -> Silk.NET.Maths.Vector3D<float>
+static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector4 value) -> Silk.NET.Maths.Vector4D<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(Silk.NET.Maths.Vector4D<float> value) -> System.Numerics.Vector4
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Matrix3X2<float> value) -> System.Numerics.Matrix3x2
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Matrix4X4<float> value) -> System.Numerics.Matrix4x4
@@ -1253,6 +1254,7 @@ static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Plan
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Quaternion<float> value) -> System.Numerics.Quaternion
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector2D<float> value) -> System.Numerics.Vector2
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector3D<float> value) -> System.Numerics.Vector3
+static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector4D<float> value) -> System.Numerics.Vector4
 static Silk.NET.Maths.Vector2D.Abs<T>(Silk.NET.Maths.Vector2D<T> value) -> Silk.NET.Maths.Vector2D<T>
 static Silk.NET.Maths.Vector2D.Add<T>(Silk.NET.Maths.Vector2D<T> left, Silk.NET.Maths.Vector2D<T> right) -> Silk.NET.Maths.Vector2D<T>
 static Silk.NET.Maths.Vector2D.Clamp<T>(Silk.NET.Maths.Vector2D<T> value1, Silk.NET.Maths.Vector2D<T> min, Silk.NET.Maths.Vector2D<T> max) -> Silk.NET.Maths.Vector2D<T>

--- a/src/Maths/Silk.NET.Maths/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
+++ b/src/Maths/Silk.NET.Maths/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
@@ -1246,6 +1246,7 @@ static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Pl
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Quaternion value) -> Silk.NET.Maths.Quaternion<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector2 value) -> Silk.NET.Maths.Vector2D<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector3 value) -> Silk.NET.Maths.Vector3D<float>
+static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector4 value) -> Silk.NET.Maths.Vector4D<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(Silk.NET.Maths.Vector4D<float> value) -> System.Numerics.Vector4
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Matrix3X2<float> value) -> System.Numerics.Matrix3x2
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Matrix4X4<float> value) -> System.Numerics.Matrix4x4
@@ -1253,6 +1254,7 @@ static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Plan
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Quaternion<float> value) -> System.Numerics.Quaternion
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector2D<float> value) -> System.Numerics.Vector2
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector3D<float> value) -> System.Numerics.Vector3
+static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector4D<float> value) -> System.Numerics.Vector4
 static Silk.NET.Maths.Vector2D.Abs<T>(Silk.NET.Maths.Vector2D<T> value) -> Silk.NET.Maths.Vector2D<T>
 static Silk.NET.Maths.Vector2D.Add<T>(Silk.NET.Maths.Vector2D<T> left, Silk.NET.Maths.Vector2D<T> right) -> Silk.NET.Maths.Vector2D<T>
 static Silk.NET.Maths.Vector2D.Clamp<T>(Silk.NET.Maths.Vector2D<T> value1, Silk.NET.Maths.Vector2D<T> min, Silk.NET.Maths.Vector2D<T> max) -> Silk.NET.Maths.Vector2D<T>

--- a/src/Maths/Silk.NET.Maths/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Maths/Silk.NET.Maths/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1246,6 +1246,7 @@ static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Pl
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Quaternion value) -> Silk.NET.Maths.Quaternion<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector2 value) -> Silk.NET.Maths.Vector2D<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector3 value) -> Silk.NET.Maths.Vector3D<float>
+static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector4 value) -> Silk.NET.Maths.Vector4D<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(Silk.NET.Maths.Vector4D<float> value) -> System.Numerics.Vector4
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Matrix3X2<float> value) -> System.Numerics.Matrix3x2
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Matrix4X4<float> value) -> System.Numerics.Matrix4x4
@@ -1253,6 +1254,7 @@ static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Plan
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Quaternion<float> value) -> System.Numerics.Quaternion
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector2D<float> value) -> System.Numerics.Vector2
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector3D<float> value) -> System.Numerics.Vector3
+static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector4D<float> value) -> System.Numerics.Vector4
 static Silk.NET.Maths.Vector2D.Abs<T>(Silk.NET.Maths.Vector2D<T> value) -> Silk.NET.Maths.Vector2D<T>
 static Silk.NET.Maths.Vector2D.Add<T>(Silk.NET.Maths.Vector2D<T> left, Silk.NET.Maths.Vector2D<T> right) -> Silk.NET.Maths.Vector2D<T>
 static Silk.NET.Maths.Vector2D.Clamp<T>(Silk.NET.Maths.Vector2D<T> value1, Silk.NET.Maths.Vector2D<T> min, Silk.NET.Maths.Vector2D<T> max) -> Silk.NET.Maths.Vector2D<T>

--- a/src/Maths/Silk.NET.Maths/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/Maths/Silk.NET.Maths/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -1246,6 +1246,7 @@ static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Pl
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Quaternion value) -> Silk.NET.Maths.Quaternion<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector2 value) -> Silk.NET.Maths.Vector2D<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector3 value) -> Silk.NET.Maths.Vector3D<float>
+static Silk.NET.Maths.SystemNumericsExtensions.ToGeneric(this System.Numerics.Vector4 value) -> Silk.NET.Maths.Vector4D<float>
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(Silk.NET.Maths.Vector4D<float> value) -> System.Numerics.Vector4
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Matrix3X2<float> value) -> System.Numerics.Matrix3x2
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Matrix4X4<float> value) -> System.Numerics.Matrix4x4
@@ -1253,6 +1254,7 @@ static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Plan
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Quaternion<float> value) -> System.Numerics.Quaternion
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector2D<float> value) -> System.Numerics.Vector2
 static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector3D<float> value) -> System.Numerics.Vector3
+static Silk.NET.Maths.SystemNumericsExtensions.ToSystem(this Silk.NET.Maths.Vector4D<float> value) -> System.Numerics.Vector4
 static Silk.NET.Maths.Vector2D.Abs<T>(Silk.NET.Maths.Vector2D<T> value) -> Silk.NET.Maths.Vector2D<T>
 static Silk.NET.Maths.Vector2D.Add<T>(Silk.NET.Maths.Vector2D<T> left, Silk.NET.Maths.Vector2D<T> right) -> Silk.NET.Maths.Vector2D<T>
 static Silk.NET.Maths.Vector2D.Clamp<T>(Silk.NET.Maths.Vector2D<T> value1, Silk.NET.Maths.Vector2D<T> min, Silk.NET.Maths.Vector2D<T> max) -> Silk.NET.Maths.Vector2D<T>

--- a/src/Maths/Silk.NET.Maths/SystemNumericsExtensions.cs
+++ b/src/Maths/Silk.NET.Maths/SystemNumericsExtensions.cs
@@ -66,7 +66,7 @@ namespace Silk.NET.Maths
         /// </summary>
         /// <param name="value">The source vector</param>
         /// <returns>The converted vector</returns>
-        public static System.Numerics.Vector4 ToSystem(Vector4D<float> value)
+        public static System.Numerics.Vector4 ToSystem(this Vector4D<float> value)
             => new(value.X, value.Y, value.Z, value.W);
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Silk.NET.Maths
         /// </summary>
         /// <param name="value">The source vector</param>
         /// <returns>The converted vector</returns>
-        public static Vector4D<float> ToGeneric(System.Numerics.Vector4 value)
+        public static Vector4D<float> ToGeneric(this System.Numerics.Vector4 value)
             => new(value.X, value.Y, value.Z, value.W);
     }
 }


### PR DESCRIPTION
I noticed that Vector4D<T> doesn't has the ToSystem function and Vector4 doesn't has the ToGeneric function, these functions in SystemNumericsExtensions class doesn't has the `this` keyword, so... I'll try to fix it. It's my first contributing experience so I'm sorry if I will make mistakes