### PR TITLE
Equality operators for Bool32

### DIFF
--- a/src/Core/Silk.NET.Core/Miscellaneous/Bool32.cs
+++ b/src/Core/Silk.NET.Core/Miscellaneous/Bool32.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Silk.NET.Core
@@ -50,5 +50,91 @@ namespace Silk.NET.Core
         /// </summary>
         /// <param name="val">The 32-bit unsigned integer value.</param>
         public static implicit operator Bool32(uint val) => new Bool32(val);
+
+        #region Bool32 vs Bool32 equality
+        /// <summary>
+        /// Compares a <see cref="Bool32"/> to a <see cref="Bool32"/> for equality.
+        /// </summary>
+        /// <param name="left">The left-hand <see cref="Bool32"/>.</param>
+        /// <param name="right">The right-hand <see cref="Bool32"/>.</param>
+        /// <returns></returns>
+        public static bool operator ==(Bool32 left, Bool32 right) => left.Value == right.Value;
+
+        /// <summary>
+        /// Compares a <see cref="Bool32"/> to a <see cref="Bool32"/> for inequality.
+        /// </summary>
+        /// <param name="left">The left-hand <see cref="Bool32"/>.</param>
+        /// <param name="right">The right-hand <see cref="Bool32"/>.</param>
+        /// <returns></returns>
+        public static bool operator !=(Bool32 left, Bool32 right) => left.Value != right.Value;
+        #endregion
+
+        #region Bool32 vs bool equality
+        /// <summary>
+        /// Compares a <see cref="Bool32"/> to a <see cref="bool"/> for equality.
+        /// </summary>
+        /// <param name="left">The left-hand <see cref="Bool32"/>.</param>
+        /// <param name="right">The right-hand <see cref="bool"/>.</param>
+        /// <returns></returns>
+        public static bool operator ==(Bool32 left, bool right) => left.Value == (right ? 1 : 0);
+
+        /// <summary>
+        /// Compares a <see cref="Bool32"/> to a <see cref="bool"/> for inequality.
+        /// </summary>
+        /// <param name="left">The left-hand <see cref="Bool32"/>.</param>
+        /// <param name="right">The right-hand <see cref="bool"/>.</param>
+        /// <returns></returns>
+        public static bool operator !=(Bool32 left, bool right) => left.Value != (right ? 1 : 0);
+
+        /// <summary>
+        /// Compares a <see cref="bool"/> to a <see cref="Bool32"/> for equality.
+        /// </summary>
+        /// <param name="left">The left-hand <see cref="bool"/>.</param>
+        /// <param name="right">The right-hand <see cref="Bool32"/>.</param>
+        /// <returns></returns>
+        public static bool operator ==(bool left, Bool32 right) => right.Value == (left ? 1 : 0);
+
+        /// <summary>
+        /// Compares a <see cref="bool"/> to a <see cref="Bool32"/> for equality.
+        /// </summary>
+        /// <param name="left">The left-hand <see cref="bool"/>.</param>
+        /// <param name="right">The right-hand <see cref="Bool32"/>.</param>
+        /// <returns></returns>
+        public static bool operator !=(bool left, Bool32 right) => right.Value != (left ? 1 : 0);
+        #endregion
+
+        #region Bool32 vs uint equality
+        /// <summary>
+        /// Compares a <see cref="Bool32"/> to a <see cref="uint"/> for equality.
+        /// </summary>
+        /// <param name="left">The left-hand <see cref="Bool32"/>.</param>
+        /// <param name="right">The right-hand <see cref="uint"/>.</param>
+        /// <returns></returns>
+        public static bool operator == (Bool32 left, uint right) => left.Value == right;
+
+        /// <summary>
+        /// Compares a <see cref="Bool32"/> to a <see cref="uint"/> for inequality.
+        /// </summary>
+        /// <param name="left">The left-hand <see cref="Bool32"/>.</param>
+        /// <param name="right">The right-hand <see cref="uint"/>.</param>
+        /// <returns></returns>
+        public static bool operator != (Bool32 left, uint right) => left.Value != right;
+
+        /// <summary>
+        /// Compares a <see cref="uint"/> to a <see cref="Bool32"/> for equality.
+        /// </summary>
+        /// <param name="left">The left-hand <see cref="uint"/>.</param>
+        /// <param name="right">The right-hand <see cref="Bool32"/>.</param>
+        /// <returns></returns>
+        public static bool operator == (uint left, Bool32 right) => left == right.Value;
+
+        /// <summary>
+        /// Compares a <see cref="uint"/> to a <see cref="Bool32"/> for inequality.
+        /// </summary>
+        /// <param name="left">The left-hand <see cref="uint"/>.</param>
+        /// <param name="right">The right-hand <see cref="Bool32"/>.</param>
+        /// <returns></returns>
+        public static bool operator != (uint left, Bool32 right) => left != right.Value;
+        #endregion
     }
 }


### PR DESCRIPTION
I noticed that Bool32 doesn't have any `==` or `!=` operators and thought it would be nice to add them. @Perksey hinted at PRs for this in #1586, so here it is!

This adds equality operators for comparing `Bool32` with `Bool32`, `bool` or `uint`

This is my first Silk.NET PR, so feel free to tell me if I've missed something.

Closes #1586