### PR TITLE
Update ImGui.NET from 1.88.0 to 1.89.7.1

### DIFF
--- a/src/Lab/Experiments/ImGuiVulkan/ImGuiVulkan.csproj
+++ b/src/Lab/Experiments/ImGuiVulkan/ImGuiVulkan.csproj
@@ -13,7 +13,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ImGui.NET" Version="1.89.2" />
+		<PackageReference Include="ImGui.NET" Version="1.89.7.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.ImGui/Silk.NET.OpenGL.Extensions.ImGui.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.ImGui/Silk.NET.OpenGL.Extensions.ImGui.csproj
@@ -19,7 +19,7 @@
         <ProjectReference Include="..\..\..\Input\Silk.NET.Input.Common\Silk.NET.Input.Common.csproj" />
         <ProjectReference Include="..\..\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
         <ProjectReference Include="..\..\..\Windowing\Silk.NET.Windowing.Common\Silk.NET.Windowing.Common.csproj" />
-        <PackageReference Include="ImGui.NET" Version="1.88.0" />
+        <PackageReference Include="ImGui.NET" Version="1.89.7.1" />
     </ItemGroup>
 
     <Import Project="..\..\..\..\build\props\common.props" />

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.ImGui/Silk.NET.OpenGL.Legacy.Extensions.ImGui.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.ImGui/Silk.NET.OpenGL.Legacy.Extensions.ImGui.csproj
@@ -24,7 +24,7 @@
         <ProjectReference Include="..\..\..\Input\Silk.NET.Input.Common\Silk.NET.Input.Common.csproj" />
         <ProjectReference Include="..\..\Silk.NET.OpenGL.Legacy\Silk.NET.OpenGL.Legacy.csproj" />
         <ProjectReference Include="..\..\..\Windowing\Silk.NET.Windowing.Common\Silk.NET.Windowing.Common.csproj" />
-        <PackageReference Include="ImGui.NET" Version="1.87.3" />
+        <PackageReference Include="ImGui.NET" Version="1.89.7.1" />
     </ItemGroup>
 
     <Import Project="..\..\..\..\build\props\common.props" />

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.ImGui/Silk.NET.OpenGLES.Extensions.ImGui.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.ImGui/Silk.NET.OpenGLES.Extensions.ImGui.csproj
@@ -23,7 +23,7 @@
         <ProjectReference Include="..\..\..\Input\Silk.NET.Input.Common\Silk.NET.Input.Common.csproj" />
         <ProjectReference Include="..\..\Silk.NET.OpenGLES\Silk.NET.OpenGLES.csproj" />
         <ProjectReference Include="..\..\..\Windowing\Silk.NET.Windowing.Common\Silk.NET.Windowing.Common.csproj" />
-        <PackageReference Include="ImGui.NET" Version="1.87.3" />
+        <PackageReference Include="ImGui.NET" Version="1.89.7.1" />
     </ItemGroup>
 
     <Import Project="..\..\..\..\build\props\common.props" />


### PR DESCRIPTION
# Summary of the PR
Updates ImGui.NET from 1.88.0 to 1.89.7.1 (latest)

# Related issues, Discord discussions, or proposals
N/A

# Further Comments
The latest versions of ImGui.NET allow users to pass `ReadOnlySpan<char>` instead of `string` on platforms where `ReadOnlySpan` is supported, saving GC overhead in UI render loops.

The main reason why I'd like to use this is so I can write allocation-free UI code so actual memory allocations happening in my engine are easier to spot. 🙂

I'm also curious if it would be possible to get a pre-release version released for `Silk.NET.OpenGL.Extensions.ImGui`. If that's normally not done, that's fine. I don't mind waiting for the next release.

Please let me know if I've missed anything.