### PR TITLE
Proper frame timing in BreakneckSleep

### DIFF
--- a/src/Core/Silk.NET.Core/Miscellaneous/BreakneckSleep.cs
+++ b/src/Core/Silk.NET.Core/Miscellaneous/BreakneckSleep.cs
@@ -45,24 +45,15 @@ public readonly struct BreakneckSleep : IDisposable
     public nint Handle { get; }
 
     /// <summary>
-    /// The duration of the sleep.
-    /// </summary>
-    public TimeSpan Duration { get; }
-
-    /// <summary>
     /// The accuracy of the underlying implementation. 
     /// </summary>
     public AccuracyMode Accuracy { get; }
 
-    private long _lastTick;
-
     /// <summary>
     /// Creates a high-resolution timer
     /// </summary>
-    /// <param name="duration"></param>
-    public BreakneckSleep(TimeSpan duration)
+    public BreakneckSleep()
     {
-        Duration = duration;
         Accuracy = AccuracyMode.BusyLoopOnly;
         if (OperatingSystem.IsWindows())
         {
@@ -80,30 +71,27 @@ public readonly struct BreakneckSleep : IDisposable
         }
     }
 
-    public void Start() {
-        _lastTick = Stopwatch.GetTimestamp();
-    }
-
     /// <summary>
-    /// Sleeps for <see cref="Duration"/>.
+    /// Sleeps for <paramref cref="duration"/>.
     /// </summary>
-    public void Sleep()
+    public void Sleep(TimeSpan duration)
     {
+        var start = Stopwatch.GetTimestamp();
         var emergencySpin = false;
         if (OperatingSystem.IsWindows())
         {
-            emergencySpin = !WindowsWait();
+            emergencySpin = !WindowsWait(duration);
         }
 
         if (OperatingSystem.IsLinux())
         {
-            LinuxWait();
+            LinuxWait(duration);
         }
 
         if (OperatingSystem.IsMacOS() || OperatingSystem.IsIOS() || OperatingSystem.IsTvOS() ||
             OperatingSystem.IsWatchOS() || OperatingSystem.IsMacCatalyst())
         {
-            AppleWait();
+            AppleWait(duration);
         }
 
         if (Accuracy is AccuracyMode.HighResolutionWithBusyLoop or AccuracyMode.BusyLoopOnly || emergencySpin)
@@ -119,9 +107,8 @@ public readonly struct BreakneckSleep : IDisposable
                 {
                     ArmBase.Yield();
                 }
-            } while (Stopwatch.GetElapsedTime(_lastTick, Stopwatch.GetTimestamp()) < Duration);
+            } while (Stopwatch.GetElapsedTime(start, Stopwatch.GetTimestamp()) < duration);
         }
-        _lastTick = Stopwatch.GetTimestamp();
     }
 
     private static unsafe (nint Handle, bool IsHighResolution) WindowsCreate()
@@ -145,7 +132,7 @@ public readonly struct BreakneckSleep : IDisposable
             : (CreateWaitableTimerExW(null, null, createWaitableTimerManualReset, timerAllAccess), false);
     }
 
-    private unsafe bool WindowsWait()
+    private unsafe bool WindowsWait(TimeSpan duration)
     {
         [DllImport("kernel32.dll", ExactSpelling = true)]
         static extern uint SetWaitableTimerEx
@@ -172,8 +159,8 @@ public readonly struct BreakneckSleep : IDisposable
         var ft = CreateFileTime
         (
             Accuracy == AccuracyMode.HighestResolution
-                ? Duration
-                : TimeSpan.FromMicroseconds(Duration.TotalMicroseconds * 0.9)
+                ? duration
+                : TimeSpan.FromMicroseconds(duration.TotalMicroseconds * 0.9)
         );
         if (SetWaitableTimerEx(Handle, &ft, 0, null, null, null, 0) == 1)
         {
@@ -184,24 +171,24 @@ public readonly struct BreakneckSleep : IDisposable
         return false;
     }
 
-    private unsafe void LinuxWait()
+    private unsafe void LinuxWait(TimeSpan duration)
     {
         [DllImport("libc", EntryPoint = "nanosleep")]
         static extern int Nanosleep(Timespec* req, Timespec* rem);
 
         var ts = new Timespec
         {
-            Seconds = Duration.Seconds,
-            Nanoseconds = Duration.Nanoseconds - Duration.Seconds * 1000000000
+            Seconds = duration.Seconds,
+            Nanoseconds = duration.Nanoseconds - duration.Seconds * 1000000000
         };
         _ = Nanosleep(&ts, null);
     }
 
-    private void AppleWait()
+    private void AppleWait(TimeSpan duration)
     {
         [DllImport("libc", EntryPoint = "usleep")]
         static extern int Usleep(uint micros);
-        _ = Usleep((uint) (Duration.TotalMicroseconds * 0.9));
+        _ = Usleep((uint) (duration.TotalMicroseconds * 0.9));
     }
 
     public void Dispose()

--- a/src/Core/Silk.NET.Core/Miscellaneous/BreakneckSleep.cs
+++ b/src/Core/Silk.NET.Core/Miscellaneous/BreakneckSleep.cs
@@ -54,6 +54,8 @@ public readonly struct BreakneckSleep : IDisposable
     /// </summary>
     public AccuracyMode Accuracy { get; }
 
+    private long _lastTick;
+
     /// <summary>
     /// Creates a high-resolution timer
     /// </summary>
@@ -78,12 +80,15 @@ public readonly struct BreakneckSleep : IDisposable
         }
     }
 
+    public void Start() {
+        _lastTick = Stopwatch.GetTimestamp();
+    }
+
     /// <summary>
     /// Sleeps for <see cref="Duration"/>.
     /// </summary>
     public void Sleep()
     {
-        var start = Stopwatch.GetTimestamp();
         var emergencySpin = false;
         if (OperatingSystem.IsWindows())
         {
@@ -114,8 +119,9 @@ public readonly struct BreakneckSleep : IDisposable
                 {
                     ArmBase.Yield();
                 }
-            } while (Stopwatch.GetElapsedTime(start, Stopwatch.GetTimestamp()) < Duration);
+            } while (Stopwatch.GetElapsedTime(_lastTick, Stopwatch.GetTimestamp()) < Duration);
         }
+        _lastTick = Stopwatch.GetTimestamp();
     }
 
     private static unsafe (nint Handle, bool IsHighResolution) WindowsCreate()

--- a/src/Lab/Experiments/TimeTrials/Program.cs
+++ b/src/Lab/Experiments/TimeTrials/Program.cs
@@ -5,11 +5,11 @@ using Silk.NET.Core;
 
 for (var fps = 60; fps < 61440; fps *= 2)
 {
-    var sleep = new BreakneckSleep(TimeSpan.FromSeconds(1 / (double)fps));
+    var sleep = new BreakneckSleep();
     for (var t = 0; t < 5; t++)
     {
         var now = Stopwatch.GetTimestamp();
-        sleep.Sleep();
+        sleep.Sleep(TimeSpan.FromSeconds(1 / (double)fps));
         Console.WriteLine
             ($"{fps} FPS = {1 / Stopwatch.GetElapsedTime(now, Stopwatch.GetTimestamp()).TotalSeconds} FPS");
     }


### PR DESCRIPTION
# Summary of the PR
Fixes BreakneckSleep in the existing CPU usage PR to store the last tick timestamp and compare to that instead of to when Sleep is called.
The branch still doesnt actually use BreakneckSleep in the window loop but still this is in theory an improvement