### PR TITLE
Update proposed new versioning rules for easier preview build usage

### DIFF
--- a/documentation/proposals/Proposal - 3.0 & 3.X Software Development Plan.md
+++ b/documentation/proposals/Proposal - 3.0 & 3.X Software Development Plan.md
@@ -169,7 +169,8 @@ Any post-3.0, pre-4.0 release will be versioned as follows:
 - The major version will always be 3
 - The minor version will be the number of the monthly update cycle i.e. the first monthly update will be versioned 3.1, the second 3.2, etc...
 - The patch version will always be 0, unless it is an emergency patch in which case it'll be the number of the emergency patch i.e. if an emergency patch is required after the first monthly update the version will be 3.1.1, if another one is required (heaven forbid) in this same cycle it'll be 3.1.2 etc...
-- The revision version will always be 0 for released builds. If separation of an unreleased (experimental) build from a released build is required, the revision version will be greater than zero. The team does not have a preference to how this requirement is met e.g. this could include all experimental builds being marked with a revision version of 1, or could include a number representing the date e.g. `20230929`; so long as it is greater than 0.
+- The revision version will always be 0 for released builds.
+- When a new version is released, the working tree will change to the next patch version to enable better consumption of experimental builds among other things, with provision that the version number may be changed upward at any time without the necessity of issuing a release.
 
 Users are expected to keep all of the versions of all Silk.NET packages they are using in-sync. We could write a Roslyn analyser or MSBuild target to help push users to this.
 

--- a/documentation/proposals/Proposal - 3.0 & 3.X Software Development Plan.md
+++ b/documentation/proposals/Proposal - 3.0 & 3.X Software Development Plan.md
@@ -169,7 +169,7 @@ Any post-3.0, pre-4.0 release will be versioned as follows:
 - The major version will always be 3
 - The minor version will be the number of the monthly update cycle i.e. the first monthly update will be versioned 3.1, the second 3.2, etc...
 - The patch version will always be 0, unless it is an emergency patch in which case it'll be the number of the emergency patch i.e. if an emergency patch is required after the first monthly update the version will be 3.1.1, if another one is required (heaven forbid) in this same cycle it'll be 3.1.2 etc...
-- The revision version will always be 0.
+- The revision version will always be 0, unless it is a preview build generated from the `develop` branch in which case it'll be 1.
 
 Users are expected to keep all of the versions of all Silk.NET packages they are using in-sync. We could write a Roslyn analyser or MSBuild target to help push users to this.
 

--- a/documentation/proposals/Proposal - 3.0 & 3.X Software Development Plan.md
+++ b/documentation/proposals/Proposal - 3.0 & 3.X Software Development Plan.md
@@ -170,7 +170,7 @@ Any post-3.0, pre-4.0 release will be versioned as follows:
 - The minor version will be the number of the monthly update cycle i.e. the first monthly update will be versioned 3.1, the second 3.2, etc...
 - The patch version will always be 0, unless it is an emergency patch in which case it'll be the number of the emergency patch i.e. if an emergency patch is required after the first monthly update the version will be 3.1.1, if another one is required (heaven forbid) in this same cycle it'll be 3.1.2 etc...
 - The revision version will always be 0 for released builds.
-- When a new version is released, the working tree will change to the next patch version to enable better consumption of experimental builds among other things, with provision that the version number may be changed upward at any time without the necessity of issuing a release.
+- The patch version shall be incremented after a release to ensure the working tree and therefore the experimental feed tracks a version higher than the currently released one, with the provision that this version number is not final and the final released version number shall be subject to all of the above rules.
 
 Users are expected to keep all of the versions of all Silk.NET packages they are using in-sync. We could write a Roslyn analyser or MSBuild target to help push users to this.
 

--- a/documentation/proposals/Proposal - 3.0 & 3.X Software Development Plan.md
+++ b/documentation/proposals/Proposal - 3.0 & 3.X Software Development Plan.md
@@ -169,7 +169,7 @@ Any post-3.0, pre-4.0 release will be versioned as follows:
 - The major version will always be 3
 - The minor version will be the number of the monthly update cycle i.e. the first monthly update will be versioned 3.1, the second 3.2, etc...
 - The patch version will always be 0, unless it is an emergency patch in which case it'll be the number of the emergency patch i.e. if an emergency patch is required after the first monthly update the version will be 3.1.1, if another one is required (heaven forbid) in this same cycle it'll be 3.1.2 etc...
-- The revision version will always be 0, unless it is a preview build generated from the `develop` branch in which case it'll be 1.
+- The revision version will always be 0 for released builds. If separation of an unreleased (experimental) build from a released build is required, the revision version will be greater than zero. The team does not have a preference to how this requirement is met e.g. this could include all experimental builds being marked with a revision version of 1, or could include a number representing the date e.g. `20230929`; so long as it is greater than 0.
 
 Users are expected to keep all of the versions of all Silk.NET packages they are using in-sync. We could write a Roslyn analyser or MSBuild target to help push users to this.
 


### PR DESCRIPTION
# Summary of the PR
Updates the proposal for the software development plan going forward such that preview/development builds are considered newer than the release they follow by standard semver/nuget conventions.

# Related issues, Discord discussions, or proposals
[![image](https://github.com/dotnet/Silk.NET/assets/3117019/939304ca-b1bd-4590-90dc-5a3a1ab9415b)](https://discord.com/channels/521092042781229087/587346162802229298/1157498331103236258)
