### PR TITLE
Add CI commit glob for MoltenVK binaries

### DIFF
--- a/build/nuke/Native/Core.cs
+++ b/build/nuke/Native/Core.cs
@@ -63,7 +63,7 @@ partial class Build {
             }
             else if (OperatingSystem.IsMacOS())
             {
-                glob ??= "src/Native/**/*.dylib";
+                glob ??= "src/Native/**/libMoltenVK.a src/Native/**/*.dylib";
             }
             else if (OperatingSystem.IsLinux())
             {


### PR DESCRIPTION
# Summary of the PR
Adds a glob for MoltenVK binaries built during CI runs. This fixes the issue of CI workflows excluding built binaries from commits.

# Related issues, Discord discussions, or proposals
No related issues.

# Further Comments
