### PR TITLE
Add support for OpenAL EffectTarget extension

### DIFF
--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/Enums/SoftEffectSlotInteger.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/Enums/SoftEffectSlotInteger.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Silk.NET.OpenAL.Extensions.Soft
+{
+    /// <summary>
+    /// A list of valid <see cref="int" /> AuxiliaryEffectSlot/GetAuxiliaryEffectSlot parameters.
+    /// </summary>
+    public enum SoftEffectSlotInteger
+    {
+        TargetSoft = 0x199C
+    }
+}

--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/SoftEffectTarget.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/SoftEffectTarget.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Native;
+
+namespace Silk.NET.OpenAL.Extensions.Soft
+{
+    /// <summary>
+    /// Exposes the public API of functions added by OpenAL Soft.
+    /// </summary>
+    [NativeApi(Prefix = "al")]
+    [Extension("AL_SOFT_effect_target")]
+    public partial class SoftEffectTarget : NativeExtension<AL>
+    {
+        /// <inheritdoc cref="ExtensionBase" />
+        public SoftEffectTarget(INativeContext ctx)
+            : base(ctx)
+        {
+        }
+
+        /// <inheritdoc />
+        [NativeApi(EntryPoint = "AuxiliaryEffectSloti")]
+        public partial void SetAuxiliaryEffectSlotProperty(uint slot, SoftEffectSlotInteger param, int value);
+
+        /// <inheritdoc />
+        [NativeApi(EntryPoint = "GetAuxiliaryEffectSloti")]
+        public partial void GetAuxiliaryEffectSlotProperty(uint slot, SoftEffectSlotInteger param, out int value);
+    }
+}

--- a/src/OpenAL/Silk.NET.OpenAL.Tests/ExtensionLoadingTests.cs
+++ b/src/OpenAL/Silk.NET.OpenAL.Tests/ExtensionLoadingTests.cs
@@ -105,6 +105,7 @@ public class ExtensionLoadingTests
         Test<EffectExtension>();
         Test<XRam>();
         Test<DeferredUpdates>();
+        Test<SoftEffectTarget>();
 
         SilkMarshal.Free(loaderPtr);
         SilkMarshal.Free(ctxLoaderPtr);


### PR DESCRIPTION
# Summary of the PR
This change adds support for the OpenAL Soft EffectTarget extension, which allows effects to be chained.
