### PR TITLE
Fix ALC_EXT_EFX hack

### DIFF
--- a/src/OpenAL/Silk.NET.OpenAL.Tests/ExtensionLoadingTests.cs
+++ b/src/OpenAL/Silk.NET.OpenAL.Tests/ExtensionLoadingTests.cs
@@ -31,6 +31,12 @@ public class ExtensionLoadingTests
     [UnmanagedCallersOnly(CallConvs = new []{typeof(CallConvCdecl)})]
     public static unsafe int AlwaysZero(byte* name) => 0;
 
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    public static unsafe Context* GetCurrentContext() => null;
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+    public static unsafe Device* GetContextsDevice(Context* ctx) => null;
+
     public unsafe delegate nint LoaderDelegate(byte* name);
     public unsafe delegate nint ContextLoaderDelegate(void* device, byte* name);
     
@@ -51,6 +57,8 @@ public class ExtensionLoadingTests
             "alcIsExtensionPresent" or "alIsExtensionPresent" => alwaysPresent
                 ? (nint) (delegate* unmanaged[Cdecl]<byte*, int>) &AlwaysOne
                 : (nint) (delegate* unmanaged[Cdecl]<byte*, int>) &AlwaysZero,
+            "alcGetCurrentContext" => (nint) (delegate* unmanaged[Cdecl]<Context*>) &GetCurrentContext,
+            "alcGetContextsDevice" => (nint) (delegate* unmanaged[Cdecl]<Context*, Device*>) &GetContextsDevice,
             "alGetProcAddress" => wrapper[0],
             "alcGetProcAddress" => wrapper[1],
             "alGetEnumValue" => (nint) (delegate* unmanaged[Cdecl]<byte*, int>) &AlwaysZero,

--- a/src/OpenAL/Silk.NET.OpenAL/AL/AL.cs
+++ b/src/OpenAL/Silk.NET.OpenAL/AL/AL.cs
@@ -36,8 +36,10 @@ namespace Silk.NET.OpenAL
                 SilkMarshal.StringIntoSpan(name, nameNative, NativeStringEncoding.UTF8);
                 fixed (byte* namePtr = nameNative)
                 {
-                    return ((delegate* unmanaged[Cdecl]<byte*, char>) Context.GetProcAddress("alcIsExtensionPresent"))
-                        (namePtr) == 1;
+                    var currentContext = ((delegate* unmanaged[Cdecl]<Context*>) Context.GetProcAddress("alcGetCurrentContext"))();
+                    var currentDevice = ((delegate* unmanaged[Cdecl]<Context*, Device*>) Context.GetProcAddress("alcGetContextsDevice"))(currentContext);
+                    return ((delegate* unmanaged[Cdecl]<Device*, byte*, char>) Context.GetProcAddress("alcIsExtensionPresent"))
+                        (currentDevice, namePtr) == 1;
                 }
             }
 


### PR DESCRIPTION
# Summary of the PR
This fixes the hack for calling `TryGetExtension` for the OpenAL EFX extension.

The `alcIsExtensionPresent` function call is missing a `Device*` argument. To be consistent with [`TryGetExtension` in ALContext](https://github.com/dotnet/Silk.NET/blob/521e18a36ca4d91393814a1b4ae6a9494a91fd9b/src/OpenAL/Silk.NET.OpenAL/ALC/ALContext.cs#L31C10-L31C10), we should pass in the current context's device.

# Related issues, Discord discussions, or proposals
[Issue](https://github.com/dotnet/Silk.NET/issues/1691)