### PR TITLE
Fix AL ReopenDevices extension

### DIFF
--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/ReopenDevices.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/ReopenDevices.cs
@@ -12,9 +12,9 @@ namespace Silk.NET.OpenAL.Extensions.Soft
     /// </summary>
     [NativeApi(Prefix = "alc")]
     [Extension("ALC_SOFT_reopen_device")]
-    public partial class ReopenDevices : NativeExtension<AL>
+    public partial class ReopenDevices : ContextExtensionBase
     {
-        /// <inheritdoc cref="ExtensionBase" />
+        /// <inheritdoc cref="ContextExtensionBase" />
         public ReopenDevices(INativeContext ctx)
             : base(ctx)
         {

--- a/src/OpenAL/Silk.NET.OpenAL.Tests/ExtensionLoadingTests.cs
+++ b/src/OpenAL/Silk.NET.OpenAL.Tests/ExtensionLoadingTests.cs
@@ -87,6 +87,7 @@ public class ExtensionLoadingTests
         Test<CaptureEnumerationEnumeration>();
         Test<EffectExtensionContext>();
         Test<Disconnect>();
+        Test<ReopenDevices>();
 
         SilkMarshal.Free(loaderPtr);
         SilkMarshal.Free(ctxLoaderPtr);


### PR DESCRIPTION
# Summary of the PR
Fixes the AL ReopenDevices extension to derive from `ContextExtensionBase` since it is a context extension.

# Related issues, Discord discussions, or proposals
[Issue](https://github.com/dotnet/Silk.NET/issues/1823)
