### PR TITLE
Fix BreakneckLock

### DIFF
--- a/src/Core/Silk.NET.Core/Miscellaneous/BreakneckLock.cs
+++ b/src/Core/Silk.NET.Core/Miscellaneous/BreakneckLock.cs
@@ -78,7 +78,7 @@ namespace Silk.NET.Core
         public void Enter(ref bool taken)
         {
             // while acquired == 1, loop, then when it == 0, exit and set it to 1
-            while (TryAcquire())
+            while (!TryAcquire())
             {
                 // NOP
             }
@@ -96,7 +96,6 @@ namespace Silk.NET.Core
         [MethodImpl(MaxOpt)]
         public void TryEnter(ref bool taken)
         {
-            // if it acquired == 0, change it to 1 and return true, else return false
             taken = TryAcquire();
         }
 
@@ -114,7 +113,7 @@ namespace Silk.NET.Core
         public void TryEnter(ref bool taken, uint iterations)
         {
             // if it acquired == 0, change it to 1 and return true, else return false
-            while (TryAcquire())
+            while (!TryAcquire())
             {
                 if (unchecked(iterations--) == 0) // postfix decrement, so no issue if iterations == 0 at first
                 {
@@ -142,7 +141,7 @@ namespace Silk.NET.Core
             long end = unchecked((long)timeout.TotalMilliseconds * Stopwatch.Frequency + start);
 
             // if it acquired == 0, change it to 1 and return true, else return false
-            while (TryAcquire())
+            while (!TryAcquire())
             {
                 if (Stopwatch.GetTimestamp() >= end)
                 {
@@ -190,6 +189,10 @@ namespace Silk.NET.Core
         }
 
         [MethodImpl(MaxOpt)]
-        private bool TryAcquire() => Interlocked.CompareExchange(ref _acquired, True, False) != False;
+        private bool TryAcquire()
+        {
+            // if it acquired == 0, change it to 1 and return true, else return false
+            return Interlocked.CompareExchange(ref _acquired, True, False) == False;
+        }
     }
 }


### PR DESCRIPTION
# Summary of the PR
Fixes the implementation of BreakneckLock (only used in SDL2 event code).
Found this issue when trying to figure out why the SDL2 platform implementation had a low update rate for inputs. (first frame locking fails but actually acquires, second frame "succeeds" to acquire the already acquired lock)

Consider the following code: ([similar to platform impl](https://github.com/dotnet/Silk.NET/blob/e433e6f51d66b02118bc037251de5d4ade58e248/src/Windowing/Silk.NET.Windowing.Sdl/SdlPlatform.cs#L152))
```csharp
var l = new BreakneckLock();
var taken = false;
Console.Out.WriteLine($"IsAcquired before: {l.IsAcquired}");
l.TryEnter(ref taken);
Console.Out.WriteLine($"---- TryEnter ----");
Console.Out.WriteLine($"taken after: {taken}");
Console.Out.WriteLine($"IsAcquired after: {l.IsAcquired}");
taken = false;
l.TryEnter(ref taken);
Console.Out.WriteLine($"---- TryEnter ----");
Console.Out.WriteLine($"taken after 2: {taken}");
Console.Out.WriteLine($"IsAcquired after 2: {l.IsAcquired}");
taken = false;
l.TryEnter(ref taken);
Console.Out.WriteLine($"---- TryEnter ----");
Console.Out.WriteLine($"taken after 3: {taken}");
Console.Out.WriteLine($"IsAcquired after 3: {l.IsAcquired}");
```

Current implementation:
```
IsAcquired before: False
---- TryEnter ----    
taken after: False    
IsAcquired after: True
---- TryEnter ----
taken after 2: True
IsAcquired after 2: True
---- TryEnter ----
taken after 3: True
IsAcquired after 3: True
```

Fixed implementation:
```
IsAcquired before: False
---- TryEnter ----
taken after: True
IsAcquired after: True
---- TryEnter ----
taken after 2: False
IsAcquired after 2: True
---- TryEnter ----
taken after 3: False
IsAcquired after 3: True
```

# Further Comments
The bug was added in this commit https://github.com/john-h-k/SpinLockSlim/commit/53de58368715ec2fcad1e4488f2167d5f2154df8