### PR TITLE
Update experimental feed docs to use RestoreAdditionalProjectSources

### DIFF
--- a/website/docs/silk.net/experimental-feed.md
+++ b/website/docs/silk.net/experimental-feed.md
@@ -39,7 +39,7 @@ In order to use the experimental feed, you must change this project file slightl
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <!-- Add the experimental feed as a restore source -->
-    <RestoreSources>$(RestoreSources);https://dotnet.github.io/Silk.NET/nuget/experimental/index.json</RestoreSources>
+    <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);https://dotnet.github.io/Silk.NET/nuget/experimental/index.json</RestoreAdditionalProjectSources>
   </PropertyGroup>
 ```
 


### PR DESCRIPTION
The experimental feed docs should suggest using ``RestoreAdditionalProjectSources`` instead of ``RestoreSources``.  Overriding ``RestoreSources`` will make it so that packages will not be restored from nuget.org unless you explicitly add them to the list it like in the snippet below.
```xml
<RestoreSources>$(RestoreSources);nuget.org;https://dotnet.github.io/Silk.NET/nuget/experimental/index.json</RestoreSources>
```
The current example provided in the docs will always fail when adding new nuget packages since it only checks the gitlab registry for packages.
``No packages exist with this id in source(s): https://dotnet.github.io/Silk.NET/nuget/experimental/index.json``

I think ``RestoreAdditionalProjectSources`` should be used since it doesn't get rid of nuget.org as the default but still allows you to provide silk.net's experimental feed as an additional restore source.

Old:
```xml
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net7.0</TargetFramework>
    <!-- Add the experimental feed as a restore source -->
    <RestoreSources>$(RestoreSources);https://dotnet.github.io/Silk.NET/nuget/experimental/index.json</RestoreSources>
  </PropertyGroup>
```

New:
```xml
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net7.0</TargetFramework>
    <!-- Add the experimental feed as a restore source -->
    <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);https://dotnet.github.io/Silk.NET/nuget/experimental/index.json</RestoreAdditionalProjectSources>
  </PropertyGroup>
```