### PR TITLE
Fix SDL2 platform losing events when using multiple windows/views

### DIFF
--- a/src/Input/Silk.NET.Input.Sdl/SdlInputContext.cs
+++ b/src/Input/Silk.NET.Input.Sdl/SdlInputContext.cs
@@ -254,7 +254,7 @@ namespace Silk.NET.Input.Sdl
 
                 if (!skipped)
                 {
-                    _sdlView.Events.RemoveAt(i);
+                    _sdlView.RemoveEvent(i);
                 }
                 else
                 {

--- a/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
@@ -289,7 +289,13 @@ namespace Silk.NET.Windowing.Internals
             _inRenderLoop = true;
             DoEvents();
             ProcessEvents?.Invoke();
+            AfterProcessingEvents();
             _inRenderLoop = false;
+        }
+        
+        internal virtual void AfterProcessingEvents()
+        {
+            // used by sdl2 windows to clear events
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining | (MethodImplOptions) 512)]

--- a/src/Windowing/Silk.NET.Windowing.Sdl/SdlView.cs
+++ b/src/Windowing/Silk.NET.Windowing.Sdl/SdlView.cs
@@ -250,7 +250,6 @@ namespace Silk.NET.Windowing.Sdl
 
         public override void DoEvents()
         {
-            ClearEvents();
             do
             {
                 _platform.DoEvents();
@@ -260,18 +259,23 @@ namespace Silk.NET.Windowing.Sdl
         }
 
         private void ClearEvents()
-        {
-            var c = Events.Count;
-            for (var i = 0; i < c; i++)
+        { 
+            // remove events in reverse order to prevent shuffling in the list
+            for (var i = Events.Count - 1; i >= 0; i--)
             {
-                var @event = Events[0];
-                if (@event.Type == (uint) EventType.Dropfile)
-                {
-                    Sdl.Free(@event.Drop.File);
-                }
-
-                Events.RemoveAt(0);
+                RemoveEvent(i);
             }
+        }
+        
+        internal void RemoveEvent(int index)
+        {
+            var @event = Events[index];
+            if (@event.Type == (uint) EventType.Dropfile)
+            {
+                Sdl.Free(@event.Drop.File);
+            }
+
+            Events.RemoveAt(index);
         }
 
         ~SdlView()
@@ -397,7 +401,7 @@ namespace Silk.NET.Windowing.Sdl
 
                 if (!skipped)
                 {
-                    Events.RemoveAt(i);
+                    RemoveEvent(i);
                 }
             }
             
@@ -431,7 +435,7 @@ namespace Silk.NET.Windowing.Sdl
                     EventType.Mousemotion when @event.Motion.WindowID == _id => true,
                     EventType.Mousebuttondown when @event.Button.WindowID == _id => true,
                     EventType.Mousebuttonup when @event.Button.WindowID == _id => true,
-                    EventType.Mousewheel when @event.Motion.WindowID == _id => true,
+                    EventType.Mousewheel when @event.Wheel.WindowID == _id => true,
                     EventType.Joyaxismotion => true,
                     EventType.Joyballmotion => true,
                     EventType.Joyhatmotion => true,
@@ -471,6 +475,11 @@ namespace Silk.NET.Windowing.Sdl
             }
             
             EndEventProcessing(taken);
+        }
+
+        internal override void AfterProcessingEvents()
+        {
+            ClearEvents();
         }
     }
 }

--- a/src/Windowing/Silk.NET.Windowing.Sdl/SdlWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Sdl/SdlWindow.cs
@@ -417,7 +417,7 @@ namespace Silk.NET.Windowing.Sdl
 
                 if (!skipped)
                 {
-                    Events.RemoveAt(i);
+                    RemoveEvent(i);
                 }
             }
 


### PR DESCRIPTION
# Summary of the PR
Currently the SDL windowing platform loses events when using multiple windows.

Flow of the bug:
- 1st Window DoEvents
  - Previous events cleared
  - Platform DoEvents
    - SDL PollEvent
    - Polled events dispatched to every window
  - Events handled for this window
- 2nd Window DoEvents
  - Previous events cleared **(and everything we just collected)**
  - Platform DoEvents
    - SDL PollEvent **(likely gives nothing since we just polled already)**
    - Polled events dispatched to every window
  - Events handled for this window **(there are none)**

The solution in this pr is to add a new (internal) AfterProcessingEvents method to (the internal) ViewImplementationBase, which performs the clearing of the event queue. Clearing at the end of DoEvents is too early for the input module.

I also took the liberty of consolidating event removal logic. I thought its best to be safe around free handling for SDL_DropEvent.

# Related issues, Discord discussions, or proposals
Fixes https://github.com/dotnet/Silk.NET/issues/1550
Fixes https://github.com/dotnet/Silk.NET/issues/350

# Further Comments
Feedback/reshaping welcome.
Maybe AfterProcessingEvents -> ClearEvents? and remove non-virtual ClearEvents from sdl view.
Or maybe this multi-poll logic is too cursed already? idk