### PR TITLE
Added SetFocus method to the Window

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IView.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IView.cs
@@ -104,6 +104,11 @@ namespace Silk.NET.Windowing
         void Reset();
 
         /// <summary>
+        /// Sets focus to current window.
+        /// </summary>
+        void SetFocus();
+
+        /// <summary>
         /// Close this window.
         /// </summary>
         void Close();

--- a/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IView.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IView.cs
@@ -106,7 +106,7 @@ namespace Silk.NET.Windowing
         /// <summary>
         /// Sets focus to current window.
         /// </summary>
-        void SetFocus();
+        void Focus();
 
         /// <summary>
         /// Close this window.

--- a/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
@@ -71,6 +71,7 @@ namespace Silk.NET.Windowing.Internals
         public abstract void ContinueEvents();
         public abstract Vector2D<int> PointToClient(Vector2D<int> point);
         public abstract Vector2D<int> PointToScreen(Vector2D<int> point);
+        public abstract void SetFocus();
         public abstract void Close();
         protected abstract void RegisterCallbacks();
         protected abstract void UnregisterCallbacks();

--- a/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
@@ -71,7 +71,7 @@ namespace Silk.NET.Windowing.Internals
         public abstract void ContinueEvents();
         public abstract Vector2D<int> PointToClient(Vector2D<int> point);
         public abstract Vector2D<int> PointToScreen(Vector2D<int> point);
-        public abstract void SetFocus();
+        public abstract void Focus();
         public abstract void Close();
         protected abstract void RegisterCallbacks();
         protected abstract void UnregisterCallbacks();

--- a/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -60,6 +60,7 @@ Silk.NET.Windowing.IView.Render -> System.Action<double>?
 Silk.NET.Windowing.IView.Reset() -> void
 Silk.NET.Windowing.IView.Resize -> System.Action<Silk.NET.Maths.Vector2D<int>>?
 Silk.NET.Windowing.IView.Run(System.Action! onFrame) -> void
+Silk.NET.Windowing.IView.SetFocus() -> void
 Silk.NET.Windowing.IView.Time.get -> double
 Silk.NET.Windowing.IView.Update -> System.Action<double>?
 Silk.NET.Windowing.IViewProperties

--- a/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -60,7 +60,7 @@ Silk.NET.Windowing.IView.Render -> System.Action<double>?
 Silk.NET.Windowing.IView.Reset() -> void
 Silk.NET.Windowing.IView.Resize -> System.Action<Silk.NET.Maths.Vector2D<int>>?
 Silk.NET.Windowing.IView.Run(System.Action! onFrame) -> void
-Silk.NET.Windowing.IView.SetFocus() -> void
+Silk.NET.Windowing.IView.Focus() -> void
 Silk.NET.Windowing.IView.Time.get -> double
 Silk.NET.Windowing.IView.Update -> System.Action<double>?
 Silk.NET.Windowing.IViewProperties

--- a/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -60,6 +60,7 @@ Silk.NET.Windowing.IView.Render -> System.Action<double>?
 Silk.NET.Windowing.IView.Reset() -> void
 Silk.NET.Windowing.IView.Resize -> System.Action<Silk.NET.Maths.Vector2D<int>>?
 Silk.NET.Windowing.IView.Run(System.Action! onFrame) -> void
+Silk.NET.Windowing.IView.SetFocus() -> void
 Silk.NET.Windowing.IView.Time.get -> double
 Silk.NET.Windowing.IView.Update -> System.Action<double>?
 Silk.NET.Windowing.IViewProperties

--- a/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/Windowing/Silk.NET.Windowing.Common/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -60,7 +60,7 @@ Silk.NET.Windowing.IView.Render -> System.Action<double>?
 Silk.NET.Windowing.IView.Reset() -> void
 Silk.NET.Windowing.IView.Resize -> System.Action<Silk.NET.Maths.Vector2D<int>>?
 Silk.NET.Windowing.IView.Run(System.Action! onFrame) -> void
-Silk.NET.Windowing.IView.SetFocus() -> void
+Silk.NET.Windowing.IView.Focus() -> void
 Silk.NET.Windowing.IView.Time.get -> double
 Silk.NET.Windowing.IView.Update -> System.Action<double>?
 Silk.NET.Windowing.IViewProperties

--- a/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
@@ -677,6 +677,11 @@ namespace Silk.NET.Windowing.Glfw
             return ret;
         }
 
+        public override void SetFocus() 
+        {
+            _glfw.FocusWindow(_glfwWindow);
+        }
+
         public override void Close()
         {
             Closing?.Invoke();

--- a/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Glfw/GlfwWindow.cs
@@ -677,7 +677,7 @@ namespace Silk.NET.Windowing.Glfw
             return ret;
         }
 
-        public override void SetFocus() 
+        public override void Focus() 
         {
             _glfw.FocusWindow(_glfwWindow);
         }

--- a/src/Windowing/Silk.NET.Windowing.Sdl/SdlView.cs
+++ b/src/Windowing/Silk.NET.Windowing.Sdl/SdlView.cs
@@ -313,6 +313,11 @@ namespace Silk.NET.Windowing.Sdl
             Reset();
         }
 
+        public override void SetFocus()
+        {
+            Sdl.RaiseWindow(SdlWindow);
+        }
+
         public override void Close()
         {
             Closing?.Invoke();

--- a/src/Windowing/Silk.NET.Windowing.Sdl/SdlView.cs
+++ b/src/Windowing/Silk.NET.Windowing.Sdl/SdlView.cs
@@ -313,7 +313,7 @@ namespace Silk.NET.Windowing.Sdl
             Reset();
         }
 
-        public override void SetFocus()
+        public override void Focus()
         {
             Sdl.RaiseWindow(SdlWindow);
         }


### PR DESCRIPTION
# Summary of the PR
Added SetFocus method to the Window

# Related issues, Discord discussions, or proposals
As was discussed here https://github.com/dotnet/Silk.NET/discussions/1526, both GLFW and SDL support this functionality and it is very usefull for the ImGui support, so it can be added to the window.

# Further Comments
Unfortunately I wasn't be able to build the project, to check if everything is working correctly, could someone to pick it up? (I am asked for some reason to enter credentials for https://chrome-internal.googlesource.com that I don't have while recursive submodule update. Also I have tons of  errors on nuke compile like  Restore: \Silk.NET\src\Windowing\Silk.NET.Windowing.Sdl\S
ilk.NET.Windowing.Sdl.csproj : error NU1301: Failed to load service index for source https://gitlab.com/api/v4/projects/47661606/packages/nuget/index.js
on. Silk.NET\Silk.NET.gen.sln)