### PR TITLE
Make Silk.NET buildable on Linux by skipping iOS and Mac Catalyst stuff.

### DIFF
--- a/.github/workflows/bindings-regeneration.yml
+++ b/.github/workflows/bindings-regeneration.yml
@@ -48,7 +48,7 @@ jobs:
       run: dotnet tool install Nuke.GlobalTool --global
     - name: Install Workloads
       # TODO: This is slow. Maybe we can make a docker container with this already done?
-      run: dotnet workload install android ios maccatalyst maui
+      run: dotnet workload install android ios maccatalyst
     - uses: GuillaumeFalourd/setup-windows10-sdk-action@v1.9
       name: Setup Windows 11 SDK
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         dotnet-version: 7.0.102
     - name: Install Workloads
-      run: dotnet workload install android ios maccatalyst maui
+      run: dotnet workload install android ios maccatalyst
     - name: Test
       if: ${{ github.repository != 'dotnet/Silk.NET' || !startsWith(github.ref, 'refs/tags/') }}
       # skip Clean, Restore, and Compile as this will build the affect the whole solution.

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -42,7 +42,7 @@ jobs:
                     7.0.*
             - name: Install Workloads for Restore
               # TODO: This is slow. Maybe we can make a docker container with this already done?
-              run: dotnet workload install android ios maccatalyst maui
+              run: dotnet workload install android ios maccatalyst
             - name: Ensure Public API Declared
               run: ./build.sh EnsureApiDeclared
               env:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 </div>
 
-<div> 
+<div>
 <!-- End exclude from NuGet readme. -->
 <!-- Begin include in NuGet readme.
 ![Silk.NET Logo](https://raw.githubusercontent.com/dotnet/Silk.NET/main/documentation/readme/silkdotnet_v3_horizontal_96.svg)
@@ -74,16 +74,18 @@ In addition, the Silk.NET working group help drive larger user-facing changes pr
 <h1 align="center">Building from source</h1>
 
 Prerequisites
-- **Must**: .NET 6 SDK
-- **Should**: [NUKE](https://nuke.build) (build system). Install using `dotnet tool install Nuke.GlobalTool --global`
-- **Should**: Android, iOS, and MAUI .NET 6 workloads (use `dotnet workload install android ios maccatalyst maui` to install them)
-- **Should**: Android SDK version 30 with NDK tools installed. On Windows, for best results this should be installed into `C:\ProgramData\Android\android-sdk`.
-- **Could**: Java JDK (for gradle)
-- **Could**: Visual Studio 2022 Community version 17.0 or later
+- .NET 6 SDK and .NET 7 SDK
+- Android, iOS, and Mac Catalyst workloads (use `dotnet workload install android ios maccatalyst` to install them)
+    - On Linux, `ios` and `maccatalyst` should be omitted as they are not available
+- Android SDK version 30 with NDK tools installed
+    - On Windows, for best results this should be installed into `C:\ProgramData\Android\android-sdk`
+- Java 11 JDK
+- Visual Studio 2022 Community version 17.0 or later (optional)
 
 Instructions
 - Clone the repository (recursively)
 - Run build.sh, build.cmd, build.ps1, or `nuke compile`.
+    - On Linux, you may need to pass `--msbuild-properties AndroidSdkDirectory=/path/to/android/sdk`
 - Use the DLLs. To get nupkgs you can use with NuGet instead, use `nuke pack`.
 
 There are more advanced build actions you can do too, such as FullBuild, Pack, FullPack, among others which you can view by doing `nuke --plan`.
@@ -127,7 +129,7 @@ Silk.NET is a [.NET Foundation](https://www.dotnetfoundation.org/projects) proje
 <div>
     <a href="https://www.jetbrains.com/?from=Silk.NET" align="right"><img src="https://raw.githubusercontent.com/dotnet/Silk.NET/main/documentation/readme/jetbrains.svg" alt="JetBrains" class="logo-footer" width="72" align="left">
     <a><br/>
-        
+
 Special thanks to [JetBrains](https://www.jetbrains.com/?from=Silk.NET) for supporting us with open-source licenses for their IDEs. </a>
 </div>
 

--- a/src/Lab/Experiments/TriangleNET6/TriangleNET6.csproj
+++ b/src/Lab/Experiments/TriangleNET6/TriangleNET6.csproj
@@ -2,7 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>net6.0;net6.0-android</TargetFrameworks>
+        <TargetFrameworks Condition="!$([MSBuild]::IsOsPlatform('Linux'))">$(TargetFrameworks);net6.0-ios</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>preview</LangVersion>
         <RuntimeIdentifiers Condition="'$(RuntimeIdentifiers)' == '' And '$(TargetFramework)' == 'net6.0'">$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifiers>

--- a/src/Maths/Silk.NET.Maths/Silk.NET.Maths.csproj
+++ b/src/Maths/Silk.NET.Maths/Silk.NET.Maths.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0-android;net6.0-ios</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0-android</TargetFrameworks>
+        <TargetFrameworks Condition="!$([MSBuild]::IsOsPlatform('Linux'))">$(TargetFrameworks);net6.0-ios</TargetFrameworks>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Vulkan/Silk.NET.Vulkan/Silk.NET.Vulkan.csproj
+++ b/src/Vulkan/Silk.NET.Vulkan/Silk.NET.Vulkan.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOsPlatform('Linux'))">$(TargetFrameworks);net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>

--- a/src/Windowing/Silk.NET.Windowing.Sdl/Silk.NET.Windowing.Sdl.csproj
+++ b/src/Windowing/Silk.NET.Windowing.Sdl/Silk.NET.Windowing.Sdl.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;net6.0-android</TargetFrameworks>
+        <TargetFrameworks Condition="!$([MSBuild]::IsOsPlatform('Linux'))">$(TargetFrameworks);net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
         <LangVersion>8</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Nullable>enable</Nullable>
         <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
             <_Parameter1>Silk.NET.Input.Sdl</_Parameter1>

--- a/src/Windowing/Silk.NET.Windowing/Silk.NET.Windowing.csproj
+++ b/src/Windowing/Silk.NET.Windowing/Silk.NET.Windowing.csproj
@@ -1,14 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0;net6.0-android</TargetFrameworks>
+        <TargetFrameworks Condition="!$([MSBuild]::IsOsPlatform('Linux'))">$(TargetFrameworks);net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
         <SilkMetapackage>true</SilkMetapackage>
     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Silk.NET.Windowing.Common\Silk.NET.Windowing.Common.csproj" />
     </ItemGroup>
-    
+
     <ItemGroup Condition="'$(TargetFramework)' != 'net6.0-android' And '$(TargetFramework)' != 'net6.0-ios' And '$(TargetFramework)' != 'net6.0-maccatalyst' And '$(TargetFramework)' != 'net6.0'">
         <ProjectReference Include="..\Silk.NET.Windowing.Glfw\Silk.NET.Windowing.Glfw.csproj" />
         <ProjectReference Include="..\Silk.NET.Windowing.Sdl\Silk.NET.Windowing.Sdl.csproj" />


### PR DESCRIPTION
Also update build instructions.

Closes #2014.