### PR TITLE
Ensure that setting the GLFW mouse standard cursor works as expected

### DIFF
--- a/src/Input/Silk.NET.Input.Glfw/GlfwCursor.cs
+++ b/src/Input/Silk.NET.Input.Glfw/GlfwCursor.cs
@@ -80,8 +80,8 @@ namespace Silk.NET.Input.Glfw
             {
                 if (_standardCursor != value)
                 {
-                    UpdateStandardCursor();
                     _standardCursor = value;
+                    UpdateStandardCursor();
                 }
             }
         }


### PR DESCRIPTION
# Summary of the PR
This fixes unexpected behavior when setting the Standard Cursor using the GLFW backend as described at #2169.