### PR TITLE
Add forced resigning of SDL2 outputs after stripping

### DIFF
--- a/build/nuke/Native/SDL2.cs
+++ b/build/nuke/Native/SDL2.cs
@@ -128,6 +128,9 @@ partial class Build
                     EnsureCleanDirectory(Path.GetDirectoryName(@out));
                     InheritedShell($"lipo -create -output \"{@out}\" \"{@in}\"").AssertZeroExitCode();
                     InheritedShell($"strip -Sx \"{@out}\"").AssertZeroExitCode();
+
+                    // Re-sign, as lipo and stripping invalidates the signature
+                    InheritedShell($"codesign --force --sign - \"{@out}\"").AssertZeroExitCode();
                 }
             }
 

--- a/build/nuke/Native/SDL2.cs
+++ b/build/nuke/Native/SDL2.cs
@@ -127,10 +127,11 @@ partial class Build
 
                     EnsureCleanDirectory(Path.GetDirectoryName(@out));
                     InheritedShell($"lipo -create -output \"{@out}\" \"{@in}\"").AssertZeroExitCode();
-                    InheritedShell($"strip -Sx \"{@out}\"").AssertZeroExitCode();
+                    InheritedShell($"strip -Sx -no_code_signature_warning \"{@out}\"").AssertZeroExitCode();
 
                     // Re-sign, as lipo and stripping invalidates the signature
-                    InheritedShell($"codesign --force --sign - \"{@out}\"").AssertZeroExitCode();
+                    InheritedShell($"codesign --remove-signature \"{@out}\"").AssertZeroExitCode();
+                    InheritedShell($"codesign --sign - \"{@out}\"").AssertZeroExitCode();
                 }
             }
 


### PR DESCRIPTION
This PR changes the SDL2 build to code-sign at the very end, fixing #2174. The build indicated:

> strip: warning: changes being made to the file will invalidate the code signature in: /Users/joskuijpers/Developer/Silk.NET/src/Native/Silk.NET.SDL.Native/runtimes/osx/native/libSDL2-2.0.dylib (for architecture x86_64)
strip: warning: changes being made to the file will invalidate the code signature in: /Users/joskuijpers/Developer/Silk.NET/src/Native/Silk.NET.SDL.Native/runtimes/osx/native/libSDL2-2.0.dylib (for architecture arm64)

On Mx systems, all binaries need a valid signature.
The build now adds a code sign, and has a new message: `libSDL2-2.0.dylib: replacing existing signature` 