### PR TITLE
Fix broken github link

### DIFF
--- a/website/_theme/src/11-navcontent.cshtml
+++ b/website/_theme/src/11-navcontent.cshtml
@@ -127,7 +127,7 @@
             </a>
           </li>
       }
-      @if (tocModelRoot.Metadata?.TryGetValue("theme.silk.nav.github", out discordLink) ?? false)
+      @if (tocModelRoot.Metadata?.TryGetValue("theme.silk.nav.github", out githubLink) ?? false)
       {
           <li class="nav-item">
             <a class="nav-link nav-link-icon" href="@githubLink" target="_blank" data-toggle="tooltip" title="Star us on Github">


### PR DESCRIPTION
The code responsible for making the github button used the incorrect variable, which resulted in the github button not leading to the proper URL.

# Summary of the PR
Changed the code to use `githubLink` instead of `discordLink`.
