### PR TITLE
Adding SyntaxContext

### DIFF
--- a/sources/SilkTouch/Clang/ContextCSharpSyntaxRewriter.cs
+++ b/sources/SilkTouch/Clang/ContextCSharpSyntaxRewriter.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Silk.NET.SilkTouch.Clang;
+
+/// <summary>
+/// <see cref="CSharpSyntaxRewriter"/> which contains a queryable current context
+/// </summary>
+/// <param name="visitIntoStructuredTrivia"></param>
+public abstract class ContextCSharpSyntaxRewriter(bool visitIntoStructuredTrivia = false)
+    : CSharpSyntaxRewriter(visitIntoStructuredTrivia)
+{
+    /// <summary>
+    /// The current type being visited
+    /// </summary>
+    public SyntaxContext.IBaseTypeContext? CurrentContext { get; internal set; }
+
+    /// <summary>
+    /// The list of the namespaces being used
+    /// </summary>
+    public List<string> Usings { get; internal set; } = [];
+
+    /// <summary>
+    /// The namespace of the current context
+    /// </summary>
+    public string CurrentNamespace { get; internal set; } = string.Empty;
+}

--- a/sources/SilkTouch/Clang/ContextCSharpSyntaxRewriter.cs
+++ b/sources/SilkTouch/Clang/ContextCSharpSyntaxRewriter.cs
@@ -20,7 +20,7 @@ public abstract class ContextCSharpSyntaxRewriter(bool visitIntoStructuredTrivia
     /// <summary>
     /// The current type being visited
     /// </summary>
-    public SyntaxContext.IBaseTypeContext? CurrentContext { get; internal set; }
+    public IBaseTypeContext? CurrentContext { get; internal set; }
 
     /// <summary>
     /// The list of the namespaces being used
@@ -31,4 +31,9 @@ public abstract class ContextCSharpSyntaxRewriter(bool visitIntoStructuredTrivia
     /// The namespace of the current context
     /// </summary>
     public string CurrentNamespace { get; internal set; } = string.Empty;
+
+    /// <summary>
+    /// The currently SyntaxContext
+    /// </summary>
+    public SyntaxContext? Context { get; internal set; };
 }

--- a/sources/SilkTouch/Clang/ContextCSharpSyntaxRewriter.cs
+++ b/sources/SilkTouch/Clang/ContextCSharpSyntaxRewriter.cs
@@ -20,7 +20,7 @@ public abstract class ContextCSharpSyntaxRewriter(bool visitIntoStructuredTrivia
     /// <summary>
     /// The current type being visited
     /// </summary>
-    public IBaseTypeContext? CurrentContext { get; internal set; }
+    public TypeContainer? CurrentContext { get; internal set; }
 
     /// <summary>
     /// The list of the namespaces being used

--- a/sources/SilkTouch/Clang/ContextCSharpSyntaxRewriter.cs
+++ b/sources/SilkTouch/Clang/ContextCSharpSyntaxRewriter.cs
@@ -35,5 +35,5 @@ public abstract class ContextCSharpSyntaxRewriter(bool visitIntoStructuredTrivia
     /// <summary>
     /// The currently SyntaxContext
     /// </summary>
-    public SyntaxContext? Context { get; internal set; };
+    public SyntaxContext? Context { get; internal set; }
 }

--- a/sources/SilkTouch/Clang/ContextCSharpSyntaxRewriter.cs
+++ b/sources/SilkTouch/Clang/ContextCSharpSyntaxRewriter.cs
@@ -1,11 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Silk.NET.SilkTouch.Clang;
@@ -28,12 +24,46 @@ public abstract class ContextCSharpSyntaxRewriter(bool visitIntoStructuredTrivia
     public List<string> Usings { get; internal set; } = [];
 
     /// <summary>
+    /// The current Namespace being visited
+    /// </summary>
+    public INamespaceContext? CurrentNamespaceContext { get; internal set; }
+
+    /// <summary>
+    /// The top-level namespace context (global context)
+    /// </summary>
+    public INamespaceContext? TopNamespaceContext { get; internal set; }
+
+    /// <summary>
     /// The namespace of the current context
     /// </summary>
-    public string CurrentNamespace { get; internal set; } = string.Empty;
+    public string CurrentNamespace => CurrentNamespaceContext?.FullNamespace ?? string.Empty;
 
     /// <summary>
     /// The currently SyntaxContext
     /// </summary>
     public SyntaxContext? Context { get; internal set; }
+
+    /// <summary>
+    /// The file that is currently being editted
+    /// </summary>
+    public string File { get; internal set; } = string.Empty;
+
+    /// <summary>
+    /// Called when a file is started being worked on
+    /// </summary>
+    /// <param name="fileName"></param>
+    public virtual void OnFileStarted(string fileName) { }
+
+    /// <summary>
+    /// Called when a file is finished being worked on
+    /// </summary>
+    /// <param name="fileName"></param>
+    public virtual void OnFileFinished(string fileName) { }
+
+    /// <summary>
+    /// Whether or not this file should be skipped upon visiting
+    /// </summary>
+    /// <param name="fileName"></param>
+    /// <returns></returns>
+    public virtual bool ShouldSkipFile(string fileName) { return false; }
 }

--- a/sources/SilkTouch/Clang/ContextCSharpSyntaxVisitor.cs
+++ b/sources/SilkTouch/Clang/ContextCSharpSyntaxVisitor.cs
@@ -26,12 +26,46 @@ public class ContextCSharpSyntaxVisitor : CSharpSyntaxVisitor
     public List<string> Usings { get; internal set; } = [];
 
     /// <summary>
+    /// The current Namespace being visited
+    /// </summary>
+    public INamespaceContext? CurrentNamespaceContext { get; internal set; }
+
+    /// <summary>
+    /// The top-level namespace context (global context)
+    /// </summary>
+    public INamespaceContext? TopNamespaceContext { get; internal set; }
+
+    /// <summary>
     /// The namespace of the current context
     /// </summary>
-    public string CurrentNamespace { get; internal set; } = string.Empty;
+    public string CurrentNamespace => CurrentNamespaceContext?.FullNamespace ?? string.Empty;
 
     /// <summary>
     /// The currently SyntaxContext
     /// </summary>
     public SyntaxContext? Context { get; internal set; }
+
+    /// <summary>
+    /// The file that is currently being editted
+    /// </summary>
+    public string File { get; internal set; } = string.Empty;
+
+    /// <summary>
+    /// Called when a file is started being worked on
+    /// </summary>
+    /// <param name="fileName"></param>
+    public virtual void OnFileStarted(string fileName) { }
+
+    /// <summary>
+    /// Called when a file is finished being worked on
+    /// </summary>
+    /// <param name="fileName"></param>
+    public virtual void OnFileFinished(string fileName) { }
+
+    /// <summary>
+    /// Whether or not this file should be skipped upon visiting
+    /// </summary>
+    /// <param name="fileName"></param>
+    /// <returns></returns>
+    public virtual bool ShouldSkipFile(string fileName) { return false; }
 }

--- a/sources/SilkTouch/Clang/ContextCSharpSyntaxVisitor.cs
+++ b/sources/SilkTouch/Clang/ContextCSharpSyntaxVisitor.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Silk.NET.SilkTouch.Clang;
+
+/// <summary>
+/// A <see cref="ContextCSharpSyntaxVisitor"/> with metadata for the current <see cref="SyntaxContext"/> Visit method
+/// </summary>
+public class ContextCSharpSyntaxVisitor : CSharpSyntaxVisitor
+{
+    /// <summary>
+    /// The current type being visited
+    /// </summary>
+    public IBaseTypeContext? CurrentContext { get; internal set; }
+
+    /// <summary>
+    /// The list of the namespaces being used
+    /// </summary>
+    public List<string> Usings { get; internal set; } = [];
+
+    /// <summary>
+    /// The namespace of the current context
+    /// </summary>
+    public string CurrentNamespace { get; internal set; } = string.Empty;
+
+    /// <summary>
+    /// The currently SyntaxContext
+    /// </summary>
+    public SyntaxContext? Context { get; internal set; }
+}

--- a/sources/SilkTouch/Clang/IBaseTypeContext.cs
+++ b/sources/SilkTouch/Clang/IBaseTypeContext.cs
@@ -226,6 +226,11 @@ public interface IBaseTypeContext
     void SetParent(IBaseTypeContext? parent);
 
     /// <summary>
+    /// Sets all subTypes to null to be cleaned later
+    /// </summary>
+    void Delete();
+
+    /// <summary>
     /// Represents a type defined within a type
     /// </summary>
     /// <param name="Node"></param>

--- a/sources/SilkTouch/Clang/IBaseTypeContext.cs
+++ b/sources/SilkTouch/Clang/IBaseTypeContext.cs
@@ -233,12 +233,18 @@ public interface IBaseTypeContext
     /// Rewrites the current type with a given rewriter and some metadata
     /// </summary>
     /// <param name="rewriter"></param>
-    /// <param name="ns"></param>
-    /// <param name="file"></param>
-    /// <param name="context"></param>
-    /// <param name="usings"></param>
+    /// <param name="ns">current namespace</param>
+    /// <param name="file">file this type is in</param>
+    /// <param name="context">related syntax context</param>
+    /// <param name="usings">available usings</param>
     /// <returns></returns>
-    IBaseTypeContext? Rewrite(ContextCSharpSyntaxRewriter rewriter, string ns, string file, SyntaxContext context, List<string> usings);
+    IBaseTypeContext? Rewrite(ContextCSharpSyntaxRewriter rewriter, string ns, string file);
+
+    /// <summary>
+    /// Visits the current type with a given visitor and some metadata
+    /// </summary>
+    /// <param name="visitor"></param>
+    void Visit(ContextCSharpSyntaxVisitor visitor);
 
     /// <summary>
     /// Converts this type to a complete <see cref="MemberDeclarationSyntax"/>

--- a/sources/SilkTouch/Clang/IBaseTypeContext.cs
+++ b/sources/SilkTouch/Clang/IBaseTypeContext.cs
@@ -46,37 +46,6 @@ public interface IBaseTypeContext
     BaseTypeDeclarationSyntax? Node { get; }
 
     /// <summary>
-    /// Does this context represent an enum
-    /// </summary>
-    bool IsEnum { get; }
-
-    /// <summary>
-    /// Attempts to retrieve information about a enum member
-    /// </summary>
-    /// <param name="memberName"></param>
-    /// <param name="member"></param>
-    /// <returns></returns>
-    bool TryGetEnumMember(string memberName, out EnumMemberDeclarationSyntax? member);
-
-    /// <summary>
-    /// Attempts to Add or overwrites existing enum member within this type
-    /// </summary>
-    /// <param name="node"></param>
-    /// <returns></returns>
-    bool TryAddEnumMember(EnumMemberDeclarationSyntax node);
-
-    /// <summary>
-    /// Removes the enum member with the given name within this type
-    /// </summary>
-    /// <param name="name"></param>
-    void RemoveEnumMember(string name);
-
-    /// <summary>
-    /// All enumerable members contained within this type
-    /// </summary>
-    IEnumerable<(string, EnumMemberDeclarationSyntax)> EnumMembers { get; }
-
-    /// <summary>
     /// Attempts to get Type object that is contained within this type
     /// </summary>
     /// <param name="typeName"></param>
@@ -123,7 +92,7 @@ public interface IBaseTypeContext
     /// </summary>
     /// <param name="node"></param>
     /// <param name="rewriter"></param>
-    bool TryAddField(FieldDeclarationSyntax node, ContextCSharpSyntaxRewriter rewriter);
+    bool TryAddField(BaseFieldDeclarationSyntax node, ContextCSharpSyntaxRewriter rewriter);
 
     /// <summary>
     /// Removes the field with the given name within this type
@@ -149,7 +118,7 @@ public interface IBaseTypeContext
     /// </summary>
     /// <param name="node"></param>
     /// <param name="rewriter"></param>
-    bool TryAddProperty(PropertyDeclarationSyntax node, ContextCSharpSyntaxRewriter rewriter);
+    bool TryAddProperty(BasePropertyDeclarationSyntax node, ContextCSharpSyntaxRewriter rewriter);
 
     /// <summary>
     /// Removes the property with the given name within this type
@@ -235,10 +204,8 @@ public interface IBaseTypeContext
     /// <param name="rewriter"></param>
     /// <param name="ns">current namespace</param>
     /// <param name="file">file this type is in</param>
-    /// <param name="context">related syntax context</param>
-    /// <param name="usings">available usings</param>
     /// <returns></returns>
-    IBaseTypeContext? Rewrite(ContextCSharpSyntaxRewriter rewriter, string ns, string file);
+    TypeContainer? Rewrite(ContextCSharpSyntaxRewriter rewriter, string ns, string file);
 
     /// <summary>
     /// Visits the current type with a given visitor and some metadata
@@ -269,32 +236,41 @@ public interface IBaseTypeContext
     /// Represents a field defined within a type
     /// </summary>
     /// <param name="Node"></param>
-    /// <param name="TypeContext"></param>
+    /// <param name="Type"></param>
     /// <param name="TypePointerDepth"></param>
-    public record struct Field(FieldDeclarationSyntax? Node = null, IBaseTypeContext? TypeContext = null, int TypePointerDepth = 0);
+    public record struct Field(BaseFieldDeclarationSyntax? Node = null, TypeContainer? Type = null, int TypePointerDepth = 0);
 
     /// <summary>
     /// Represents a property defined within a type
     /// </summary>
     /// <param name="Node"></param>
-    /// <param name="TypeContext"></param>
+    /// <param name="Type"></param>
     /// <param name="TypePointerDepth"></param>
-    public record struct Property(PropertyDeclarationSyntax? Node = null, IBaseTypeContext? TypeContext = null, int TypePointerDepth = 0);
+    public record struct Property(BasePropertyDeclarationSyntax? Node = null, TypeContainer? Type = null, int TypePointerDepth = 0);
 
     /// <summary>
     /// Represents a method defined within a type
     /// </summary>
     /// <param name="Node"></param>
-    /// <param name="ReturnTypeContext"></param>
+    /// <param name="ReturnType"></param>
     /// <param name="ReturnTypePointerDepth"></param>
     /// <param name="Parameters"></param>
-    public record struct Method(MethodDeclarationSyntax? Node = null, IBaseTypeContext? ReturnTypeContext = null, int ReturnTypePointerDepth = 0, IEnumerable<(string, MethodParameter)>? Parameters = null);
+    public record struct Method(MethodDeclarationSyntax? Node = null, TypeContainer? ReturnType = null, int ReturnTypePointerDepth = 0, IEnumerable<(string, MethodParameter)>? Parameters = null);
 
     /// <summary>
     /// Represents a parameter of a method defined within a type
     /// </summary>
     /// <param name="Node"></param>
-    /// <param name="TypeContext"></param>
+    /// <param name="Type"></param>
     /// <param name="TypePointerDepth"></param>
-    public record struct MethodParameter(ParameterSyntax Node, IBaseTypeContext TypeContext, int TypePointerDepth);
+    public record struct MethodParameter(ParameterSyntax Node, TypeContainer? Type, int TypePointerDepth);
+
+    /// <summary>
+    /// Represents a delegate type
+    /// </summary>
+    /// <param name="Node"></param>
+    /// <param name="ReturnType"></param>
+    /// <param name="ReturnTypePointerDepth"></param>
+    /// <param name="Parameters"></param>
+    public record Delegate(DelegateDeclarationSyntax? Node = null, TypeContainer? ReturnType = null, int ReturnTypePointerDepth = 0, IEnumerable<(string, MethodParameter)>? Parameters = null);
 }

--- a/sources/SilkTouch/Clang/IBaseTypeContext.cs
+++ b/sources/SilkTouch/Clang/IBaseTypeContext.cs
@@ -1,17 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Silk.NET.SilkTouch.Clang;
 
 /// <summary>
-/// A queryable representation of a <see cref="BaseTypeDeclarationSyntax"/>
+/// A representation of a class, struct, etc. in a SyntaxContext
 /// </summary>
 public interface IBaseTypeContext
 {
@@ -46,13 +42,18 @@ public interface IBaseTypeContext
     BaseTypeDeclarationSyntax? Node { get; }
 
     /// <summary>
+    /// A list of generic parameters
+    /// </summary>
+    IEnumerable<TypeParameterSyntax> GenericParameters { get; }
+
+    /// <summary>
     /// Attempts to get Type object that is contained within this type
     /// </summary>
     /// <param name="typeName"></param>
     /// <param name="type"></param>
     /// <returns></returns>
     /// <param name="genericParameterCount"></param>
-    bool TryGetSubType(string typeName, out SubType type, int genericParameterCount = 0);
+    bool TryGetSubType(string typeName, out TypeContainer type, int genericParameterCount = 0);
 
     /// <summary>
     /// Attempts to Add or overwrites a sub type within this type
@@ -60,6 +61,13 @@ public interface IBaseTypeContext
     /// <param name="node"></param>
     /// <param name="rewriter"></param>
     bool TryAddSubType(BaseTypeDeclarationSyntax node, ContextCSharpSyntaxRewriter rewriter);
+
+    /// <summary>
+    /// Attempts to Add or overwrites a sub type within this type
+    /// </summary>
+    /// <param name="node"></param>
+    /// <param name="rewriter"></param>
+    bool TryAddSubType(DelegateDeclarationSyntax node, ContextCSharpSyntaxRewriter rewriter);
 
     /// <summary>
     /// Removes the subtype with the given name and number of parameters within this type
@@ -77,7 +85,7 @@ public interface IBaseTypeContext
     /// <summary>
     /// All subtypes contained within this type
     /// </summary>
-    IEnumerable<(string, IEnumerable<SubType>)> SubTypes { get; }
+    IEnumerable<(string, IEnumerable<TypeContainer>)> SubTypes { get; }
 
     /// <summary>
     /// Attempts to get the type and pointer depth of the field in this type
@@ -93,7 +101,7 @@ public interface IBaseTypeContext
     /// <param name="node"></param>
     /// <param name="rewriter"></param>
     bool TryAddField(BaseFieldDeclarationSyntax node, ContextCSharpSyntaxRewriter rewriter);
-
+    
     /// <summary>
     /// Removes the field with the given name within this type
     /// </summary>
@@ -269,13 +277,4 @@ public interface IBaseTypeContext
     /// <param name="Type"></param>
     /// <param name="TypePointerDepth"></param>
     public record struct MethodParameter(ParameterSyntax Node, TypeContainer? Type, int TypePointerDepth);
-
-    /// <summary>
-    /// Represents a delegate type
-    /// </summary>
-    /// <param name="Node"></param>
-    /// <param name="ReturnType"></param>
-    /// <param name="ReturnTypePointerDepth"></param>
-    /// <param name="Parameters"></param>
-    public record Delegate(DelegateDeclarationSyntax? Node = null, TypeContainer? ReturnType = null, int ReturnTypePointerDepth = 0, IEnumerable<(string, MethodParameter)>? Parameters = null);
 }

--- a/sources/SilkTouch/Clang/IBaseTypeContext.cs
+++ b/sources/SilkTouch/Clang/IBaseTypeContext.cs
@@ -247,6 +247,12 @@ public interface IBaseTypeContext
     MemberDeclarationSyntax? ToCompletedNode();
 
     /// <summary>
+    /// Changes the parent for this type
+    /// </summary>
+    /// <param name="parent"></param>
+    void SetParent(IBaseTypeContext? parent);
+
+    /// <summary>
     /// Represents a type defined within a type
     /// </summary>
     /// <param name="Node"></param>

--- a/sources/SilkTouch/Clang/IBaseTypeContext.cs
+++ b/sources/SilkTouch/Clang/IBaseTypeContext.cs
@@ -1,0 +1,288 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Silk.NET.SilkTouch.Clang;
+
+/// <summary>
+/// A queryable representation of a <see cref="BaseTypeDeclarationSyntax"/>
+/// </summary>
+public interface IBaseTypeContext
+{
+    /// <summary>
+    /// A <see cref="TypeSyntax"/> which represents this type
+    /// </summary>
+    TypeSyntax Syntax { get; }
+
+    /// <summary>
+    /// The name of the file that contains this type
+    /// </summary>
+    string FileName { get; }
+
+    /// <summary>
+    /// The name of the type
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// The containing type context
+    /// </summary>
+    IBaseTypeContext? Parent { get; }
+
+    /// <summary>
+    /// The number of GenericParameters
+    /// </summary>
+    int GenericParameterCount { get; }
+
+    /// <summary>
+    /// The SyntaxNode representing this type
+    /// </summary>
+    BaseTypeDeclarationSyntax? Node { get; }
+
+    /// <summary>
+    /// Does this context represent an enum
+    /// </summary>
+    bool IsEnum { get; }
+
+    /// <summary>
+    /// Attempts to retrieve information about a enum member
+    /// </summary>
+    /// <param name="memberName"></param>
+    /// <param name="member"></param>
+    /// <returns></returns>
+    bool TryGetEnumMember(string memberName, out EnumMemberDeclarationSyntax? member);
+
+    /// <summary>
+    /// Attempts to Add or overwrites existing enum member within this type
+    /// </summary>
+    /// <param name="node"></param>
+    /// <returns></returns>
+    bool TryAddEnumMember(EnumMemberDeclarationSyntax node);
+
+    /// <summary>
+    /// Removes the enum member with the given name within this type
+    /// </summary>
+    /// <param name="name"></param>
+    void RemoveEnumMember(string name);
+
+    /// <summary>
+    /// All enumerable members contained within this type
+    /// </summary>
+    IEnumerable<(string, EnumMemberDeclarationSyntax)> EnumMembers { get; }
+
+    /// <summary>
+    /// Attempts to get Type object that is contained within this type
+    /// </summary>
+    /// <param name="typeName"></param>
+    /// <param name="type"></param>
+    /// <returns></returns>
+    /// <param name="genericParameterCount"></param>
+    bool TryGetSubType(string typeName, out SubType type, int genericParameterCount = 0);
+
+    /// <summary>
+    /// Attempts to Add or overwrites a sub type within this type
+    /// </summary>
+    /// <param name="node"></param>
+    /// <param name="rewriter"></param>
+    bool TryAddSubType(BaseTypeDeclarationSyntax node, ContextCSharpSyntaxRewriter rewriter);
+
+    /// <summary>
+    /// Removes the subtype with the given name and number of parameters within this type
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="genericParameterCount"></param>
+    void RemoveSubType(string name, int genericParameterCount = 0);
+
+    /// <summary>
+    /// Removes all subtypes with the given name within this type
+    /// </summary>
+    /// <param name="name"></param>
+    void RemoveSubTypes(string name);
+
+    /// <summary>
+    /// All subtypes contained within this type
+    /// </summary>
+    IEnumerable<(string, IEnumerable<SubType>)> SubTypes { get; }
+
+    /// <summary>
+    /// Attempts to get the type and pointer depth of the field in this type
+    /// </summary>
+    /// <param name="fieldName"></param>
+    /// <param name="field"></param>
+    /// <returns></returns>
+    bool TryGetField(string fieldName, out Field field);
+
+    /// <summary>
+    /// Attempts to Add or overwrites a field within this type
+    /// </summary>
+    /// <param name="node"></param>
+    /// <param name="rewriter"></param>
+    bool TryAddField(FieldDeclarationSyntax node, ContextCSharpSyntaxRewriter rewriter);
+
+    /// <summary>
+    /// Removes the field with the given name within this type
+    /// </summary>
+    /// <param name="name"></param>
+    void RemoveField(string name);
+
+    /// <summary>
+    /// All Fields contained within this tyoe
+    /// </summary>
+    IEnumerable<(string, Field)> Fields { get; }
+
+    /// <summary>
+    /// Attempts to get the type and pointer depth of the property in this type
+    /// </summary>
+    /// <param name="propertyName"></param>
+    /// <param name="property"></param>
+    /// <returns></returns>
+    bool TryGetProperty(string propertyName, out Property property);
+
+    /// <summary>
+    /// Attempts to Add or overwrites a property with the given name within this type
+    /// </summary>
+    /// <param name="node"></param>
+    /// <param name="rewriter"></param>
+    bool TryAddProperty(PropertyDeclarationSyntax node, ContextCSharpSyntaxRewriter rewriter);
+
+    /// <summary>
+    /// Removes the property with the given name within this type
+    /// </summary>
+    /// <param name="name"></param>
+    void RemoveProperty(string name);
+
+    /// <summary>
+    /// All Properties contained within this type
+    /// </summary>
+    IEnumerable<(string, Property)> Properties { get; }
+
+    /// <summary>
+    /// Does this type inherit from the given type
+    /// </summary>
+    /// <param name="baseType"></param>
+    /// <returns></returns>
+    bool HasBaseType(string baseType);
+
+    /// <summary>
+    /// Does this type inherit from the given type
+    /// </summary>
+    /// <param name="baseType"></param>
+    /// <returns></returns>
+    bool HasBaseType(BaseTypeSyntax baseType);
+
+    /// <summary>
+    /// Attempts to Add or overwrites a base type for this type to derive from
+    /// </summary>
+    /// <param name="baseType"></param>
+    /// <param name="context"></param>
+    /// <param name="rewriter"></param>
+    /// <returns></returns>
+    bool TryAddBaseType(BaseTypeSyntax baseType, SyntaxContext context, ContextCSharpSyntaxRewriter rewriter);
+
+    /// <summary>
+    /// Removes a type from the list of parent types
+    /// </summary>
+    /// <param name="baseType"></param>
+    void RemoveBaseType(string baseType);
+
+    /// <summary>
+    /// All types this type derives from
+    /// </summary>
+    IEnumerable<(string, BaseTypeSyntax, IBaseTypeContext)> BaseTypes { get; }
+
+    /// <summary>
+    /// Attempts to get all methods with a given name and their info
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="methodInfo"></param>
+    /// <returns></returns>
+    bool TryGetMethods(string name, out IEnumerable<Method> methodInfo);
+
+    /// <summary>
+    /// Attempts to Add or overwrites a method within this type
+    /// </summary>
+    /// <param name="node"></param>
+    /// <param name="rewriter"></param>
+    bool TryAddMethod(MethodDeclarationSyntax node, ContextCSharpSyntaxRewriter rewriter);
+
+    /// <summary>
+    /// Removes the method with the given name and matching parameters within this type
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="parameters"></param>
+    void RemoveMethod(string name, params TypeSyntax[] parameters);
+
+    /// <summary>
+    /// Removes the methods with the given name within this type
+    /// </summary>
+    /// <param name="name"></param>
+    void RemoveMethods(string name);
+
+    /// <summary>
+    /// All methods contained within this type
+    /// </summary>
+    IEnumerable<(string, IEnumerable<Method>)> Methods { get; }
+
+    /// <summary>
+    /// Rewrites the current type with a given rewriter and some metadata
+    /// </summary>
+    /// <param name="rewriter"></param>
+    /// <param name="ns"></param>
+    /// <param name="file"></param>
+    /// <param name="context"></param>
+    /// <param name="usings"></param>
+    /// <returns></returns>
+    IBaseTypeContext? Rewrite(ContextCSharpSyntaxRewriter rewriter, string ns, string file, SyntaxContext context, List<string> usings);
+
+    /// <summary>
+    /// Converts this type to a complete <see cref="MemberDeclarationSyntax"/>
+    /// </summary>
+    /// <returns></returns>
+    MemberDeclarationSyntax? ToCompletedNode();
+
+    /// <summary>
+    /// Represents a type defined within a type
+    /// </summary>
+    /// <param name="Node"></param>
+    /// <param name="TypeContext"></param>
+    public record struct SubType(BaseTypeDeclarationSyntax? Node = null, IBaseTypeContext? TypeContext = null);
+
+    /// <summary>
+    /// Represents a field defined within a type
+    /// </summary>
+    /// <param name="Node"></param>
+    /// <param name="TypeContext"></param>
+    /// <param name="TypePointerDepth"></param>
+    public record struct Field(FieldDeclarationSyntax? Node = null, IBaseTypeContext? TypeContext = null, int TypePointerDepth = 0);
+
+    /// <summary>
+    /// Represents a property defined within a type
+    /// </summary>
+    /// <param name="Node"></param>
+    /// <param name="TypeContext"></param>
+    /// <param name="TypePointerDepth"></param>
+    public record struct Property(PropertyDeclarationSyntax? Node = null, IBaseTypeContext? TypeContext = null, int TypePointerDepth = 0);
+
+    /// <summary>
+    /// Represents a method defined within a type
+    /// </summary>
+    /// <param name="Node"></param>
+    /// <param name="ReturnTypeContext"></param>
+    /// <param name="ReturnTypePointerDepth"></param>
+    /// <param name="Parameters"></param>
+    public record struct Method(MethodDeclarationSyntax? Node = null, IBaseTypeContext? ReturnTypeContext = null, int ReturnTypePointerDepth = 0, IEnumerable<(string, MethodParameter)>? Parameters = null);
+
+    /// <summary>
+    /// Represents a parameter of a method defined within a type
+    /// </summary>
+    /// <param name="Node"></param>
+    /// <param name="TypeContext"></param>
+    /// <param name="TypePointerDepth"></param>
+    public record struct MethodParameter(ParameterSyntax Node, IBaseTypeContext TypeContext, int TypePointerDepth);
+}

--- a/sources/SilkTouch/Clang/IDelegateContext.cs
+++ b/sources/SilkTouch/Clang/IDelegateContext.cs
@@ -26,6 +26,11 @@ public interface IDelegateContext
     DelegateDeclarationSyntax? Node { get; }
 
     /// <summary>
+    /// The containing parent type if this delegate is contained within a type
+    /// </summary>
+    IBaseTypeContext? Parent { get; }
+
+    /// <summary>
     /// A representation of each of the parameters
     /// </summary>
     IEnumerable<(string, IBaseTypeContext.MethodParameter)> Parameters { get; }

--- a/sources/SilkTouch/Clang/IDelegateContext.cs
+++ b/sources/SilkTouch/Clang/IDelegateContext.cs
@@ -1,17 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Silk.NET.SilkTouch.Clang;
 
 /// <summary>
-/// A representation of a Delegate
+/// A representation of a Delegate in a SyntaxContext
 /// </summary>
 public interface IDelegateContext
 {
@@ -29,6 +25,11 @@ public interface IDelegateContext
     /// The containing parent type if this delegate is contained within a type
     /// </summary>
     IBaseTypeContext? Parent { get; }
+
+    /// <summary>
+    /// The number of GenericParameters
+    /// </summary>
+    int GenericParameterCount { get; }
 
     /// <summary>
     /// A representation of each of the parameters

--- a/sources/SilkTouch/Clang/IDelegateContext.cs
+++ b/sources/SilkTouch/Clang/IDelegateContext.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Silk.NET.SilkTouch.Clang;
+
+/// <summary>
+/// A representation of a Delegate
+/// </summary>
+public interface IDelegateContext
+{
+    /// <summary>
+    /// The name of the delegate
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// The syntax node
+    /// </summary>
+    DelegateDeclarationSyntax? Node { get; }
+
+    /// <summary>
+    /// A representation of each of the parameters
+    /// </summary>
+    IEnumerable<(string, IBaseTypeContext.MethodParameter)> Parameters { get; }
+
+    /// <summary>
+    /// Rewrites the current type with a given rewriter and some metadata
+    /// </summary>
+    /// <param name="rewriter"></param>
+    /// <param name="ns">current namespace</param>
+    /// <param name="file">file this type is in</param>
+    /// <returns></returns>
+    TypeContainer? Rewrite(ContextCSharpSyntaxRewriter rewriter, string ns, string file);
+
+    /// <summary>
+    /// Visits the current type with a given visitor and some metadata
+    /// </summary>
+    /// <param name="visitor"></param>
+    void Visit(ContextCSharpSyntaxVisitor visitor);
+}

--- a/sources/SilkTouch/Clang/IEnumTypeContext.cs
+++ b/sources/SilkTouch/Clang/IEnumTypeContext.cs
@@ -1,15 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Silk.NET.SilkTouch.Clang;
 
+/// <summary>
+/// Represents an Enumeration type in a SyntaxContext
+/// </summary>
 public interface IEnumTypeContext
 {
     /// <summary>

--- a/sources/SilkTouch/Clang/IEnumTypeContext.cs
+++ b/sources/SilkTouch/Clang/IEnumTypeContext.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Silk.NET.SilkTouch.Clang;
+
+public interface IEnumTypeContext
+{
+    /// <summary>
+    /// A <see cref="TypeSyntax"/> which represents this type
+    /// </summary>
+    TypeSyntax Syntax { get; }
+
+    /// <summary>
+    /// The name of the file that contains this type
+    /// </summary>
+    string FileName { get; }
+
+    /// <summary>
+    /// The name of the type
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// The containing type context
+    /// </summary>
+    IBaseTypeContext? Parent { get; }
+
+    /// <summary>
+    /// The SyntaxNode representing this type
+    /// </summary>
+    EnumDeclarationSyntax? Node { get; }
+
+    /// <summary>
+    /// Attempts to retrieve information about a enum member
+    /// </summary>
+    /// <param name="memberName"></param>
+    /// <param name="member"></param>
+    /// <returns></returns>
+    bool TryGetEnumMember(string memberName, out EnumMemberDeclarationSyntax? member);
+
+    /// <summary>
+    /// Attempts to Add or overwrites existing enum member within this type
+    /// </summary>
+    /// <param name="node"></param>
+    /// <returns></returns>
+    bool TryAddEnumMember(EnumMemberDeclarationSyntax node);
+
+    /// <summary>
+    /// Removes the enum member with the given name within this type
+    /// </summary>
+    /// <param name="name"></param>
+    void RemoveEnumMember(string name);
+
+    /// <summary>
+    /// All enumerable members contained within this type
+    /// </summary>
+    IEnumerable<(string, EnumMemberDeclarationSyntax)> EnumMembers { get; }
+
+    /// <summary>
+    /// Rewrites the current type with a given rewriter and some metadata
+    /// </summary>
+    /// <param name="rewriter"></param>
+    /// <param name="ns">current namespace</param>
+    /// <param name="file">file this type is in</param>
+    /// <returns></returns>
+    TypeContainer? Rewrite(ContextCSharpSyntaxRewriter rewriter, string ns, string file);
+
+    /// <summary>
+    /// Visits the current type with a given visitor and some metadata
+    /// </summary>
+    /// <param name="visitor"></param>
+    void Visit(ContextCSharpSyntaxVisitor visitor);
+
+    /// <summary>
+    /// Converts this type to a complete <see cref="MemberDeclarationSyntax"/>
+    /// </summary>
+    /// <returns></returns>
+    MemberDeclarationSyntax? ToCompletedNode();
+
+    /// <summary>
+    /// Changes the parent for this type
+    /// </summary>
+    /// <param name="parent"></param>
+    void SetParent(IBaseTypeContext? parent);
+
+    /// <summary>
+    /// Does this type inherit from the given type
+    /// </summary>
+    /// <param name="baseType"></param>
+    /// <returns></returns>
+    bool HasBaseType(string baseType);
+
+    /// <summary>
+    /// Does this type inherit from the given type
+    /// </summary>
+    /// <param name="baseType"></param>
+    /// <returns></returns>
+    bool HasBaseType(BaseTypeSyntax baseType);
+
+    /// <summary>
+    /// All types this type derives from
+    /// </summary>
+    IEnumerable<(string, BaseTypeSyntax, IBaseTypeContext)> BaseTypes { get; }
+}

--- a/sources/SilkTouch/Clang/INamespaceContext.cs
+++ b/sources/SilkTouch/Clang/INamespaceContext.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Silk.NET.SilkTouch.Clang.IBaseTypeContext;
+
+namespace Silk.NET.SilkTouch.Clang;
+
+/// <summary>
+/// Represents a namespace within a SyntaxContext
+/// </summary>
+public interface INamespaceContext
+{
+    /// <summary>
+    /// The parent namespace if one exists
+    /// </summary>
+    INamespaceContext? Parent { get; }
+    /// <summary>
+    /// The full namespace within this namespace object
+    /// </summary>
+    string FullNamespace { get; }
+    /// <summary>
+    /// Name of the current namespace (just the final element)
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// The Syntax node representing this namespace
+    /// </summary>
+    BaseNamespaceDeclarationSyntax? Node { get; }
+
+    /// <summary>
+    /// Adds the namespace declaration 
+    /// </summary>
+    /// <param name="syntax"></param>
+    /// <param name="rewriter"></param>
+    void AddNamespace(BaseNamespaceDeclarationSyntax syntax, ContextCSharpSyntaxRewriter rewriter);
+
+    /// <summary>
+    /// Removes a namespace with the given name within this namespace
+    /// </summary>
+    /// <param name="name"></param>
+    void RemoveNamespace(string name);
+
+    /// <summary>
+    /// Attempt to get a namespace with the given name within this namespace
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="ns"></param>
+    /// <returns></returns>
+    bool TryGetNamespace(string name, out INamespaceContext? ns);
+
+    /// <summary>
+    /// All the namespaces contained within this namespace
+    /// </summary>
+    IEnumerable<(string, INamespaceContext)> Namespaces { get; }
+
+    /// <summary>
+    /// Attempts to get Type object that is contained within this namespace
+    /// </summary>
+    /// <param name="typeName"></param>
+    /// <param name="type"></param>
+    /// <returns></returns>
+    /// <param name="genericParameterCount"></param>
+    bool TryGetType(string typeName, out TypeContainer type, int genericParameterCount = 0);
+
+    /// <summary>
+    /// Attempts to Add or overwrites a sub type within this namespace
+    /// </summary>
+    /// <param name="node"></param>
+    /// <param name="rewriter"></param>
+    bool TryAddType(BaseTypeDeclarationSyntax node, ContextCSharpSyntaxRewriter rewriter);
+
+    /// <summary>
+    /// Attempts to Add or overwrites a sub type within this namespace
+    /// </summary>
+    /// <param name="node"></param>
+    /// <param name="rewriter"></param>
+    bool TryAddType(DelegateDeclarationSyntax node, ContextCSharpSyntaxRewriter rewriter);
+
+    /// <summary>
+    /// Removes the subtype with the given name and number of parameters within this namespace
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="genericParameterCount"></param>
+    void RemoveType(string name, int genericParameterCount = 0);
+
+    /// <summary>
+    /// Removes all subtypes with the given name within this namespace
+    /// </summary>
+    /// <param name="name"></param>
+    void RemoveTypes(string name);
+
+    /// <summary>
+    /// All types contained within this namespace
+    /// </summary>
+    IEnumerable<(string, IEnumerable<TypeContainer>)> Types { get; }
+
+    /// <summary>
+    /// Merges the members of the given namespace into this one
+    /// </summary>
+    /// <param name="ns"></param>
+    /// <param name="rewriter"></param>
+    void Merge(BaseNamespaceDeclarationSyntax ns, ContextCSharpSyntaxRewriter rewriter)
+    {
+        foreach (var mem in ns.Members)
+        {
+            if (mem is BaseNamespaceDeclarationSyntax subNs)
+            {
+                AddNamespace(subNs, rewriter)
+            }
+            else if (mem is BaseTypeDeclarationSyntax ty)
+            {
+                TryAddType(ty, rewriter);
+            }
+            else if (mem is DelegateDeclarationSyntax del)
+            {
+                TryAddType(del, rewriter);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns a complete version of this node if possible
+    /// </summary>
+    /// <returns></returns>
+    BaseNamespaceDeclarationSyntax? ToCompletedNode() => null;
+}

--- a/sources/SilkTouch/Clang/SyntaxContext.cs
+++ b/sources/SilkTouch/Clang/SyntaxContext.cs
@@ -1,0 +1,456 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using ClangSharp;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Silk.NET.SilkTouch.Clang;
+
+/// <summary>
+/// 
+/// </summary>
+public class SyntaxContext
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="syntax"></param>
+    public SyntaxContext(GeneratedSyntax syntax)
+    {
+        foreach ((var fName, var node) in syntax.Files)
+        {
+            if (node is CompilationUnitSyntax comp)
+            {
+                Files.Add(fName, new CompilationContext(fName, comp, TypeDefinitionContainers));
+            }
+            else
+            {
+                throw new Exception("CompilationUnitSyntax missing");
+            }
+        }
+    }
+
+    Dictionary<string, CompilationContext> Files = [];
+
+    Dictionary<string, NamespaceContext> Namespaces = [];
+
+    Dictionary<string, List<TypeContextContainer>> TypeDefinitionContainers = [];
+
+    private class CompilationContext
+    {
+        public CompilationContext(string file, CompilationUnitSyntax node, Dictionary<string, List<TypeContextContainer>> TypeDefinitionContainers)
+        {
+            List<string> usings = node.Usings.Select(u => u.Name!.ToString()).ToList();
+            foreach (var member in node.Members)
+            {
+                if (member is BaseNamespaceDeclarationSyntax ns)
+                {
+                    var nsContext = new NamespaceContext(string.Empty, ns, TypeDefinitionContainers, usings, file);
+                    Namespaces.Add(nsContext.Node.Name.ToString(), nsContext);
+                }
+                else
+                {
+                    throw new Exception($"CompilationUnit for {file} contains a member of type ({member.GetType()}) which isn't supported");
+                }
+            }
+            Node = node.WithMembers(List(Array.Empty<MemberDeclarationSyntax>()));
+        }
+
+        public CompilationUnitSyntax Node;
+        public Dictionary<string, NamespaceContext> Namespaces = [];
+
+        public CompilationUnitSyntax ToCompletedNode()
+        {
+            return Node.WithMembers(List(Namespaces.Select(n => (MemberDeclarationSyntax)n.Value.ToCompletedNode())));
+        }
+    }
+
+    private class NamespaceContext
+    {
+        public NamespaceContext(string namesp, BaseNamespaceDeclarationSyntax node, Dictionary<string, List<TypeContextContainer>> TypeDefinitionContainers, List<string> usings, string file = "")
+        {
+            string[] names = node.Name.ToString().Split('.');
+
+            namesp += $"{(namesp.Length > 0 ? "." : "")}{node.Name}";
+            if (names.Length != 1)
+            {
+                NamespaceContext child = new NamespaceContext(namesp, node.WithName(IdentifierName(names[names.Length - 1])), TypeDefinitionContainers, usings, file);
+                namesp = namesp.Remove(namesp.Length - (names.Last().Length + 1));
+                node = node.WithMembers(List(Array.Empty<MemberDeclarationSyntax>()));
+
+                for (int i = names.Length - 2; i >= 1; i--)
+                {
+                    NamespaceContext current = new NamespaceContext(namesp, node.WithName(IdentifierName(names[i])), TypeDefinitionContainers, usings, file);
+                    namesp = namesp.Remove(namesp.Length - (names[i].Length + 1));
+                    current.Namespaces.Add(names[i + 1], child);
+                    child = current;
+                }
+
+                Namespaces.Add(names[1], child);
+                Node = node.WithName(IdentifierName(names[0]));
+                return;
+            }
+
+            foreach(var member in node.Members)
+            {
+                if (member is BaseNamespaceDeclarationSyntax ns)
+                {
+                    var nsContext = new NamespaceContext(namesp, ns, TypeDefinitionContainers, usings, file);
+                    Namespaces.Add(nsContext.Node.Name.ToString(), nsContext);
+                }
+                else if (member is EnumDeclarationSyntax e)
+                {
+                    var en = new TypeContextContainer(namesp, new EnumContext(file, e));
+                    if (e.Modifiers.Any(token => token.IsKind(SyntaxKind.PublicKeyword)))
+                    {
+                        if (!TypeDefinitionContainers.TryGetValue(e.Identifier.Text, out var list))
+                        {
+                            list = [];
+                            TypeDefinitionContainers.Add(e.Identifier.Text, list);
+                        }
+                        if (list.Count == 1 && list[0].Type is UnknownTypeContext)
+                        {
+                            list[0].Type = en.Type;
+                            list[0].Namespace = en.Namespace;
+                            en = list[0];
+                        }
+                        else
+                        {
+                            list.Add(en);
+                        }
+                    }
+                    Types.Add(e.Identifier.Text, en);
+                }
+                else if (member is TypeDeclarationSyntax t)
+                {
+                    var ty = new TypeContextContainer(namesp, new TypeContext(namesp, file, t, TypeDefinitionContainers, usings));
+                    if (t.Modifiers.Any(token => token.IsKind(SyntaxKind.PublicKeyword)))
+                    {
+                        if (!TypeDefinitionContainers.TryGetValue(t.Identifier.Text, out var list))
+                        {
+                            list = [];
+                            TypeDefinitionContainers.Add(t.Identifier.Text, list);
+                        }
+                        if (list.Count == 1 && list[0].Type is UnknownTypeContext)
+                        {
+                            list[0].Type = ty.Type;
+                            list[0].Namespace = ty.Namespace;
+                            ty = list[0];
+                        }
+                        else
+                        {
+                            list.Add(ty);
+                        }
+                    }
+                    Types.Add(t.Identifier.Text, ty);
+                }
+                else
+                {
+                    throw new Exception($"Namespace {node.Name}{(file != "" ? " in file " + file : "")} contains a member of type ({member.GetType()}) which isn't supported");
+                }
+            }
+
+            Node = node.WithName(IdentifierName(names[0]));
+        }
+
+        public BaseNamespaceDeclarationSyntax Node;
+        public Dictionary<string, NamespaceContext> Namespaces = [];
+        public Dictionary<string, TypeContextContainer> Types = [];
+
+        public BaseNamespaceDeclarationSyntax ToCompletedNode()
+        {
+            List<MemberDeclarationSyntax> members = [];
+            members.AddRange(Namespaces.Select(n => n.Value.ToCompletedNode()));
+            members.AddRange(Types.Select(t => t.Value.Type.ToCompletedNode()!));
+            return Node.WithMembers(List(members));
+        }
+    }
+
+    private class TypeContext : IBaseTypeContext
+    {
+        public TypeContext(string ns, string file, TypeDeclarationSyntax node, Dictionary<string, List<TypeContextContainer>> TypeDefinitionContainers, List<string> usings)
+        {
+            File = file;
+
+            foreach (var member in node.Members)
+            {
+                if (member is EnumDeclarationSyntax e)
+                {
+                    var en = new TypeContextContainer(ns, new EnumContext(file, e));
+                    if (e.Modifiers.Any(token => token.IsKind(SyntaxKind.PublicKeyword)))
+                    {
+                        if (!TypeDefinitionContainers.TryGetValue(e.Identifier.Text, out var list))
+                        {
+                            list = [];
+                            TypeDefinitionContainers.Add(e.Identifier.Text, list);
+                        }
+                        if (list.Count == 1 && list[0].Type is UnknownTypeContext)
+                        {
+                            list[0].Type = en.Type;
+                            list[0].Namespace = en.Namespace;
+                            en = list[0];
+                        }
+                        else
+                        {
+                            list.Add(en);
+                        }
+                    }
+                    SubTypes.Add(e.Identifier.Text, en);
+                }
+                else if (member is TypeDeclarationSyntax t)
+                {
+                    var ty = new TypeContextContainer(ns, new TypeContext(ns, file, t, TypeDefinitionContainers, usings));
+                    if (t.Modifiers.Any(token => token.IsKind(SyntaxKind.PublicKeyword)))
+                    {
+                        if (!TypeDefinitionContainers.TryGetValue(t.Identifier.Text, out var list))
+                        {
+                            list = [];
+                            TypeDefinitionContainers.Add(t.Identifier.Text, list);
+                        }
+                        if (list.Count == 1 && list[0].Type is UnknownTypeContext)
+                        {
+                            list[0].Type = ty.Type;
+                            list[0].Namespace = ty.Namespace;
+                            ty = list[0];
+                        }
+                        else
+                        {
+                            list.Add(ty);
+                        }
+                    }
+                    SubTypes.Add(t.Identifier.Text, ty);
+                }
+                else if (member is MethodDeclarationSyntax m)
+                {
+                    string name = m.Identifier.Text;
+                    if (!Methods.TryGetValue(name, out var methods))
+                    {
+                        methods = new();
+                        Methods.Add(name, methods);
+                    }
+                    methods.Add(new(m));
+                }
+                else if (member is FieldDeclarationSyntax f)
+                {
+                    TypeSyntax syn = f.Declaration.Type;
+                    int pDepth = 0;
+                    while (syn is PointerTypeSyntax pointer)
+                    {
+                        pDepth++;
+                        syn = pointer.ElementType;
+                    }
+
+                    TypeContextContainer type;
+                    if (TypeDefinitionContainers.TryGetValue(syn.ToString(), out var list))
+                    {
+                        type = list.First();
+
+                        foreach(var decl in list)
+                        {
+                            if (NamespaceMatch(ns, decl.Namespace) || usings.Contains(decl.Namespace))
+                            {
+                                type = decl;
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        type = new(string.Empty, new UnknownTypeContext(syn));
+                        TypeDefinitionContainers.Add(syn.ToString(), new() { type });
+                    }
+                    
+                    foreach (var dec in f.Declaration.Variables)
+                    {
+                        Fields.Add(dec.Identifier.Text, new(type, pDepth, f.WithDeclaration(f.Declaration.WithVariables(SeparatedList(new[] { dec })))));
+                    }
+                }
+                else if (member is PropertyDeclarationSyntax p)
+                {
+                    TypeSyntax syn = p.Type;
+                    int pDepth = 0;
+                    while (syn is PointerTypeSyntax pointer)
+                    {
+                        pDepth++;
+                        syn = pointer.ElementType;
+                    }
+
+                    TypeContextContainer type;
+                    if (TypeDefinitionContainers.TryGetValue(syn.ToString(), out var list))
+                    {
+                        type = list.First();
+
+                        foreach (var decl in list)
+                        {
+                            if (NamespaceMatch(ns, decl.Namespace) || usings.Contains(decl.Namespace))
+                            {
+                                type = decl;
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        type = new(string.Empty, new UnknownTypeContext(syn));
+                        TypeDefinitionContainers.Add(syn.ToString(), new() { type });
+                    }
+
+                    Properties.Add(p.Identifier.Text, new(type, pDepth, p));
+                }
+            }
+
+            Node = node.WithMembers(List(Array.Empty<MemberDeclarationSyntax>()));
+        }
+
+        public string File;
+        public TypeDeclarationSyntax Node;
+        public Dictionary<string, TypeContextContainer> SubTypes = [];
+        public Dictionary<string, List<MethodContext>> Methods = [];
+        public Dictionary<string, FieldContext> Fields = [];
+        public Dictionary<string, PropertyContext> Properties = [];
+
+        public TypeSyntax Syntax => IdentifierName(Node.Identifier.Text);
+
+        public MemberDeclarationSyntax? ToCompletedNode()
+        {
+            List<MemberDeclarationSyntax> members = [];
+            members.AddRange(SubTypes.Select(t => t.Value.Type.ToCompletedNode()!));
+            foreach (string method in Methods.Keys)
+            {
+                members.AddRange(Methods[method].Select(m => m.Node));
+            }
+            members.AddRange(Fields.Select(f => f.Value.ToCompletedNode()));
+            members.AddRange(Properties.Select(p => p.Value.ToCompletedNode()));
+            return Node.WithMembers(List(members));
+        }
+    }
+
+    private class EnumContext : LeafNodeContext<EnumDeclarationSyntax>, IBaseTypeContext
+    {
+        public EnumContext(string file, EnumDeclarationSyntax node) : base(node) { File = file; }
+
+        public string File;
+        public TypeSyntax Syntax => IdentifierName(Node.Identifier.Text);
+
+        public MemberDeclarationSyntax? ToCompletedNode()
+        {
+            return Node;
+        }
+    }
+
+    private interface IBaseTypeContext
+    {
+        TypeSyntax Syntax { get; }
+
+        MemberDeclarationSyntax? ToCompletedNode();
+    }
+
+    private class UnknownTypeContext : IBaseTypeContext
+    {
+        public UnknownTypeContext(TypeSyntax type) { Type = type; }
+        TypeSyntax Type;
+
+        public TypeSyntax Syntax => Type;
+
+        public MemberDeclarationSyntax? ToCompletedNode()
+        {
+            return null;
+        }
+    }
+
+    private class TypeContextContainer
+    {
+        public TypeContextContainer(string ns, IBaseTypeContext ty)
+        {
+            Namespace = ns;
+            Type = ty;
+        }
+
+        public string Namespace;
+        public IBaseTypeContext Type;
+    }
+
+    private class MethodContext : LeafNodeContext<MethodDeclarationSyntax>
+    {
+        public MethodContext(MethodDeclarationSyntax node) : base(node) { }
+    }
+
+    private class FieldContext : VariableNodes<FieldDeclarationSyntax>
+    {
+        public FieldContext(TypeContextContainer container, int pointerDepth, FieldDeclarationSyntax node) : base(container, node) { PointerDepth = pointerDepth; }
+
+        public int PointerDepth;
+
+        public FieldDeclarationSyntax ToCompletedNode()
+        {
+            var type = Container.Type.Syntax;
+
+            int pDepth = PointerDepth;
+            while (pDepth > 0)
+            {
+                type = PointerType(type);
+                pDepth--;
+            }
+
+            return Node.WithDeclaration(Node.Declaration.WithType(type));
+        }
+    }
+
+    private class PropertyContext : VariableNodes<PropertyDeclarationSyntax>
+    {
+        public PropertyContext(TypeContextContainer container, int pointerDepth, PropertyDeclarationSyntax node) : base(container, node) { PointerDepth = pointerDepth; }
+
+        public int PointerDepth;
+
+        public PropertyDeclarationSyntax ToCompletedNode()
+        {
+            var type = Container.Type.Syntax;
+
+            int pDepth = PointerDepth;
+            while (pDepth > 0)
+            {
+                type = PointerType(type);
+                pDepth--;
+            }
+
+            return Node.WithType(type);
+        }
+    }
+
+    private class VariableNodes<TNodeType> : LeafNodeContext<TNodeType>
+    {
+        public VariableNodes(TypeContextContainer container, TNodeType node) : base(node) { Container = container; }
+
+        public TypeContextContainer Container;
+    }
+
+    private class LeafNodeContext<TNodeType>(TNodeType node)
+    {
+        public TNodeType Node = node;
+    }
+
+    /// <summary>
+    /// checks if ns1 is a child namespace of ns2
+    /// </summary>
+    /// <param name="ns1"></param>
+    /// <param name="ns2"></param>
+    /// <returns></returns>
+    private static bool NamespaceMatch(string ns1, string ns2)
+    {
+        for (int i = 0; i < ns2.Length; i++)
+        {
+            if (ns2[i] != ns1[i])
+                return false;
+        }
+        return true;
+    }
+}

--- a/sources/SilkTouch/Clang/SyntaxContext.cs
+++ b/sources/SilkTouch/Clang/SyntaxContext.cs
@@ -746,7 +746,27 @@ public class SyntaxContext
 
         public bool Rewrite(ContextCSharpSyntaxRewriter rewriter, string file, SyntaxContext context)
         {
+            var node = rewriter.Visit(Node) as CompilationUnitSyntax;
+
+            if (node is null)
+            {
+                return false;
+            }
+
             List<string> usings = Node.Usings.Select(u => u.Name!.ToString()).ToList();
+            foreach (var member in node.Members)
+            {
+                if (member is BaseNamespaceDeclarationSyntax ns)
+                {
+                    var nsContext = new NamespaceContext(string.Empty, ns, context, usings, file);
+                    Namespaces.Add(nsContext.Node.Name.ToString(), nsContext);
+                }
+                else
+                {
+                    throw new Exception($"CompilationUnit for {file} contains a member of type ({member.GetType()}) which isn't supported");
+                }
+            }
+            Node = node.WithMembers(List(Array.Empty<MemberDeclarationSyntax>()));
 
             List<string> removals = [];
             foreach (var nameSp in Namespaces)

--- a/sources/SilkTouch/Clang/TypeContainer.cs
+++ b/sources/SilkTouch/Clang/TypeContainer.cs
@@ -1,12 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Silk.NET.SilkTouch.Clang;
 
 /// <summary>

--- a/sources/SilkTouch/Clang/TypeContainer.cs
+++ b/sources/SilkTouch/Clang/TypeContainer.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Silk.NET.SilkTouch.Clang;
+
+/// <summary>
+/// A container to represent a potential Type/Delegate since often the two can be used interchangably
+/// </summary>
+/// <param name="Type"></param>
+/// <param name="Delegate"></param>
+/// <param name="Enum"></param>
+public record struct TypeContainer(IBaseTypeContext? Type = null, IEnumTypeContext? Enum = null, IDelegateContext? Delegate = null);

--- a/sources/SilkTouch/Mods/AddApiProfiles.cs
+++ b/sources/SilkTouch/Mods/AddApiProfiles.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Humanizer;
@@ -61,11 +62,11 @@ public class AddApiProfiles(
         string? jobKey,
         IEnumerable<
             IApiMetadataProvider<IEnumerable<SupportedApiProfileAttribute>>
-        > versionProviders
+        > versionProviders,
+        Dictionary<string, UsingDirectiveSyntax> aggregatedUsings,
+        Configuration cfg
     ) : ModCSharpSyntaxRewriter
     {
-        public BakeSet? Baked { get; set; }
-
         public ApiProfileDecl? Profile { get; set; }
 
         public ILogger? Logger { get; set; }
@@ -287,7 +288,7 @@ public class AddApiProfiles(
             where T : BaseFieldDeclarationSyntax
         {
             var retNode = @base(node);
-            if (Baked is null && Profile is not null && retNode is T ret)
+            if (Profile is not null && retNode is T ret)
             {
                 // When we're in baking mode, all of the baking logic is done in VisitVariableDeclarator. However this
                 // does nothing in the non-baking case, where we should add the attribute to the field as a marker.
@@ -321,75 +322,11 @@ public class AddApiProfiles(
                 return retNode;
             }
 
-            if (Baked is null)
-            {
-                return retNode is T ret
+            return retNode is T ret
                     ? ret.AddAttributeLists(
                         AttributeList(SingletonSeparatedList(GetProfileAttribute(null)))
                     )
                     : retNode;
-            }
-
-            // Get this type's bake set for some final validation checks.
-            // This also registers the bake set if the type had no members.
-            var bakeSet = GetOrRegisterTypeBakeSet(node);
-
-            // If this is a struct or record struct, fields should exactly match.
-            if (
-                (
-                    node is StructDeclarationSyntax s
-                        ? (SyntaxList<MemberDeclarationSyntax>?)s.Members
-                        : node is RecordDeclarationSyntax r
-                        && r.Modifiers.Any(SyntaxKind.StructKeyword)
-                            ? r.Members
-                            : null
-                )
-                is not { } members
-            )
-            {
-                // If it's not a struct or record struct, we've registered the type and that's all we really need to do.
-                // Any members will have been registered in the base call.
-                return null; // baking erases, but the caller should know that.
-            }
-
-            var bakedFields = bakeSet
-                .Children.OrderBy(x => x.Value.Index)
-                .Select(x => x.Value.Syntax)
-                .OfType<FieldDeclarationSyntax>()
-                .SelectMany(x => x.Declaration.Variables.Select(y => (x.Declaration.Type, Var: y)))
-                .ToArray();
-            var ourFields = members
-                .OfType<FieldDeclarationSyntax>()
-                .SelectMany(x => x.Declaration.Variables.Select(y => (x.Declaration.Type, Var: y)))
-                .ToArray();
-            if (bakedFields.Length != ourFields.Length)
-            {
-                throw new InvalidOperationException(
-                    $"Differing number of fields between definitions of {node.Identifier} ({bakedFields.Length} vs "
-                        + $"{ourFields.Length})"
-                );
-            }
-
-            for (var i = 0; i < bakedFields.Length; i++)
-            {
-                if (
-                    bakedFields[i].Type.ToString() != ourFields[i].Type.ToString()
-                    || bakedFields[i].Var.Identifier.ToString()
-                        != ourFields[i].Var.Identifier.ToString()
-                    || bakedFields[i].Var.Initializer?.ToString()
-                        != ourFields[i].Var.Initializer?.ToString()
-                    || bakedFields[i].Var.ArgumentList?.ToString()
-                        != ourFields[i].Var.ArgumentList?.ToString()
-                )
-                {
-                    throw new InvalidOperationException(
-                        $"Field {i} differs between definitions of {node.Identifier}. "
-                            + $"Left: {bakedFields[i]}, right: {ourFields[i]}"
-                    );
-                }
-            }
-
-            return null; // baking erases, but the caller should know that.
         }
 
         private SyntaxNode? Visit<T>(
@@ -425,294 +362,55 @@ public class AddApiProfiles(
                 return retNode;
             }
 
-            // If we're not in baking mode...
-            if (Baked is null)
+            // If we didn't get an inner node when we're not in baking mode, return now as this is bad.
+            // Also, we can only add attributes for TSeparated, not the inner TVisiting, so we also return now if we
+            // want to add an attribute. This is super convoluted I know. The onus is on the caller to add the
+            // attribute in this case.
+            if (retNode is not (TSeparated ret and TVisiting))
             {
-                // If we didn't get an inner node when we're not in baking mode, return now as this is bad.
-                // Also, we can only add attributes for TSeparated, not the inner TVisiting, so we also return now if we
-                // want to add an attribute. This is super convoluted I know. The onus is on the caller to add the
-                // attribute in this case.
-                if (retNode is not (TSeparated ret and TVisiting))
-                {
-                    // expected to at least be TVisiting, but we can only add if it's TSeparated. If it's not at least
-                    // TVisiting, it is likely null. In either case this does what we want.
-                    return retNode;
-                }
-
-                // Add the attribute if this is the node we are visiting.
-                return ret.AddAttributeLists(
-                    AttributeList(SingletonSeparatedList(GetProfileAttribute(name)))
-                );
+                // expected to at least be TVisiting, but we can only add if it's TSeparated. If it's not at least
+                // TVisiting, it is likely null. In either case this does what we want.
+                return retNode;
             }
 
-            Logger?.LogTrace(
-                "Baking item for \"{}\" with discriminator \"{}\": {}",
-                Profile.Profile,
-                discrim,
-                nodeToAdd
+            // Add the attribute if this is the node we are visiting.
+            return ret.AddAttributeLists(
+                AttributeList(SingletonSeparatedList(GetProfileAttribute(name)))
             );
-            var parent = GetOrRegisterAncestorBakeSet(nodeVisiting);
-
-            // Have we seen the member before?
-            if (parent.Children.TryGetValue(discrim, out var baked))
-            {
-                // Make sure it's the same concrete type
-                if (baked.Syntax.GetType() != nodeToAdd.GetType())
-                {
-                    throw new InvalidOperationException(
-                        $"The existing definition for \"{discrim}\" is a {baked.Syntax.GetType()} whereas this "
-                            + $"definition is a {nodeToAdd.GetType()}. Left: {baked.Syntax}, right: {nodeToAdd}"
-                    );
-                }
-
-                // Boldly assume it's the same implementation, modifiers, etc
-                // TODO ^^^ is this okay? should be fine if we're getting DllImports as inputs.
-
-                // Okay fine here's some extra handling just in case it's a partial:
-                var bakedNode = (TSeparated)baked.Syntax;
-                if (
-                    nodeToAdd is BaseMethodDeclarationSyntax meth
-                    && bakedNode is BaseMethodDeclarationSyntax bakedMeth
-                    && baked.Syntax.Modifiers.Any(SyntaxKind.PartialKeyword)
-                    && nodeToAdd.Modifiers.Any(SyntaxKind.PartialKeyword)
-                )
-                {
-                    var precedence = false;
-                    if (bakedMeth.Body is null && meth.Body is not null)
-                    {
-                        if (bakedMeth.ExpressionBody is not null)
-                        {
-                            throw new InvalidOperationException(
-                                $"The existing definition for \"{discrim}\" provides an expression body whereas this "
-                                    + "definition provides a statement body"
-                            );
-                        }
-
-                        // Our definition takes precedence
-                        precedence = true;
-                    }
-
-                    if (bakedMeth.ExpressionBody is null && meth.ExpressionBody is not null)
-                    {
-                        if (bakedMeth.Body is not null)
-                        {
-                            throw new InvalidOperationException(
-                                $"The existing definition for \"{discrim}\" provides an expression body whereas this "
-                                    + "definition provides a statement body"
-                            );
-                        }
-
-                        if (precedence)
-                        {
-                            throw new InvalidOperationException(
-                                $"This definition for \"{discrim}\" provides both an expression and a statement body."
-                            );
-                        }
-
-                        // Our definition takes precedence
-                        precedence = true;
-                    }
-
-                    if (precedence)
-                    {
-                        baked.Syntax = nodeToAdd.AddAttributeLists(
-                            baked
-                                .Syntax.AttributeLists.Select(x =>
-                                    x.WithAttributes(
-                                        SeparatedList(
-                                            x.Attributes.Where(y =>
-                                                y.IsAttribute("Silk.NET.Core.SupportedApiAttribute")
-                                            )
-                                        )
-                                    )
-                                )
-                                .Where(x => x.Attributes.Count > 0)
-                                .ToArray()
-                        );
-                    }
-                }
-
-                // Check that constants and enums have the same value
-                if (
-                    (baked.Syntax, nodeToAdd) is
-
-                    (EnumMemberDeclarationSyntax lEnum, EnumMemberDeclarationSyntax rEnum)
-                )
-                {
-                    if (lEnum.EqualsValue?.Value.ToString() != rEnum.EqualsValue?.Value.ToString())
-                    {
-                        Logger?.LogWarning(
-                            "Enum member with discriminator \"{}\" differs between definitions. Left: {}, right: {}",
-                            discrim,
-                            lEnum.EqualsValue?.Value.ToString() ?? "auto-assigned",
-                            rEnum.EqualsValue?.Value.ToString() ?? "auto-assigned"
-                        );
-                    }
-                }
-                else if (
-                    (baked.Syntax, nodeToAdd) is
-
-                    (FieldDeclarationSyntax lConst, FieldDeclarationSyntax rConst)
-                )
-                {
-                    var isConst = lConst.Modifiers.Any(SyntaxKind.ConstKeyword);
-                    if (isConst != rConst.Modifiers.Any(SyntaxKind.ConstKeyword))
-                    {
-                        Logger?.LogWarning(
-                            "Const with discriminator \"{}\" isn't const in its redefinition. Left: {}, right: {}",
-                            discrim,
-                            lConst.ToString(),
-                            rConst.ToString()
-                        );
-                    }
-                    else if (
-                        isConst
-                        && lConst.Declaration.Variables[0].Initializer?.Value.ToString()
-                            != rConst.Declaration.Variables[0].Initializer?.Value.ToString()
-                    )
-                    {
-                        Logger?.LogWarning(
-                            "Const value with discriminator \"{}\" differs between definitions. Left: {}, right: {}",
-                            discrim,
-                            lConst.Declaration.Variables[0].Initializer?.Value.ToString(),
-                            rConst.Declaration.Variables[0].Initializer?.Value.ToString()
-                        );
-                    }
-                }
-            }
-
-            // Update the bake set. This adds if we haven't seen the member before, otherwise we just update the
-            // existing declaration by adding our attribute list.
-            parent.Children[discrim] = (
-                (baked.Syntax ?? nodeToAdd).AddAttributeLists(
-                    AttributeList(SingletonSeparatedList(GetProfileAttribute(name)))
-                ),
-                null,
-                baked.Syntax is null ? parent.Children.Count : baked.Index
-            );
-
-            return null; // erase it, but the caller should know to do that anyway.
         }
 
-        private BakeSet GetOrRegisterAncestorBakeSet(SyntaxNode node) =>
-            node.Parent is null
-                ? Baked ?? throw new InvalidOperationException("BakeSet not set")
-                : GetOrRegisterTypeBakeSet(node.Parent);
-
-        private BakeSet GetOrRegisterTypeBakeSet(SyntaxNode node)
+        public override bool ShouldSkipFile(string fileName)
         {
-            var nsPre = node.NamespaceFromSyntaxNode() is { Length: > 0 } ns
-                ? $"{ns}."
-                : string.Empty;
-            var bakeSet = Baked ?? throw new InvalidOperationException("BakeSet not set");
-
-            // To handle nested types, we go through each ancestor (starting from the top, hence the reverse) and get
-            // the bake set (or create if needed), and do this for each ancestor until we finally get to the containing
-            // type of the given node.
-            foreach (
-                var decl in node.AncestorsAndSelf().OfType<BaseTypeDeclarationSyntax>().Reverse()
-            )
+            if (!fileName.StartsWith("sources/"))
             {
-                var discrim = $"{nsPre}{decl.Identifier}";
-                if (
-                    decl is TypeDeclarationSyntax
-                    {
-                        TypeParameterList.Parameters.Count: > 0 and var cnt
-                    }
+                return true;
+            }
+
+            Profile = cfg
+                .Profiles?.Where(x =>
+                    fileName[8..].StartsWith(x.SourceSubdirectory, StringComparison.OrdinalIgnoreCase)
                 )
-                {
-                    discrim += $"`{cnt}";
-                }
-                nsPre = string.Empty; // only the top-level type shall be prefixed with the namespace
-                bakeSet = (
-                    bakeSet!.Children.TryGetValue(discrim, out var baked)
-                        ? bakeSet.Children[discrim] = (
-                            MergeDecls(
-                                WithProfile(StripBare(decl), Profile),
-                                (BaseTypeDeclarationSyntax)baked.Syntax
-                            ),
-                            baked.Inner ?? new BakeSet(),
-                            baked.Index
-                        )
-                        : bakeSet.Children[discrim] = (
-                            WithProfile(StripBare(decl), Profile),
-                            new BakeSet(),
-                            bakeSet.Children.Count
-                        )
-                ).Inner;
-            }
-
-            return bakeSet!;
-            static BaseTypeDeclarationSyntax StripBare(BaseTypeDeclarationSyntax node) =>
-                node switch
-                {
-                    // TODO do we need to strip more than this for dedupe purposes?
-                    TypeDeclarationSyntax klass => klass.WithMembers(default),
-                    EnumDeclarationSyntax enumeration => enumeration.WithMembers(default),
-                    _ => node
-                };
-
-            static BaseTypeDeclarationSyntax MergeDecls(
-                BaseTypeDeclarationSyntax node1,
-                BaseTypeDeclarationSyntax node2
-            )
+                .MaxBy(x => x.SourceSubdirectory.Length);
+            if (Profile is null)
             {
-                if (node1.GetType() != node2.GetType())
-                {
-                    throw new ArgumentException(
-                        "Node types differed - the profiles may contain two types with the "
-                            + "same name but with a different datatype (i.e. profile 1 contains a "
-                            + $"{node1.Kind().Humanize()} whereas profile 2 contains a {node2.Kind().Humanize()})"
-                    );
-                }
-                return node1
-                    .WithModifiers(
-                        TokenList(
-                            node2.Modifiers.Concat(node2.Modifiers).DistinctBy(x => x.ToString())
-                        )
-                    )
-                    .WithBaseList(
-                        node1.BaseList?.WithTypes(
-                            SeparatedList(
-                                node1
-                                    .BaseList.Types.Concat(
-                                        node2.BaseList?.Types ?? Enumerable.Empty<BaseTypeSyntax>()
-                                    )
-                                    .DistinctBy(x => x.ToString())
-                            )
-                        )
-                    )
-                    .WithAttributeLists(
-                        List(
-                            node1
-                                .AttributeLists.SelectMany(x =>
-                                    x.Attributes.Select(y =>
-                                        x.WithAttributes(SingletonSeparatedList(y))
-                                    )
-                                )
-                                .Concat(
-                                    node2.AttributeLists.SelectMany(x =>
-                                        x.Attributes.Select(y =>
-                                            x.WithAttributes(SingletonSeparatedList(y))
-                                        )
-                                    )
-                                )
-                                .DistinctBy(x => x.ToString())
-                        )
-                    );
+                return true;
             }
+            return false;
+        }
 
-            BaseTypeDeclarationSyntax WithProfile(
-                BaseTypeDeclarationSyntax decl,
-                ApiProfileDecl? profile
-            ) =>
-                profile is null
-                    ? decl
-                    : decl.AddAttributeLists(
-                        AttributeList(
-                            SingletonSeparatedList(GetProfileAttribute(decl.Identifier.ToString()))
-                        )
-                    );
+        public override void OnFileStarted(string fileName)
+        {
+            Logger?.LogDebug("Identified profile {} for {}", Profile, fileName);
+        }
+
+        public override void OnFileFinished(string fileName)
+        {
+            foreach (var (k, v) in UsingsToAdd)
+            {
+                aggregatedUsings.TryAdd(k, v);
+            }
+            UsingsToAdd.Clear();
+            Profile = null;
         }
     }
 
@@ -724,147 +422,15 @@ public class AddApiProfiles(
         > Children { get; } = new();
     }
 
-    /// <summary>
-    /// A map of baked roots to deduplicated <see cref="MemberDeclarationSyntax"/>es and their associated discriminants.
-    /// </summary>
-    private Dictionary<string, BakeSet> _baked = new();
-
     /// <inheritdoc />
-    public override Task<GeneratedSyntax> AfterScrapeAsync(string key, GeneratedSyntax syntax)
+    public override Task<SyntaxContext> AfterScrapeAsync(string key, SyntaxContext context)
     {
         var cfg = config.Get(key);
-        var rewriter = new Rewriter(key, versionProviders.Get(key).ToArray()) { Logger = logger };
-        var bakery = new Dictionary<string, BakeSet>();
-        var baked = new List<string>();
         var aggregatedUsings = new Dictionary<string, UsingDirectiveSyntax>();
-        foreach (var (path, root) in syntax.Files)
-        {
-            if (!path.StartsWith("sources/"))
-            {
-                continue;
-            }
+        var rewriter = new Rewriter(key, versionProviders.Get(key).ToArray(), aggregatedUsings, cfg) { Logger = logger };
 
-            rewriter.Profile = cfg
-                .Profiles?.Where(x =>
-                    path[8..].StartsWith(x.SourceSubdirectory, StringComparison.OrdinalIgnoreCase)
-                )
-                .MaxBy(x => x.SourceSubdirectory.Length);
-            if (rewriter.Profile is null)
-            {
-                continue;
-            }
+        context.Rewrite(rewriter);
 
-            logger.LogDebug("Identified profile {} for {}", rewriter.Profile, path);
-            if (rewriter.Profile.BakedOutputSubdirectory is not null)
-            {
-                var discrim = $"sources/{rewriter.Profile.BakedOutputSubdirectory.Trim('/')}";
-                if (!bakery.TryGetValue(discrim, out var bakeSet))
-                {
-                    bakeSet = bakery[discrim] = new BakeSet();
-                }
-
-                rewriter.Baked = bakeSet;
-                baked.Add(path);
-            }
-
-            syntax.Files[path] = rewriter.Visit(root);
-            foreach (var (k, v) in rewriter.UsingsToAdd)
-            {
-                aggregatedUsings.TryAdd(k, v);
-            }
-            rewriter.UsingsToAdd.Clear();
-            rewriter.Baked = null;
-            rewriter.Profile = null;
-        }
-
-        foreach (var path in baked)
-        {
-            syntax.Files.Remove(path);
-        }
-
-        foreach (var (subdir, bakeSet) in bakery)
-        {
-            foreach (var (fqTopLevelType, bakedMember) in bakeSet.Children)
-            {
-                var (iden, bakedSyntax) = Bake(bakedMember);
-                if (iden is null)
-                {
-                    throw new InvalidOperationException(
-                        "Cannot output an unidentified syntax. Top-level syntax should be type declarations only."
-                    );
-                }
-
-                var ns = fqTopLevelType.LastIndexOf('.') is not -1 and var idx
-                    ? fqTopLevelType[..idx]
-                    : null;
-                syntax.Files[$"{subdir}/{PathForFullyQualified(fqTopLevelType)}"] =
-                    CompilationUnit()
-                        .WithMembers(
-                            ns is null
-                                ? SingletonList(bakedSyntax)
-                                : SingletonList<MemberDeclarationSyntax>(
-                                    FileScopedNamespaceDeclaration(
-                                            ModUtils.NamespaceIntoIdentifierName(ns)
-                                        )
-                                        .WithMembers(SingletonList(bakedSyntax))
-                                )
-                        )
-                        .WithUsings(ModCSharpSyntaxRewriter.GetUsings(aggregatedUsings, null));
-            }
-        }
-
-        return Task.FromResult(syntax);
+        return Task.FromResult(context);
     }
-
-    private static (string? Identifier, MemberDeclarationSyntax Syntax) Bake(
-        (MemberDeclarationSyntax Syntax, BakeSet? Inner, int Index) member
-    ) =>
-        member.Syntax switch
-        {
-            TypeDeclarationSyntax ty
-                => (
-                    ty.Identifier
-                        + (
-                            ty.TypeParameterList is { Parameters.Count: > 0 and var cnt }
-                                ? $"`{cnt}"
-                                : string.Empty
-                        ),
-                    ty.WithMembers(
-                        List(
-                            ty.Members.Concat(
-                                member
-                                    .Inner?.Children.Values.OrderBy(x => x.Index)
-                                    .Select(x => Bake(x).Syntax)
-                                    ?? Enumerable.Empty<MemberDeclarationSyntax>()
-                            )
-                        )
-                    )
-                ),
-            EnumDeclarationSyntax enumDecl
-                => (
-                    enumDecl.Identifier.ToString(),
-                    enumDecl.WithMembers(
-                        SeparatedList(
-                            enumDecl.Members.Concat(
-                                member
-                                    .Inner?.Children.Values.OrderBy(x => x.Index)
-                                    .Select(x => x.Syntax)
-                                    .OfType<EnumMemberDeclarationSyntax>()
-                                    ?? Enumerable.Empty<EnumMemberDeclarationSyntax>()
-                            )
-                        )
-                    )
-                ),
-            DelegateDeclarationSyntax del
-                => (
-                    del.Identifier
-                        + (
-                            del.TypeParameterList is { Parameters.Count: > 0 and var cnt }
-                                ? $"`{cnt}"
-                                : string.Empty
-                        ),
-                    del
-                ),
-            var x => (null, x)
-        };
 }

--- a/sources/SilkTouch/Mods/AddOpaqueStructs.cs
+++ b/sources/SilkTouch/Mods/AddOpaqueStructs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -55,10 +55,10 @@ public class AddOpaqueStructs : IMod
     }
 
     /// <inheritdoc />
-    public Task<GeneratedSyntax> AfterScrapeAsync(string key, GeneratedSyntax syntax)
+    public Task<SyntaxContext> AfterScrapeAsync(string key, SyntaxContext context)
     {
         var cfg = _config.Get(key);
-        var diags = new List<Diagnostic>(syntax.Diagnostics);
+        var diags = new List<Diagnostic>(context.Diagnostics);
         foreach (var name in cfg.Names ?? Array.Empty<string>())
         {
             var qualified = name.LastIndexOf('.');
@@ -80,7 +80,7 @@ public class AddOpaqueStructs : IMod
                 continue;
             }
 
-            syntax.Files.Add(
+            context.AddFile(
                 $"sources/{name[(qualified + 1)..]}.gen.cs",
                 CompilationUnit()
                     .WithMembers(
@@ -103,6 +103,6 @@ public class AddOpaqueStructs : IMod
             );
         }
 
-        return Task.FromResult(syntax with { Diagnostics = diags });
+        return Task.FromResult(context);
     }
 }

--- a/sources/SilkTouch/Mods/Common/IMod.cs
+++ b/sources/SilkTouch/Mods/Common/IMod.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Silk.NET.SilkTouch.Clang;
 
@@ -40,13 +40,13 @@ public interface IMod
     /// opportunity to mutate the syntax tree.
     /// </summary>
     /// <param name="key">The job name (corresponds to the configuration key for mod configs).</param>
-    /// <param name="syntax">The generated output from ClangSharp (or the previous mod).</param>
+    /// <param name="context">The generated output from ClangSharp (or the previous mod).</param>
     /// <returns>
     /// The modified syntax nodes to be either passed to the next mod or output from the generator if this is the last
     /// mod.
     /// </returns>
-    Task<GeneratedSyntax> AfterScrapeAsync(string key, GeneratedSyntax syntax) =>
-        Task.FromResult(syntax);
+    Task<SyntaxContext> AfterScrapeAsync(string key, SyntaxContext context) =>
+        Task.FromResult(context);
 
     /// <summary>
     /// Runs before SilkTouch is going to output the MSBuild workspace. The generated documents have already been added,

--- a/sources/SilkTouch/Mods/Common/Mod.cs
+++ b/sources/SilkTouch/Mods/Common/Mod.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Silk.NET.SilkTouch.Clang;
@@ -55,8 +55,8 @@ public class Mod : IMod
     }
 
     /// <inheritdoc />
-    public virtual Task<GeneratedSyntax> AfterScrapeAsync(string key, GeneratedSyntax syntax) =>
-        Task.FromResult(syntax);
+    public virtual Task<GeneratedSyntax> AfterScrapeAsync(string key, SyntaxContext context) =>
+        Task.FromResult(context);
 
     /// <inheritdoc />
     public virtual Task<GeneratorWorkspace> BeforeOutputAsync(

--- a/sources/SilkTouch/Mods/Common/Mod.cs
+++ b/sources/SilkTouch/Mods/Common/Mod.cs
@@ -55,7 +55,7 @@ public class Mod : IMod
     }
 
     /// <inheritdoc />
-    public virtual Task<GeneratedSyntax> AfterScrapeAsync(string key, SyntaxContext context) =>
+    public virtual Task<SyntaxContext> AfterScrapeAsync(string key, SyntaxContext context) =>
         Task.FromResult(context);
 
     /// <inheritdoc />

--- a/sources/SilkTouch/Mods/Common/ModCSharpSyntaxRewriter.cs
+++ b/sources/SilkTouch/Mods/Common/ModCSharpSyntaxRewriter.cs
@@ -145,4 +145,7 @@ public abstract class ModCSharpSyntaxRewriter(bool visitIntoStructuredTrivia = f
     /// <returns>The discriminator string.</returns>
     protected static string Discrim(UsingDirectiveSyntax use) =>
         new(use.WithoutTrivia().ToString().Where(char.IsAsciiLetterOrDigit).ToArray());
+
+    /// <inheritdoc/>
+    public override bool ShouldSkipFile(string fileName) => fileName.StartsWith("sources/");
 }

--- a/sources/SilkTouch/Mods/Common/ModCSharpSyntaxRewriter.cs
+++ b/sources/SilkTouch/Mods/Common/ModCSharpSyntaxRewriter.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Silk.NET.SilkTouch.Clang;
 using Silk.NET.SilkTouch.Mods.Transformation;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
@@ -13,7 +14,7 @@ namespace Silk.NET.SilkTouch.Mods;
 /// <see cref="CSharpSyntaxRewriter"/> containing common functionality for mods.
 /// </summary>
 public abstract class ModCSharpSyntaxRewriter(bool visitIntoStructuredTrivia = false)
-    : CSharpSyntaxRewriter(visitIntoStructuredTrivia),
+    : ContextCSharpSyntaxRewriter(visitIntoStructuredTrivia),
         ITransformationContext
 {
     private ThreadLocal<Dictionary<string, UsingDirectiveSyntax>> _usingsToAdd =

--- a/sources/SilkTouch/SilkTouchGenerator.cs
+++ b/sources/SilkTouch/SilkTouchGenerator.cs
@@ -256,6 +256,8 @@ public class SilkTouchGenerator(
         rawBindings.Files.Clear(); // GC ASAP
         var bindings = new GeneratedSyntax(syntaxTrees, rawBindings.Diagnostics);
 
+        var context = new SyntaxContext( bindings );
+
         // Mod the bindings
         // ReSharper disable once LoopCanBeConvertedToQuery
         foreach (var mod in jobMods)


### PR DESCRIPTION
# Summary of the PR
Adds the SyntaxContext object to better interact with the whole syntax tree. Reworks the mods system to use this instead of the GeneratedSyntax object, which is instead used as part of the SyntaxContext construction.
