### PR TITLE
ImGui memory leak fix

### DIFF
--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.ImGui/ImGuiController.cs
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.ImGui/ImGuiController.cs
@@ -251,7 +251,7 @@ namespace Silk.NET.OpenGL.Legacy.Extensions.ImGui
         {
             var io = ImGuiNET.ImGui.GetIO();
 
-            var mouseState = _input.Mice[0].CaptureState();
+            using var mouseState = _input.Mice[0].CaptureState();
 
             io.MouseDown[0] = mouseState.IsButtonPressed(MouseButton.Left);
             io.MouseDown[1] = mouseState.IsButtonPressed(MouseButton.Right);


### PR DESCRIPTION
# Summary of the PR
The `ImGuiController::UpdateImGuiImput`  function creates a `MouseState` but never disposes it. 
This causes the `MemoryPool` to keep renting new buffers in the constructor, resulting in a small memory leak.

