### PR TITLE
Add CI builds (MacOS only) for ANGLE

### DIFF
--- a/.github/workflows/angle.yml
+++ b/.github/workflows/angle.yml
@@ -1,0 +1,43 @@
+name: MoltenVK
+on:
+    push:
+        branches-ignore:
+            - "ci/**"
+            - "develop/**"
+            - "main"
+        paths:
+            - build/submodules/ANGLE
+            - build/nuke/Native/Core.cs
+            - build/nuke/Native/Angle.cs
+            - .github/workflows/angle.yml
+jobs:
+    Build:
+        if: github.repository == 'dotnet/Silk.NET'
+        strategy:
+            fail-fast: false
+            matrix:
+                env:
+                    - os: macos-13-xlarge
+                      name: Darwin
+                      nuke_invoke: ./build.sh
+        name: ${{ matrix.env.name }} Build
+        runs-on: ${{ matrix.env.os }}
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  token: ${{ secrets.PUSHABLE_GITHUB_TOKEN }}
+
+            - name: Configure git
+              run: |
+                  git config --local user.email "9011267+dotnet-bot@users.noreply.github.com"
+                  git config --local user.name "The Silk.NET Automaton"
+
+            # Install python
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: "3.10"
+
+            - name: Build ANGLE
+              run: ${{ matrix.env.nuke_invoke }} Angle
+              env:
+                  PUSHABLE_GITHUB_TOKEN: ${{ secrets.PUSHABLE_GITHUB_TOKEN }}

--- a/.github/workflows/angle.yml
+++ b/.github/workflows/angle.yml
@@ -1,4 +1,4 @@
-name: MoltenVK
+name: ANGLE
 on:
     push:
         branches-ignore:

--- a/build/nuke/Native/Angle.cs
+++ b/build/nuke/Native/Angle.cs
@@ -2,112 +2,150 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
-using JetBrains.Annotations;
 using Nuke.Common;
-using Nuke.Common.CI.GitHubActions;
-using Nuke.Common.Git;
 using Nuke.Common.IO;
 using Nuke.Common.Tooling;
-using Nuke.Common.Tools.DotNet;
-using Nuke.Common.Tools.Git;
-using Octokit;
-using Octokit.Internal;
-using static Nuke.Common.IO.CompressionTasks;
+using Nuke.Common.Utilities.Collections;
 using static Nuke.Common.IO.FileSystemTasks;
-using static Nuke.Common.IO.HttpTasks;
-using static Nuke.Common.Tooling.ProcessTasks;
-using static Nuke.Common.Tools.DotNet.DotNetTasks;
-using static Nuke.Common.Tools.Git.GitTasks;
-using static Nuke.Common.Tools.GitHub.GitHubTasks;
 
 partial class Build {
-    // NOTE: Disabled until space issues are resolved! If you are a user who needs this please submit a PR!
+    // NOTE: Enabled only on MacOS until space issues are resolved! If you are a user who needs this please submit a PR!
 
-    // AbsolutePath AnglePath => RootDirectory / "build" / "submodules" / "ANGLE";
+    Target Angle => CommonTarget
+    (
+        x => x.Before(Compile)
+            .After(Clean)
+            .Executes
+            (
+                () =>
+                {
+                    var tempDir = (AbsolutePath)Directory.CreateTempSubdirectory("silkDotNetAngleBuild").FullName;
+                    InheritedShell($"git clone --depth 1 --single-branch https://chromium.googlesource.com/chromium/tools/depot_tools.git", tempDir).AssertZeroExitCode();
+                    AddToPath(tempDir / "depot_tools");
 
-    // Target Angle => CommonTarget
-    // (
-    //     x => x.Before(Compile)
-    //         .After(Clean)
-    //         .Executes
-    //         (
-    //             () =>
-    //             {
-    //                 var @out = AnglePath / "out" / "Release";
-    //                 EnsureCleanDirectory(@out);
-    //                 var zip = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-    //                 var unzip = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-    //                 HttpDownloadFile("https://storage.googleapis.com/chrome-infra/depot_tools.zip", zip);
-    //                 UncompressZip(zip, unzip);
-    //                 if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
-    //                 {
-    //                     InheritedShell($"chmod -R 777 \"{unzip}\"");
-    //                 }
+                    if (OperatingSystem.IsWindows())
+                    {
+                        Environment.SetEnvironmentVariable("DEPOT_TOOLS_WIN_TOOLCHAIN", "0");
+                    }
 
-    //                 AddToPath(unzip);
-    //                 if (OperatingSystem.IsWindows())
-    //                 {
-    //                     Environment.SetEnvironmentVariable("DEPOT_TOOLS_WIN_TOOLCHAIN", "0");
-    //                 }
+                    var angleSourceDir = tempDir / "angle_source";
+                    EnsureCleanDirectory(angleSourceDir);
+                    InheritedShell("fetch --no-history angle", angleSourceDir).AssertZeroExitCode();
 
-    //                 InheritedShell("python scripts/bootstrap.py", AnglePath).AssertZeroExitCode();
-    //                 InheritedShell("gclient sync", AnglePath).AssertZeroExitCode();
-    //                 if (OperatingSystem.IsLinux())
-    //                 {
-    //                     InheritedShell("sudo ./build/install-build-deps.sh", AnglePath).AssertZeroExitCode();
-    //                 }
+                    // save space
+                    // DeleteDirectory takes too long (it deletes individual files)
+                    Directory.Delete(angleSourceDir / "third_party"/ "VK-GL-CTS", true); // this is only possible because we disable tests below
+                    Directory.Delete(angleSourceDir / "third_party"/ "dawn", true); // this is only possible because we disable wgpu below
+                    (angleSourceDir / "third_party").GlobDirectories("*.git").ForEach(DeleteDirectory);
+                    
+                    if (OperatingSystem.IsLinux())
+                    {
+                        InheritedShell("sudo ./build/install-build-deps.sh", angleSourceDir).AssertZeroExitCode();
+                    }
 
-    //                 var runtimes = RootDirectory / "src" / "Native" / "Silk.NET.OpenGLES.ANGLE.Native" / "runtimes";
-    //                 if (OperatingSystem.IsWindows())
-    //                 {
-    //                     InheritedShell
-    //                         (
-    //                             "gn gen out/Release " +
-    //                             "--args='is_component_build=false target_cpu=\"\"x86\"\" is_debug=false'",
-    //                             AnglePath
-    //                         )
-    //                         .AssertZeroExitCode();
-    //                     InheritedShell($"autoninja -C \"{@out}\"", AnglePath).AssertZeroExitCode();
-    //                     CopyAll
-    //                     (
-    //                         // libANGLE might not exist, this is fine
-    //                         @out.GlobFiles("libGLESv2.dll", "libEGL.dll", "libANGLE.dll"),
-    //                         runtimes / "win-x64" / "native"
-    //                     );
-    //                     CopyAll
-    //                     (
-    //                         @out.GlobFiles("libGLESv2.dll", "libEGL.dll", "libANGLE.dll"),
-    //                         runtimes / "win-x86" / "native"
-    //                     );
-    //                 }
-    //                 else
-    //                 {
-    //                     InheritedShell
-    //                         (
-    //                             $"gn gen \"{@out}\" " +
-    //                             "--args=\"is_component_build=false is_debug=false\"",
-    //                             AnglePath
-    //                         )
-    //                         .AssertZeroExitCode();
-    //                     InheritedShell($"autoninja -C \"{@out}\"", AnglePath).AssertZeroExitCode();
-    //                     CopyAll
-    //                     (
-    //                         @out.GlobFiles
-    //                         (
-    //                             "libGLESv2.so", "libEGL.so", "libANGLE.so",
-    //                             "libGLESv2.dylib", "libEGL.dylib", "libANGLE.dylib"
-    //                         ),
-    //                         runtimes / (OperatingSystem.IsMacOS() ? "osx-x64" : "linux-x64") / "native"
-    //                     );
-    //                 }
+                    var runtimes = RootDirectory / "src" / "Native" / "Silk.NET.OpenGLES.ANGLE.Native" / "runtimes";
+                    // if (OperatingSystem.IsWindows())
+                    // {
+                    //     var @out = angleSourceDir / "out" / "Release";
+                    //     EnsureCleanDirectory(@out);
+                    //     InheritedShell
+                    //         (
+                    //             "gn gen out/Release " +
+                    //             "--args='is_component_build=false target_cpu=\"\"x86\"\" is_debug=false'",
+                    //             angleSourceDir
+                    //         )
+                    //         .AssertZeroExitCode();
+                    //     InheritedShell($"autoninja -C \"{@out}\"", angleSourceDir).AssertZeroExitCode();
+                    //     CopyAll
+                    //     (
+                    //         // libANGLE might not exist, this is fine
+                    //         @out.GlobFiles("libGLESv2.dll", "libEGL.dll", "libANGLE.dll"),
+                    //         runtimes / "win-x64" / "native"
+                    //     );
+                    //     CopyAll
+                    //     (
+                    //         @out.GlobFiles("libGLESv2.dll", "libEGL.dll", "libANGLE.dll"),
+                    //         runtimes / "win-x86" / "native"
+                    //     );
+                    // }
+                    // else
+                        if (OperatingSystem.IsMacOS())
+                    {
+                        foreach (var arch in new [] { "arm64", "x64" })
+                        {
+                            var @out = angleSourceDir / "out" / $"Release_{arch}";
+                            EnsureCleanDirectory(@out);
+                            var args = new[]
+                            {
+                                ("target_cpu", $"\"{arch}\""),
+                                ("is_debug", "false"),
+                                // ("angle_assert_always_on", "true"),
+                                ("angle_build_tests", "false"),
+                                ("angle_enable_null", "false"),
+                                ("angle_enable_vulkan", "false"),
+                                ("angle_enable_wgpu", "false"),
+                                // ("angle_enable_abseil", "false"),
+                                ("angle_enable_gl", "false"),
+                            };
+                            InheritedShell
+                                (
+                                    $"gn gen \"{@out}\" --args='{string.Join(" ", args.Select(arg => $"{arg.Item1} = {arg.Item2}"))}'",
+                                    angleSourceDir
+                                )
+                                .AssertZeroExitCode();
+                            InheritedShell($"autoninja -C \"{@out}\"", angleSourceDir).AssertZeroExitCode();
+                        }
+                        
+                        // create universal mac binaries
+                        var arm64NativeRuntimes = runtimes / "osx-arm64" / "native";
+                        var x64NativeRuntimes = runtimes / "osx-x64" / "native";
+                        EnsureCleanDirectory(arm64NativeRuntimes);
+                        EnsureCleanDirectory(x64NativeRuntimes);
+                        foreach (var lib in new[] { "libGLESv2.dylib", "libEGL.dylib" })
+                        {
+                            var x64Lib = angleSourceDir / "out" / "Release_x64" / lib;
+                            var arm64Lib = angleSourceDir / "out" / "Release_arm64" / lib;
+                            InheritedShell
+                                (
+                                    $"lipo -create \"{arm64Lib}\" \"{x64Lib}\" -output \"{arm64NativeRuntimes / lib}\"",
+                                    angleSourceDir
+                                )
+                                .AssertZeroExitCode();
+                        }
+                        
+                        CopyAll
+                        (
+                            arm64NativeRuntimes.GlobFiles("libGLESv2.dll", "libEGL.dll", "libANGLE.dll"),
+                            x64NativeRuntimes
+                        );
+                    }
+                    // else
+                    //     if (OperatingSystem.IsLinux())
+                    // {
+                    //     var @out = angleSourceDir / "out" / "Release";
+                    //     EnsureCleanDirectory(@out);
+                    //     InheritedShell
+                    //         (
+                    //             $"gn gen \"{@out}\" " +
+                    //             "--args=\"is_component_build=false is_debug=false\"",
+                    //             angleSourceDir
+                    //         )
+                    //         .AssertZeroExitCode();
+                    //     InheritedShell($"autoninja -C \"{@out}\"", angleSourceDir).AssertZeroExitCode();
+                    //     CopyAll
+                    //     (
+                    //         @out.GlobFiles
+                    //         (
+                    //             "libGLESv2.so", "libEGL.so", "libANGLE.so"
+                    //         ),
+                    //         runtimes / "linux-x64" / "native"
+                    //     );
+                    // }
 
-    //                 PrUpdatedNativeBinary("ANGLE");
-    //             }
-    //         )
-    // );
+                    PrUpdatedNativeBinary("ANGLE");
+                }
+            )
+    );
 }


### PR DESCRIPTION
# Summary of the PR
This PR adjusts the `Angle.cs` script to optimize disk space usage and also build fat binaries for MacOS (to work on both arm64 and x64 macs). For now, only MacOS builds are enabled.

# Related issues, Discord discussions, or proposals
Links go here.
https://github.com/dotnet/Silk.NET/issues/2024
# Further Comments
