### PR TITLE
Dispose Glfw/Sdl When Checking if Applicable

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Glfw/GlfwPlatform.cs
+++ b/src/Windowing/Silk.NET.Windowing.Glfw/GlfwPlatform.cs
@@ -23,9 +23,10 @@ namespace Silk.NET.Windowing.Glfw
         (
             () =>
             {
+                GLFW.Glfw? api = null;
                 try
                 {
-                    GLFW.Glfw.GetApi(); // activate the class so we can determine if we can activate the class
+                    api = GLFW.Glfw.GetApi(); // activate the class so we can determine if we can activate the class
                 }
                 catch (Exception ex)
                 {
@@ -33,6 +34,10 @@ namespace Silk.NET.Windowing.Glfw
                     Console.WriteLine($"Can't load GLFW: {ex}");
 #endif
                     return false;
+                }
+                finally
+                {
+                    api?.Dispose();
                 }
 
                 return true;

--- a/src/Windowing/Silk.NET.Windowing.Sdl/SdlPlatform.cs
+++ b/src/Windowing/Silk.NET.Windowing.Sdl/SdlPlatform.cs
@@ -34,9 +34,10 @@ namespace Silk.NET.Windowing.Sdl
         (
             () =>
             {
+                SDL.Sdl? api = null;
                 try
                 {
-                    SDL.Sdl.GetApi();
+                    api = SDL.Sdl.GetApi();
                 }
                 catch (Exception ex)
                 {
@@ -44,6 +45,10 @@ namespace Silk.NET.Windowing.Sdl
                     Console.WriteLine($"Can't load SDL: {ex}");
 #endif
                     return false;
+                }
+                finally
+                {
+                    api?.Dispose();
                 }
 
                 return true;


### PR DESCRIPTION
# Summary of the PR
Calling `GLFW.Glfw.GetApi();` when Glfw is applicable without disposing it leaks the native module. So we make sure `Dispose()` is called, which triggers freeing of the native library and reduce the 'counter'.

# Further Comments  
This was discovered when I was trying to delete the native library (`glfw3.dll`) on program exit. The delete failed because the program was still referencing the module.  
The codebase uses the lazy `GlfwProvider.GLFW` where it makes sense. When needed, the lazy implementation will have the `Dispose()` called, thus freeing `glfw3`. But because of the applicable check, the module will never truly be freed without calling `GlfwProvider.GLFW.Value._ctx.Dispose();` manually at least once after a Window creation


