### PR TITLE
Bump Microsoft.Extensions.DependencyModel

### DIFF
--- a/src/Core/Silk.NET.Core/Silk.NET.Core.csproj
+++ b/src/Core/Silk.NET.Core/Silk.NET.Core.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
         <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-        <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
         <PackageReference Include="System.Memory" Version="4.5.5" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
         <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />

--- a/src/Lab/Experiments/PrototypeStructChaining/PrototypeStructChaining/PrototypeStructChaining.csproj
+++ b/src/Lab/Experiments/PrototypeStructChaining/PrototypeStructChaining/PrototypeStructChaining.csproj
@@ -11,7 +11,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
         <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-        <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
         <ProjectReference Include="..\..\..\..\Core\Silk.NET.Core\Silk.NET.Core.csproj" />
         <PackageReference Include="System.Memory" Version="4.5.5" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />


### PR DESCRIPTION
This is mainly to bump the transitive System.Text.Json dependency from 8.0.0 to 9.0.0, fixing https://github.com/advisories/GHSA-hh2w-p6rv-4g7w.

Closes #2370. As described in that issue, the System.Text.Json dependency is shipped to all consumers of the `Silk.NET.Core` package and will result in build warnings when building with the .NET 9 SDK.
