### PR TITLE
Fix typos on the website root page

### DIFF
--- a/website/index.cshtml
+++ b/website/index.cshtml
@@ -240,7 +240,7 @@
           <br />
           <br />
           
-          This means you can count on us not disappearing tomorrow, and continuing to reamin under steady development; a guarantee that similar libraries just can't provide.</p>
+          This means you can count on us not disappearing tomorrow, and continuing to remain under steady development; a guarantee that similar libraries just can't provide.</p>
       </div>
       <div class="col-lg-4">
         <div class="icon icon-lg icon-shape bg-gradient-white shadow rounded-circle text-primary">

--- a/website/index.cshtml
+++ b/website/index.cshtml
@@ -247,7 +247,7 @@
           <i class="ni ni-atom text-primary"></i>
         </div>
         <h5 class="text-white mt-3">Continuously improving.</h5>
-        <p class="text-white mt-3">We're quick to develop and release new major versions for keeping up with changes and new trends in the ecosystem. In addition, we're keen to create infrastructure to make minor incremental improvments easy to implement.<br /><br />We're happy to look at any idea the community has for us, large or small, so feel free to chat to us if you think there's a way we can improve!</p>
+        <p class="text-white mt-3">We're quick to develop and release new major versions for keeping up with changes and new trends in the ecosystem. In addition, we're keen to create infrastructure to make minor incremental improvements easy to implement.<br /><br />We're happy to look at any idea the community has for us, large or small, so feel free to chat to us if you think there's a way we can improve!</p>
       </div>
       <div class="col-lg-4">
         <div class="icon icon-lg icon-shape bg-gradient-white shadow rounded-circle text-primary">


### PR DESCRIPTION
# Summary of the PR
Fixes the "remain" and "improvements" typos found on the website root of the github.io pages.

![image](https://github.com/user-attachments/assets/c86b9e24-9304-4be9-90b3-698478eac8d2)
![image](https://github.com/user-attachments/assets/7a242b7b-73a8-42e3-b2fb-a4a258e88f29)

# Further Comments
Untested