### PR TITLE
Fix aar duplication for Android

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Sdl/Silk.NET.Windowing.Sdl.csproj
+++ b/src/Windowing/Silk.NET.Windowing.Sdl/Silk.NET.Windowing.Sdl.csproj
@@ -27,7 +27,7 @@
 
     <!-- Android Specific Files -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
-        <AndroidLibrary Update="Android\app-release.aar" Bind="true" />
+        <AndroidLibrary Update="Android\app-release.aar" Bind="true" Pack="false" />
         <TransformFile Include="Android/Metadata.xml" />
         <TransformFile Include="Android/EnumFields.xml" />
         <TransformFile Include="Android/EnumMethods.xml" />


### PR DESCRIPTION
Android applications currently can't build due to type duplication issues. It turns out we've been shipping the same AAR twice and haven't noticed until now.