### PR TITLE
Use UTF-8 for OpenAL string marshalling

### DIFF
--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Creative/EnumerateAll.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Creative/EnumerateAll.cs
@@ -3,7 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+using System.Linq;
+using System.Text;
 using Silk.NET.Core.Attributes;
 using Silk.NET.Core.Contexts;
 using Silk.NET.Core.Native;
@@ -36,24 +37,18 @@ namespace Silk.NET.OpenAL.Extensions.Creative
             unsafe
             {
                 var result = GetStringList(null, param);
-                if (result == (byte*) 0)
-                {
-                    return new List<string>();
-                }
+                if (result is null) return Enumerable.Empty<string>();
 
                 var strings = new List<string>();
 
                 var currentPos = result;
-                while (true)
+                while (*currentPos != '\0')
                 {
-                    var currentString = Marshal.PtrToStringAnsi((nint) currentPos);
-                    if (string.IsNullOrEmpty(currentString))
-                    {
-                        break;
-                    }
+                    var currentLength = (int) SilkMarshal.StringLength((nint) currentPos, NativeStringEncoding.UTF8);
+                    var currentString = Encoding.UTF8.GetString(currentPos, currentLength);
 
                     strings.Add(currentString);
-                    currentPos += currentString.Length + 1;
+                    currentPos += currentLength + 1;
                 }
 
                 return strings;

--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.EXT/CaptureEnumerationEnumeration.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.EXT/CaptureEnumerationEnumeration.cs
@@ -3,7 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+using System.Linq;
+using System.Text;
 using Silk.NET.Core.Attributes;
 using Silk.NET.Core.Contexts;
 using Silk.NET.Core.Native;
@@ -37,24 +38,18 @@ namespace Silk.NET.OpenAL.Extensions.EXT
             unsafe
             {
                 var result = GetStringList(null, param);
-                if (result == (byte*) 0)
-                {
-                    return new List<string>();
-                }
+                if (result is null) return Enumerable.Empty<string>();
 
                 var strings = new List<string>();
-
+ 
                 var currentPos = result;
-                while (true)
+                while (*currentPos != '\0')
                 {
-                    var currentString = Marshal.PtrToStringAnsi((nint) currentPos);
-                    if (string.IsNullOrEmpty(currentString))
-                    {
-                        break;
-                    }
+                    var currentLength = (int) SilkMarshal.StringLength((nint) currentPos, NativeStringEncoding.UTF8);
+                    var currentString = Encoding.UTF8.GetString(currentPos, currentLength);
 
                     strings.Add(currentString);
-                    currentPos += currentString.Length + 1;
+                    currentPos += currentLength + 1;
                 }
 
                 return strings;

--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Enumeration/Enumeration.cs
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Enumeration/Enumeration.cs
@@ -3,7 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+using System.Linq;
+using System.Text;
 using Silk.NET.Core.Attributes;
 using Silk.NET.Core.Contexts;
 using Silk.NET.Core.Native;
@@ -36,24 +37,18 @@ namespace Silk.NET.OpenAL.Extensions.Enumeration
             unsafe
             {
                 var result = GetStringList(null, param);
-                if (result == (byte*) 0)
-                {
-                    return new List<string>();
-                }
+                if (result is null) return Enumerable.Empty<string>();
 
                 var strings = new List<string>();
 
                 var currentPos = result;
-                while (true)
+                while (*currentPos != '\0')
                 {
-                    var currentString = Marshal.PtrToStringAnsi((nint) currentPos);
-                    if (string.IsNullOrEmpty(currentString))
-                    {
-                        break;
-                    }
+                    var currentLength = (int) SilkMarshal.StringLength((nint) currentPos, NativeStringEncoding.UTF8);
+                    var currentString = Encoding.UTF8.GetString(currentPos, currentLength);
 
                     strings.Add(currentString);
-                    currentPos += currentString.Length + 1;
+                    currentPos += currentLength + 1;
                 }
 
                 return strings;


### PR DESCRIPTION
`Marshal.PtrToStringAnsi` uses the system codepage which is problematic especially on windows. OpenAL returns UTF-8 strings which should be parsed as UTF-8.

Using the following test code:
```csharp
var api = ALContext.GetApi();
api.TryGetExtension<EnumerateAll>(null, out var enumerateAll);
var deviceEnumerable = enumerateAll.GetStringList(GetEnumerateAllContextStringList.AllDevicesSpecifier);
foreach (var deviceName in deviceEnumerable)
{
    Console.WriteLine(deviceName);
}
```

with a non-utf-8 codepage and a device named `test ドットネット`, I get:

before:
`OpenAL Soft on test ãƒ%ãƒƒãƒ^ãƒ?ãƒƒãƒ^ (Realtek High Definition Audio)`

after (with proper console encoding configured):
`OpenAL Soft on test ドットネット (Realtek High Definition Audio)`