### PR TITLE
Gracefully map unknown or invalid `Input.Key` to `ImGuiKey.None`.

### DIFF
--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.ImGui/ImGuiController.cs
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.ImGui/ImGuiController.cs
@@ -287,7 +287,6 @@ namespace Silk.NET.OpenGL.Legacy.Extensions.ImGui
         /// </summary>
         /// <param name="key">The Silk.NET.Input.Key to translate.</param>
         /// <returns>The corresponding ImGuiKey.</returns>
-        /// <exception cref="NotImplementedException">When the key has not been implemented yet.</exception>
         private static ImGuiKey TranslateInputKeyToImGuiKey(Key key)
         {
             return key switch
@@ -409,7 +408,7 @@ namespace Silk.NET.OpenGL.Legacy.Extensions.ImGui
                 Key.F22 => ImGuiKey.F22,
                 Key.F23 => ImGuiKey.F23,
                 Key.F24 => ImGuiKey.F24,
-                _ => throw new NotImplementedException(),
+                _ => ImGuiKey.None,       // Key isn't implemented
             };
         }
 


### PR DESCRIPTION
# Summary of the PR
Changes `ImGuiController.TranslateInputKeyToImGuiKey` to no longer throw a `NotImplementedException` when given an unknown key and instead gracefully map to `ImGuiKey.None`, the ImGui equivalent of an unmapped/discarded key.

# Related issues, Discord discussions, or proposals
Fixes #2372.