### PR TITLE
Add bindings for MediaFoundation

### DIFF
--- a/build/include/silk.net.mediafoundation.h
+++ b/build/include/silk.net.mediafoundation.h
@@ -1,0 +1,2 @@
+#include <Windows.h>
+#include <mfmediaengine.h>

--- a/generator.json
+++ b/generator.json
@@ -2778,7 +2778,72 @@
             "namespace": "Silk.NET.XInput",
             "extensionsNamespace": "Silk.NET.XInput.Extensions",
             "typeMaps": [
-                {},
+                {
+                    "$include.dxTypemap": "build/dx_typemap.json",
+                    "$include.commonTypeMap": "build/csharp_typemap.json"
+                }
+            ]
+        },
+        {
+            "profileName": "MediaFoundation",
+            "sources": [
+                "build/include/silk.net.mediafoundation.h"
+            ],
+            "mode": "Clang",
+            "cacheDir": "build/cache",
+            "cacheKey": "mediafoundation",
+            "controlDescriptors": [
+                "convert-windows-only",
+                "typemap-native",
+                "no-pre-2.17-obsolete-enums"
+            ],
+            "converter": {},
+            "prefix": "MF",
+            "clang": {
+                "args": [
+                    "--language=c++",
+                    "--std=c++17",
+                    "-m32",
+                    "-Wno-expansion-to-defined",
+                    "-Wno-ignored-attributes",
+                    "-Wno-ignored-pragma-intrinsic",
+                    "-Wno-nonportable-include-path",
+                    "-Wno-pragma-pack",
+                    "-I$windowsSdkIncludes",
+                    "-Ibuild/include"
+                ],
+                "traverse": [
+                    "$windowsSdkDir/Include/$windowsSdkVersion/um/mfmediaengine.h"
+                ],
+                "classes": {
+                    "silk.net.mediafoundation.h": "[Core]MediaFoundation"
+                }
+            },
+            "exclude": [],
+            "rename": {},
+            "bakery": {
+                "profileNames": [
+                    "silk.net.mediafoundation"
+                ]
+            },
+            "output": {
+                "mode": "Default",
+                "path": "src/Microsoft",
+                "licenseFile": "build/LICENSE_HEADER.txt",
+                "props": "build/props/bindings.props"
+            },
+            "namespace": "Silk.NET.MediaFoundation",
+            "extensionsNamespace": "Silk.NET.MediaFoundation.Extensions",
+            "nameContainer": {
+                "linux-x64": "libMediaFoundation.so",
+                "win-x64": "MediaFoundation.dll",
+                "win-x86": "MediaFoundation.dll",
+                "osx-x64": "libMediaFoundation.dylib",
+                "android": "libMediaFoundation.so",
+                "iOS": "__Internal",
+                "className": "MediaFoundationLibraryNameContainer"
+            },
+            "typeMaps": [
                 {
                     "$include.dxTypemap": "build/dx_typemap.json",
                     "$include.commonTypeMap": "build/csharp_typemap.json"

--- a/generator.json
+++ b/generator.json
@@ -2820,7 +2820,14 @@
                 }
             },
             "exclude": [],
-            "rename": {},
+            "rename": {
+                "MF_MEDIA_ENGINE_CANPLAY": "MediaEngineCanPlay",
+                "MF_MEDIA_ENGINE_CREATEFLAGS": "MediaEngineCreateFlags",
+                "MF_MEDIA_ENGINE_ERR": "MediaEngineError",
+                "_MF_MEDIA_ENGINE_KEYERR": "MediaEngineKeyError",
+                "MF_MEDIA_ENGINE_STREAMTYPE_FAILED": "MediaEngineStreamTypeFailed",
+                "MF_MEDIAKEYS_REQUIREMENT": "MediaKeysRequirement"
+            },
             "bakery": {
                 "profileNames": [
                     "silk.net.mediafoundation"

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/HdcpStatus.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/HdcpStatus.gen.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "_MF_HDCP_STATUS")]
+    public enum HdcpStatus : int
+    {
+        [NativeName("Name", "MF_HDCP_STATUS_ON")]
+        On = 0x0,
+        [NativeName("Name", "MF_HDCP_STATUS_OFF")]
+        Off = 0x1,
+        [NativeName("Name", "MF_HDCP_STATUS_ON_WITH_TYPE_ENFORCEMENT")]
+        OnWithTypeEnforcement = 0x2,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineCanplay.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineCanplay.gen.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MEDIA_ENGINE_CANPLAY")]
+    public enum MediaEngineCanplay : int
+    {
+        [NativeName("Name", "MF_MEDIA_ENGINE_CANPLAY_NOT_SUPPORTED")]
+        NotSupported = 0x0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_CANPLAY_MAYBE")]
+        Maybe = 0x1,
+        [NativeName("Name", "MF_MEDIA_ENGINE_CANPLAY_PROBABLY")]
+        Probably = 0x2,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineCanplay.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineCanplay.gen.cs
@@ -10,7 +10,7 @@ using Silk.NET.Core.Attributes;
 namespace Silk.NET.MediaFoundation
 {
     [NativeName("Name", "MF_MEDIA_ENGINE_CANPLAY")]
-    public enum MediaEngineCanplay : int
+    public enum MediaEngineCanPlay : int
     {
         [NativeName("Name", "MF_MEDIA_ENGINE_CANPLAY_NOT_SUPPORTED")]
         NotSupported = 0x0,

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineCreateflags.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineCreateflags.gen.cs
@@ -11,7 +11,7 @@ namespace Silk.NET.MediaFoundation
 {
     [Flags]
     [NativeName("Name", "MF_MEDIA_ENGINE_CREATEFLAGS")]
-    public enum MediaEngineCreateflags : int
+    public enum MediaEngineCreateFlags : int
     {
         [NativeName("Name", "")]
         None = 0,

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineCreateflags.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineCreateflags.gen.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Flags]
+    [NativeName("Name", "MF_MEDIA_ENGINE_CREATEFLAGS")]
+    public enum MediaEngineCreateflags : int
+    {
+        [NativeName("Name", "")]
+        None = 0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_AUDIOONLY")]
+        Audioonly = 0x1,
+        [NativeName("Name", "MF_MEDIA_ENGINE_WAITFORSTABLE_STATE")]
+        WaitforstableState = 0x2,
+        [NativeName("Name", "MF_MEDIA_ENGINE_FORCEMUTE")]
+        Forcemute = 0x4,
+        [NativeName("Name", "MF_MEDIA_ENGINE_REAL_TIME_MODE")]
+        RealTimeMode = 0x8,
+        [NativeName("Name", "MF_MEDIA_ENGINE_DISABLE_LOCAL_PLUGINS")]
+        DisableLocalPlugins = 0x10,
+        [NativeName("Name", "MF_MEDIA_ENGINE_CREATEFLAGS_MASK")]
+        CreateflagsMask = 0x1F,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineErr.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineErr.gen.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MEDIA_ENGINE_ERR")]
+    public enum MediaEngineErr : int
+    {
+        [NativeName("Name", "MF_MEDIA_ENGINE_ERR_NOERROR")]
+        Noerror = 0x0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_ERR_ABORTED")]
+        Aborted = 0x1,
+        [NativeName("Name", "MF_MEDIA_ENGINE_ERR_NETWORK")]
+        Network = 0x2,
+        [NativeName("Name", "MF_MEDIA_ENGINE_ERR_DECODE")]
+        Decode = 0x3,
+        [NativeName("Name", "MF_MEDIA_ENGINE_ERR_SRC_NOT_SUPPORTED")]
+        SrcNotSupported = 0x4,
+        [NativeName("Name", "MF_MEDIA_ENGINE_ERR_ENCRYPTED")]
+        Encrypted = 0x5,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineError.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineError.gen.cs
@@ -10,7 +10,7 @@ using Silk.NET.Core.Attributes;
 namespace Silk.NET.MediaFoundation
 {
     [NativeName("Name", "MF_MEDIA_ENGINE_ERR")]
-    public enum MediaEngineErr : int
+    public enum MediaEngineError : int
     {
         [NativeName("Name", "MF_MEDIA_ENGINE_ERR_NOERROR")]
         Noerror = 0x0,

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineEvent.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineEvent.gen.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MEDIA_ENGINE_EVENT")]
+    public enum MediaEngineEvent : int
+    {
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_LOADSTART")]
+        Loadstart = 0x1,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_PROGRESS")]
+        Progress = 0x2,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_SUSPEND")]
+        Suspend = 0x3,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_ABORT")]
+        Abort = 0x4,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_ERROR")]
+        Error = 0x5,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_EMPTIED")]
+        Emptied = 0x6,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_STALLED")]
+        Stalled = 0x7,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_PLAY")]
+        Play = 0x8,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_PAUSE")]
+        Pause = 0x9,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_LOADEDMETADATA")]
+        Loadedmetadata = 0xA,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_LOADEDDATA")]
+        Loadeddata = 0xB,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_WAITING")]
+        Waiting = 0xC,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_PLAYING")]
+        Playing = 0xD,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_CANPLAY")]
+        Canplay = 0xE,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_CANPLAYTHROUGH")]
+        Canplaythrough = 0xF,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_SEEKING")]
+        Seeking = 0x10,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_SEEKED")]
+        Seeked = 0x11,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_TIMEUPDATE")]
+        Timeupdate = 0x12,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_ENDED")]
+        Ended = 0x13,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_RATECHANGE")]
+        Ratechange = 0x14,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_DURATIONCHANGE")]
+        Durationchange = 0x15,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_VOLUMECHANGE")]
+        Volumechange = 0x16,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_FORMATCHANGE")]
+        Formatchange = 0x3E8,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_PURGEQUEUEDEVENTS")]
+        Purgequeuedevents = 0x3E9,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_TIMELINE_MARKER")]
+        TimelineMarker = 0x3EA,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_BALANCECHANGE")]
+        Balancechange = 0x3EB,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_DOWNLOADCOMPLETE")]
+        Downloadcomplete = 0x3EC,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_BUFFERINGSTARTED")]
+        Bufferingstarted = 0x3ED,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_BUFFERINGENDED")]
+        Bufferingended = 0x3EE,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_FRAMESTEPCOMPLETED")]
+        Framestepcompleted = 0x3EF,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_NOTIFYSTABLESTATE")]
+        Notifystablestate = 0x3F0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_FIRSTFRAMEREADY")]
+        Firstframeready = 0x3F1,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_TRACKSCHANGE")]
+        Trackschange = 0x3F2,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_OPMINFO")]
+        Opminfo = 0x3F3,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_RESOURCELOST")]
+        Resourcelost = 0x3F4,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_DELAYLOADEVENT_CHANGED")]
+        DelayloadeventChanged = 0x3F5,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_STREAMRENDERINGERROR")]
+        Streamrenderingerror = 0x3F6,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_SUPPORTEDRATES_CHANGED")]
+        SupportedratesChanged = 0x3F7,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EVENT_AUDIOENDPOINTCHANGE")]
+        Audioendpointchange = 0x3F8,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineExtensionType.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineExtensionType.gen.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MEDIA_ENGINE_EXTENSION_TYPE")]
+    public enum MediaEngineExtensionType : int
+    {
+        [NativeName("Name", "MF_MEDIA_ENGINE_EXTENSION_TYPE_MEDIASOURCE")]
+        Mediasource = 0x0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_EXTENSION_TYPE_BYTESTREAM")]
+        Bytestream = 0x1,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineFrameProtectionFlags.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineFrameProtectionFlags.gen.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Flags]
+    [NativeName("Name", "MF_MEDIA_ENGINE_FRAME_PROTECTION_FLAGS")]
+    public enum MediaEngineFrameProtectionFlags : int
+    {
+        [NativeName("Name", "")]
+        None = 0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_FRAME_PROTECTION_FLAG_PROTECTED")]
+        Protected = 0x1,
+        [NativeName("Name", "MF_MEDIA_ENGINE_FRAME_PROTECTION_FLAG_REQUIRES_SURFACE_PROTECTION")]
+        RequiresSurfaceProtection = 0x2,
+        [NativeName("Name", "MF_MEDIA_ENGINE_FRAME_PROTECTION_FLAG_REQUIRES_ANTI_SCREEN_SCRAPE_PROTECTION")]
+        RequiresAntiScreenScrapeProtection = 0x4,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineKeyError.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineKeyError.gen.cs
@@ -10,7 +10,7 @@ using Silk.NET.Core.Attributes;
 namespace Silk.NET.MediaFoundation
 {
     [NativeName("Name", "_MF_MEDIA_ENGINE_KEYERR")]
-    public enum MediaEngineKeyerr : int
+    public enum MediaEngineKeyError : int
     {
         [NativeName("Name", "MF_MEDIAENGINE_KEYERR_UNKNOWN")]
         Unknown = 0x1,

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineKeyerr.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineKeyerr.gen.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "_MF_MEDIA_ENGINE_KEYERR")]
+    public enum MediaEngineKeyerr : int
+    {
+        [NativeName("Name", "MF_MEDIAENGINE_KEYERR_UNKNOWN")]
+        Unknown = 0x1,
+        [NativeName("Name", "MF_MEDIAENGINE_KEYERR_CLIENT")]
+        Client = 0x2,
+        [NativeName("Name", "MF_MEDIAENGINE_KEYERR_SERVICE")]
+        Service = 0x3,
+        [NativeName("Name", "MF_MEDIAENGINE_KEYERR_OUTPUT")]
+        Output = 0x4,
+        [NativeName("Name", "MF_MEDIAENGINE_KEYERR_HARDWARECHANGE")]
+        Hardwarechange = 0x5,
+        [NativeName("Name", "MF_MEDIAENGINE_KEYERR_DOMAIN")]
+        Domain = 0x6,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineNetwork.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineNetwork.gen.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MEDIA_ENGINE_NETWORK")]
+    public enum MediaEngineNetwork : int
+    {
+        [NativeName("Name", "MF_MEDIA_ENGINE_NETWORK_EMPTY")]
+        Empty = 0x0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_NETWORK_IDLE")]
+        Idle = 0x1,
+        [NativeName("Name", "MF_MEDIA_ENGINE_NETWORK_LOADING")]
+        Loading = 0x2,
+        [NativeName("Name", "MF_MEDIA_ENGINE_NETWORK_NO_SOURCE")]
+        NoSource = 0x3,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineOpmStatus.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineOpmStatus.gen.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MEDIA_ENGINE_OPM_STATUS")]
+    public enum MediaEngineOpmStatus : int
+    {
+        [NativeName("Name", "MF_MEDIA_ENGINE_OPM_NOT_REQUESTED")]
+        NotRequested = 0x0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_OPM_ESTABLISHED")]
+        Established = 0x1,
+        [NativeName("Name", "MF_MEDIA_ENGINE_OPM_FAILED_VM")]
+        FailedVM = 0x2,
+        [NativeName("Name", "MF_MEDIA_ENGINE_OPM_FAILED_BDA")]
+        FailedBda = 0x3,
+        [NativeName("Name", "MF_MEDIA_ENGINE_OPM_FAILED_UNSIGNED_DRIVER")]
+        FailedUnsignedDriver = 0x4,
+        [NativeName("Name", "MF_MEDIA_ENGINE_OPM_FAILED")]
+        Failed = 0x5,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEnginePreload.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEnginePreload.gen.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MEDIA_ENGINE_PRELOAD")]
+    public enum MediaEnginePreload : int
+    {
+        [NativeName("Name", "MF_MEDIA_ENGINE_PRELOAD_MISSING")]
+        Missing = 0x0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_PRELOAD_EMPTY")]
+        Empty = 0x1,
+        [NativeName("Name", "MF_MEDIA_ENGINE_PRELOAD_NONE")]
+        None = 0x2,
+        [NativeName("Name", "MF_MEDIA_ENGINE_PRELOAD_METADATA")]
+        Metadata = 0x3,
+        [NativeName("Name", "MF_MEDIA_ENGINE_PRELOAD_AUTOMATIC")]
+        Automatic = 0x4,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineProtectionFlags.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineProtectionFlags.gen.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Flags]
+    [NativeName("Name", "MF_MEDIA_ENGINE_PROTECTION_FLAGS")]
+    public enum MediaEngineProtectionFlags : int
+    {
+        [NativeName("Name", "")]
+        None = 0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_ENABLE_PROTECTED_CONTENT")]
+        EnableProtectedContent = 0x1,
+        [NativeName("Name", "MF_MEDIA_ENGINE_USE_PMP_FOR_ALL_CONTENT")]
+        UsePmpForAllContent = 0x2,
+        [NativeName("Name", "MF_MEDIA_ENGINE_USE_UNPROTECTED_PMP")]
+        UseUnprotectedPmp = 0x4,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineReady.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineReady.gen.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MEDIA_ENGINE_READY")]
+    public enum MediaEngineReady : int
+    {
+        [NativeName("Name", "MF_MEDIA_ENGINE_READY_HAVE_NOTHING")]
+        Nothing = 0x0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_READY_HAVE_METADATA")]
+        Metadata = 0x1,
+        [NativeName("Name", "MF_MEDIA_ENGINE_READY_HAVE_CURRENT_DATA")]
+        CurrentData = 0x2,
+        [NativeName("Name", "MF_MEDIA_ENGINE_READY_HAVE_FUTURE_DATA")]
+        FutureData = 0x3,
+        [NativeName("Name", "MF_MEDIA_ENGINE_READY_HAVE_ENOUGH_DATA")]
+        EnoughData = 0x4,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineS3DPackingMode.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineS3DPackingMode.gen.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MEDIA_ENGINE_S3D_PACKING_MODE")]
+    public enum MediaEngineS3DPackingMode : int
+    {
+        [NativeName("Name", "MF_MEDIA_ENGINE_S3D_PACKING_MODE_NONE")]
+        None = 0x0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_S3D_PACKING_MODE_SIDE_BY_SIDE")]
+        SideBySide = 0x1,
+        [NativeName("Name", "MF_MEDIA_ENGINE_S3D_PACKING_MODE_TOP_BOTTOM")]
+        TopBottom = 0x2,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineSeekMode.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineSeekMode.gen.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MEDIA_ENGINE_SEEK_MODE")]
+    public enum MediaEngineSeekMode : int
+    {
+        [NativeName("Name", "MF_MEDIA_ENGINE_SEEK_MODE_NORMAL")]
+        Normal = 0x0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_SEEK_MODE_APPROXIMATE")]
+        Approximate = 0x1,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineStatistic.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineStatistic.gen.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MEDIA_ENGINE_STATISTIC")]
+    public enum MediaEngineStatistic : int
+    {
+        [NativeName("Name", "MF_MEDIA_ENGINE_STATISTIC_FRAMES_RENDERED")]
+        FramesRendered = 0x0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_STATISTIC_FRAMES_DROPPED")]
+        FramesDropped = 0x1,
+        [NativeName("Name", "MF_MEDIA_ENGINE_STATISTIC_BYTES_DOWNLOADED")]
+        BytesDownloaded = 0x2,
+        [NativeName("Name", "MF_MEDIA_ENGINE_STATISTIC_BUFFER_PROGRESS")]
+        BufferProgress = 0x3,
+        [NativeName("Name", "MF_MEDIA_ENGINE_STATISTIC_FRAMES_PER_SECOND")]
+        FramesPerSecond = 0x4,
+        [NativeName("Name", "MF_MEDIA_ENGINE_STATISTIC_PLAYBACK_JITTER")]
+        PlaybackJitter = 0x5,
+        [NativeName("Name", "MF_MEDIA_ENGINE_STATISTIC_FRAMES_CORRUPTED")]
+        FramesCorrupted = 0x6,
+        [NativeName("Name", "MF_MEDIA_ENGINE_STATISTIC_TOTAL_FRAME_DELAY")]
+        TotalFrameDelay = 0x7,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineStreamtypeFailed.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineStreamtypeFailed.gen.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MEDIA_ENGINE_STREAMTYPE_FAILED")]
+    public enum MediaEngineStreamtypeFailed : int
+    {
+        [NativeName("Name", "MF_MEDIA_ENGINE_STREAMTYPE_FAILED_UNKNOWN")]
+        Unknown = 0x0,
+        [NativeName("Name", "MF_MEDIA_ENGINE_STREAMTYPE_FAILED_AUDIO")]
+        Audio = 0x1,
+        [NativeName("Name", "MF_MEDIA_ENGINE_STREAMTYPE_FAILED_VIDEO")]
+        Video = 0x2,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineStreamtypeFailed.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediaEngineStreamtypeFailed.gen.cs
@@ -10,7 +10,7 @@ using Silk.NET.Core.Attributes;
 namespace Silk.NET.MediaFoundation
 {
     [NativeName("Name", "MF_MEDIA_ENGINE_STREAMTYPE_FAILED")]
-    public enum MediaEngineStreamtypeFailed : int
+    public enum MediaEngineStreamTypeFailed : int
     {
         [NativeName("Name", "MF_MEDIA_ENGINE_STREAMTYPE_FAILED_UNKNOWN")]
         Unknown = 0x0,

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediakeysRequirement.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediakeysRequirement.gen.cs
@@ -10,7 +10,7 @@ using Silk.NET.Core.Attributes;
 namespace Silk.NET.MediaFoundation
 {
     [NativeName("Name", "MF_MEDIAKEYS_REQUIREMENT")]
-    public enum MediakeysRequirement : int
+    public enum MediaKeysRequirement : int
     {
         [NativeName("Name", "MF_MEDIAKEYS_REQUIREMENT_REQUIRED")]
         Required = 0x1,

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediakeysRequirement.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MediakeysRequirement.gen.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MEDIAKEYS_REQUIREMENT")]
+    public enum MediakeysRequirement : int
+    {
+        [NativeName("Name", "MF_MEDIAKEYS_REQUIREMENT_REQUIRED")]
+        Required = 0x1,
+        [NativeName("Name", "MF_MEDIAKEYS_REQUIREMENT_OPTIONAL")]
+        Optional = 0x2,
+        [NativeName("Name", "MF_MEDIAKEYS_REQUIREMENT_NOT_ALLOWED")]
+        NotAllowed = 0x3,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MseAppendMode.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MseAppendMode.gen.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MSE_APPEND_MODE")]
+    public enum MseAppendMode : int
+    {
+        [NativeName("Name", "MF_MSE_APPEND_MODE_SEGMENTS")]
+        Segments = 0x0,
+        [NativeName("Name", "MF_MSE_APPEND_MODE_SEQUENCE")]
+        Sequence = 0x1,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MseError.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MseError.gen.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MSE_ERROR")]
+    public enum MseError : int
+    {
+        [NativeName("Name", "MF_MSE_ERROR_NOERROR")]
+        Noerror = 0x0,
+        [NativeName("Name", "MF_MSE_ERROR_NETWORK")]
+        Network = 0x1,
+        [NativeName("Name", "MF_MSE_ERROR_DECODE")]
+        Decode = 0x2,
+        [NativeName("Name", "MF_MSE_ERROR_UNKNOWN_ERROR")]
+        UnknownError = 0x3,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MseOpusSupportType.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MseOpusSupportType.gen.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MSE_OPUS_SUPPORT_TYPE")]
+    public enum MseOpusSupportType : int
+    {
+        [NativeName("Name", "MF_MSE_OPUS_SUPPORT_ON")]
+        On = 0x0,
+        [NativeName("Name", "MF_MSE_OPUS_SUPPORT_OFF")]
+        Off = 0x1,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MseReady.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MseReady.gen.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MSE_READY")]
+    public enum MseReady : int
+    {
+        [NativeName("Name", "MF_MSE_READY_CLOSED")]
+        Closed = 0x1,
+        [NativeName("Name", "MF_MSE_READY_OPEN")]
+        Open = 0x2,
+        [NativeName("Name", "MF_MSE_READY_ENDED")]
+        Ended = 0x3,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/MseVP9SupportType.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/MseVP9SupportType.gen.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_MSE_VP9_SUPPORT_TYPE")]
+    public enum MseVP9SupportType : int
+    {
+        [NativeName("Name", "MF_MSE_VP9_SUPPORT_DEFAULT")]
+        Default = 0x0,
+        [NativeName("Name", "MF_MSE_VP9_SUPPORT_ON")]
+        On = 0x1,
+        [NativeName("Name", "MF_MSE_VP9_SUPPORT_OFF")]
+        Off = 0x2,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextAlignment.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextAlignment.gen.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_ALIGNMENT")]
+    public enum TimedTextAlignment : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_ALIGNMENT_START")]
+        Start = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_ALIGNMENT_END")]
+        End = 0x1,
+        [NativeName("Name", "MF_TIMED_TEXT_ALIGNMENT_CENTER")]
+        Center = 0x2,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextBoutenPosition.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextBoutenPosition.gen.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_BOUTEN_POSITION")]
+    public enum TimedTextBoutenPosition : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_BOUTEN_POSITION_BEFORE")]
+        Before = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_BOUTEN_POSITION_AFTER")]
+        After = 0x1,
+        [NativeName("Name", "MF_TIMED_TEXT_BOUTEN_POSITION_OUTSIDE")]
+        Outside = 0x2,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextBoutenType.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextBoutenType.gen.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_BOUTEN_TYPE")]
+    public enum TimedTextBoutenType : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_BOUTEN_TYPE_NONE")]
+        None = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_BOUTEN_TYPE_AUTO")]
+        Auto = 0x1,
+        [NativeName("Name", "MF_TIMED_TEXT_BOUTEN_TYPE_FILLEDCIRCLE")]
+        Filledcircle = 0x2,
+        [NativeName("Name", "MF_TIMED_TEXT_BOUTEN_TYPE_OPENCIRCLE")]
+        Opencircle = 0x3,
+        [NativeName("Name", "MF_TIMED_TEXT_BOUTEN_TYPE_FILLEDDOT")]
+        Filleddot = 0x4,
+        [NativeName("Name", "MF_TIMED_TEXT_BOUTEN_TYPE_OPENDOT")]
+        Opendot = 0x5,
+        [NativeName("Name", "MF_TIMED_TEXT_BOUTEN_TYPE_FILLEDSESAME")]
+        Filledsesame = 0x6,
+        [NativeName("Name", "MF_TIMED_TEXT_BOUTEN_TYPE_OPENSESAME")]
+        Opensesame = 0x7,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextCueEvent.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextCueEvent.gen.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_CUE_EVENT")]
+    public enum TimedTextCueEvent : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_CUE_EVENT_ACTIVE")]
+        Active = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_CUE_EVENT_INACTIVE")]
+        Inactive = 0x1,
+        [NativeName("Name", "MF_TIMED_TEXT_CUE_EVENT_CLEAR")]
+        Clear = 0x2,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextDecoration.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextDecoration.gen.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Flags]
+    [NativeName("Name", "MF_TIMED_TEXT_DECORATION")]
+    public enum TimedTextDecoration : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_DECORATION_NONE")]
+        None = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_DECORATION_UNDERLINE")]
+        Underline = 0x1,
+        [NativeName("Name", "MF_TIMED_TEXT_DECORATION_LINE_THROUGH")]
+        LineThrough = 0x2,
+        [NativeName("Name", "MF_TIMED_TEXT_DECORATION_OVERLINE")]
+        Overline = 0x4,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextDisplayAlignment.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextDisplayAlignment.gen.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_DISPLAY_ALIGNMENT")]
+    public enum TimedTextDisplayAlignment : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_DISPLAY_ALIGNMENT_BEFORE")]
+        Before = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_DISPLAY_ALIGNMENT_AFTER")]
+        After = 0x1,
+        [NativeName("Name", "MF_TIMED_TEXT_DISPLAY_ALIGNMENT_CENTER")]
+        Center = 0x2,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextErrorCode.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextErrorCode.gen.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_ERROR_CODE")]
+    public enum TimedTextErrorCode : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_ERROR_CODE_NOERROR")]
+        Noerror = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_ERROR_CODE_FATAL")]
+        Fatal = 0x1,
+        [NativeName("Name", "MF_TIMED_TEXT_ERROR_CODE_DATA_FORMAT")]
+        DataFormat = 0x2,
+        [NativeName("Name", "MF_TIMED_TEXT_ERROR_CODE_NETWORK")]
+        Network = 0x3,
+        [NativeName("Name", "MF_TIMED_TEXT_ERROR_CODE_INTERNAL")]
+        Internal = 0x4,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextFontStyle.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextFontStyle.gen.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_FONT_STYLE")]
+    public enum TimedTextFontStyle : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_FONT_STYLE_NORMAL")]
+        Normal = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_FONT_STYLE_OBLIQUE")]
+        Oblique = 0x1,
+        [NativeName("Name", "MF_TIMED_TEXT_FONT_STYLE_ITALIC")]
+        Italic = 0x2,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextRubyAlign.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextRubyAlign.gen.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_RUBY_ALIGN")]
+    public enum TimedTextRubyAlign : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_RUBY_ALIGN_CENTER")]
+        Center = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_RUBY_ALIGN_START")]
+        Start = 0x1,
+        [NativeName("Name", "MF_TIMED_TEXT_RUBY_ALIGN_END")]
+        End = 0x2,
+        [NativeName("Name", "MF_TIMED_TEXT_RUBY_ALIGN_SPACEAROUND")]
+        Spacearound = 0x3,
+        [NativeName("Name", "MF_TIMED_TEXT_RUBY_ALIGN_SPACEBETWEEN")]
+        Spacebetween = 0x4,
+        [NativeName("Name", "MF_TIMED_TEXT_RUBY_ALIGN_WITHBASE")]
+        Withbase = 0x5,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextRubyPosition.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextRubyPosition.gen.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_RUBY_POSITION")]
+    public enum TimedTextRubyPosition : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_RUBY_POSITION_BEFORE")]
+        Before = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_RUBY_POSITION_AFTER")]
+        After = 0x1,
+        [NativeName("Name", "MF_TIMED_TEXT_RUBY_POSITION_OUTSIDE")]
+        Outside = 0x2,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextRubyReserve.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextRubyReserve.gen.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_RUBY_RESERVE")]
+    public enum TimedTextRubyReserve : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_RUBY_RESERVE_NONE")]
+        None = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_RUBY_RESERVE_BEFORE")]
+        Before = 0x1,
+        [NativeName("Name", "MF_TIMED_TEXT_RUBY_RESERVE_AFTER")]
+        After = 0x2,
+        [NativeName("Name", "MF_TIMED_TEXT_RUBY_RESERVE_BOTH")]
+        Both = 0x3,
+        [NativeName("Name", "MF_TIMED_TEXT_RUBY_RESERVE_OUTSIDE")]
+        Outside = 0x4,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextScrollMode.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextScrollMode.gen.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_SCROLL_MODE")]
+    public enum TimedTextScrollMode : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_SCROLL_MODE_POP_ON")]
+        PopOn = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_SCROLL_MODE_ROLL_UP")]
+        RollUp = 0x1,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextTrackKind.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextTrackKind.gen.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_TRACK_KIND")]
+    public enum TimedTextTrackKind : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_TRACK_KIND_UNKNOWN")]
+        Unknown = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_TRACK_KIND_SUBTITLES")]
+        Subtitles = 0x1,
+        [NativeName("Name", "MF_TIMED_TEXT_TRACK_KIND_CAPTIONS")]
+        Captions = 0x2,
+        [NativeName("Name", "MF_TIMED_TEXT_TRACK_KIND_METADATA")]
+        Metadata = 0x3,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextTrackReadyState.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextTrackReadyState.gen.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_TRACK_READY_STATE")]
+    public enum TimedTextTrackReadyState : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_TRACK_READY_STATE_NONE")]
+        None = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_TRACK_READY_STATE_LOADING")]
+        Loading = 0x1,
+        [NativeName("Name", "MF_TIMED_TEXT_TRACK_READY_STATE_LOADED")]
+        Loaded = 0x2,
+        [NativeName("Name", "MF_TIMED_TEXT_TRACK_READY_STATE_ERROR")]
+        Error = 0x3,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextUnitType.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextUnitType.gen.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_UNIT_TYPE")]
+    public enum TimedTextUnitType : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_UNIT_TYPE_PIXELS")]
+        Pixels = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_UNIT_TYPE_PERCENTAGE")]
+        Percentage = 0x1,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextWritingMode.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Enums/TimedTextWritingMode.gen.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using Silk.NET.Core.Attributes;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MF_TIMED_TEXT_WRITING_MODE")]
+    public enum TimedTextWritingMode : int
+    {
+        [NativeName("Name", "MF_TIMED_TEXT_WRITING_MODE_LRTB")]
+        Lrtb = 0x0,
+        [NativeName("Name", "MF_TIMED_TEXT_WRITING_MODE_RLTB")]
+        Rltb = 0x1,
+        [NativeName("Name", "MF_TIMED_TEXT_WRITING_MODE_TBRL")]
+        Tbrl = 0x2,
+        [NativeName("Name", "MF_TIMED_TEXT_WRITING_MODE_TBLR")]
+        Tblr = 0x3,
+        [NativeName("Name", "MF_TIMED_TEXT_WRITING_MODE_LR")]
+        LR = 0x4,
+        [NativeName("Name", "MF_TIMED_TEXT_WRITING_MODE_RL")]
+        RL = 0x5,
+        [NativeName("Name", "MF_TIMED_TEXT_WRITING_MODE_TB")]
+        TB = 0x6,
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/MediaFoundation.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/MediaFoundation.gen.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    public unsafe partial class MediaFoundation
+    {
+        [NativeName("Type", "unsigned long long")]
+        [NativeName("Name", "MF_INVALID_PRESENTATION_TIME")]
+        public const ulong InvalidPresentationTime = unchecked((ulong) 0x8000000000000000);
+
+    }
+}
+

--- a/src/Microsoft/Silk.NET.MediaFoundation/MediaFoundationLibraryNameContainer.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/MediaFoundationLibraryNameContainer.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Silk.NET.Core.Loader;
+
+namespace Silk.NET.MediaFoundation
+{
+    /// <summary>
+    /// Contains the library name of MediaFoundation.
+    /// </summary>
+    internal class MediaFoundationLibraryNameContainer : SearchPathContainer
+    {
+        /// <inheritdoc />
+        public override string[] Linux => new[] { "libMediaFoundation.so" };
+
+        /// <inheritdoc />
+        public override string[] MacOS => new[] { "libMediaFoundation.dylib" };
+
+        /// <inheritdoc />
+        public override string[] Android => new[] { "libMediaFoundation.so" };
+
+        /// <inheritdoc />
+        public override string[] IOS => new[] { "__Internal" };
+
+        /// <inheritdoc />
+        public override string[] Windows64 => new[] { "MediaFoundation.dll" };
+
+        /// <inheritdoc />
+        public override string[] Windows86 => new[] { "MediaFoundation.dll" };
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Silk.NET.MediaFoundation.csproj
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Silk.NET.MediaFoundation.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>10</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+  </ItemGroup>
+
+  <Import Project="..\..\..\build\props\bindings.props" />
+</Project>

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/AudioSourceProviderVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/AudioSourceProviderVtblExtensions.gen.cs
@@ -1,0 +1,193 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class AudioSourceProviderVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IAudioSourceProvider> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IAudioSourceProvider> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IAudioSourceProvider> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IAudioSourceProvider> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IAudioSourceProvider> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IAudioSourceProvider> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int ProvideInput(this ComPtr<IAudioSourceProvider> thisVtbl, uint dwSampleCount, uint* pdwChannelCount, float* pInterleavedAudioData)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, uint, uint*, float*, int>)@this->LpVtbl[3])(@this, dwSampleCount, pdwChannelCount, pInterleavedAudioData);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int ProvideInput(this ComPtr<IAudioSourceProvider> thisVtbl, uint dwSampleCount, uint* pdwChannelCount, ref float pInterleavedAudioData)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (float* pInterleavedAudioDataPtr = &pInterleavedAudioData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, uint, uint*, float*, int>)@this->LpVtbl[3])(@this, dwSampleCount, pdwChannelCount, pInterleavedAudioDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int ProvideInput(this ComPtr<IAudioSourceProvider> thisVtbl, uint dwSampleCount, ref uint pdwChannelCount, float* pInterleavedAudioData)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* pdwChannelCountPtr = &pdwChannelCount)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, uint, uint*, float*, int>)@this->LpVtbl[3])(@this, dwSampleCount, pdwChannelCountPtr, pInterleavedAudioData);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int ProvideInput(this ComPtr<IAudioSourceProvider> thisVtbl, uint dwSampleCount, ref uint pdwChannelCount, ref float pInterleavedAudioData)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* pdwChannelCountPtr = &pdwChannelCount)
+        {
+            fixed (float* pInterleavedAudioDataPtr = &pInterleavedAudioData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, uint, uint*, float*, int>)@this->LpVtbl[3])(@this, dwSampleCount, pdwChannelCountPtr, pInterleavedAudioDataPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IAudioSourceProvider> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IAudioSourceProvider> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IAudioSourceProvider> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int ProvideInput(this ComPtr<IAudioSourceProvider> thisVtbl, uint dwSampleCount, uint* pdwChannelCount, Span<float> pInterleavedAudioData)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->ProvideInput(dwSampleCount, pdwChannelCount, ref pInterleavedAudioData.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int ProvideInput(this ComPtr<IAudioSourceProvider> thisVtbl, uint dwSampleCount, Span<uint> pdwChannelCount, float* pInterleavedAudioData)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->ProvideInput(dwSampleCount, ref pdwChannelCount.GetPinnableReference(), pInterleavedAudioData);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int ProvideInput(this ComPtr<IAudioSourceProvider> thisVtbl, uint dwSampleCount, Span<uint> pdwChannelCount, Span<float> pInterleavedAudioData)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->ProvideInput(dwSampleCount, ref pdwChannelCount.GetPinnableReference(), ref pInterleavedAudioData.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IAudioSourceProvider> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IAudioSourceProvider.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IAudioSourceProvider.gen.cs
@@ -1,0 +1,180 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("ebbaf249-afc2-4582-91c6-b60df2e84954")]
+    [NativeName("Name", "IAudioSourceProvider")]
+    public unsafe partial struct IAudioSourceProvider : IComVtbl<IAudioSourceProvider>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("ebbaf249-afc2-4582-91c6-b60df2e84954");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IAudioSourceProvider val)
+            => Unsafe.As<IAudioSourceProvider, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IAudioSourceProvider
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IAudioSourceProvider*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IAudioSourceProvider*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IAudioSourceProvider*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IAudioSourceProvider*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IAudioSourceProvider*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IAudioSourceProvider*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int ProvideInput(uint dwSampleCount, uint* pdwChannelCount, float* pInterleavedAudioData)
+        {
+            var @this = (IAudioSourceProvider*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, uint, uint*, float*, int>)@this->LpVtbl[3])(@this, dwSampleCount, pdwChannelCount, pInterleavedAudioData);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int ProvideInput(uint dwSampleCount, uint* pdwChannelCount, ref float pInterleavedAudioData)
+        {
+            var @this = (IAudioSourceProvider*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (float* pInterleavedAudioDataPtr = &pInterleavedAudioData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, uint, uint*, float*, int>)@this->LpVtbl[3])(@this, dwSampleCount, pdwChannelCount, pInterleavedAudioDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int ProvideInput(uint dwSampleCount, ref uint pdwChannelCount, float* pInterleavedAudioData)
+        {
+            var @this = (IAudioSourceProvider*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* pdwChannelCountPtr = &pdwChannelCount)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, uint, uint*, float*, int>)@this->LpVtbl[3])(@this, dwSampleCount, pdwChannelCountPtr, pInterleavedAudioData);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int ProvideInput(uint dwSampleCount, ref uint pdwChannelCount, ref float pInterleavedAudioData)
+        {
+            var @this = (IAudioSourceProvider*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* pdwChannelCountPtr = &pdwChannelCount)
+            {
+                fixed (float* pInterleavedAudioDataPtr = &pInterleavedAudioData)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IAudioSourceProvider*, uint, uint*, float*, int>)@this->LpVtbl[3])(@this, dwSampleCount, pdwChannelCountPtr, pInterleavedAudioDataPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IAudioSourceProvider*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IAudioSourceProvider*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFBufferListNotify.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFBufferListNotify.gen.cs
@@ -1,0 +1,146 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("24cd47f7-81d8-4785-adb2-af697a963cd2")]
+    [NativeName("Name", "IMFBufferListNotify")]
+    public unsafe partial struct IMFBufferListNotify : IComVtbl<IMFBufferListNotify>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("24cd47f7-81d8-4785-adb2-af697a963cd2");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFBufferListNotify val)
+            => Unsafe.As<IMFBufferListNotify, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFBufferListNotify
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFBufferListNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFBufferListNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFBufferListNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFBufferListNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFBufferListNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFBufferListNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void OnAddSourceBuffer()
+        {
+            var @this = (IMFBufferListNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, void>)@this->LpVtbl[3])(@this);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void OnRemoveSourceBuffer()
+        {
+            var @this = (IMFBufferListNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, void>)@this->LpVtbl[4])(@this);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFBufferListNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFBufferListNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFCdmSuspendNotify.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFCdmSuspendNotify.gen.cs
@@ -1,0 +1,150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("7a5645d2-43bd-47fd-87b7-dcd24cc7d692")]
+    [NativeName("Name", "IMFCdmSuspendNotify")]
+    public unsafe partial struct IMFCdmSuspendNotify : IComVtbl<IMFCdmSuspendNotify>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("7a5645d2-43bd-47fd-87b7-dcd24cc7d692");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFCdmSuspendNotify val)
+            => Unsafe.As<IMFCdmSuspendNotify, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFCdmSuspendNotify
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFCdmSuspendNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFCdmSuspendNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFCdmSuspendNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFCdmSuspendNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFCdmSuspendNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFCdmSuspendNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Begin()
+        {
+            var @this = (IMFCdmSuspendNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, int>)@this->LpVtbl[3])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int End()
+        {
+            var @this = (IMFCdmSuspendNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, int>)@this->LpVtbl[4])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFCdmSuspendNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFCdmSuspendNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFExtendedDRMTypeSupport.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFExtendedDRMTypeSupport.gen.cs
@@ -111,107 +111,107 @@ namespace Silk.NET.MediaFoundation
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int IsTypeSupportedEx(char* type, char* keySystem, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int IsTypeSupportedEx(char* type, char* keySystem, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
-            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystem, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, type, keySystem, pAnswer);
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int IsTypeSupportedEx(char* type, char* keySystem, ref MediaEngineCanplay pAnswer)
+        public readonly unsafe int IsTypeSupportedEx(char* type, char* keySystem, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystem, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, type, keySystem, pAnswerPtr);
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int IsTypeSupportedEx(char* type, ref char keySystem, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int IsTypeSupportedEx(char* type, ref char keySystem, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             fixed (char* keySystemPtr = &keySystem)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswer);
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswer);
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int IsTypeSupportedEx(char* type, ref char keySystem, ref MediaEngineCanplay pAnswer)
+        public readonly unsafe int IsTypeSupportedEx(char* type, ref char keySystem, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             fixed (char* keySystemPtr = &keySystem)
             {
-                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
                 {
-                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswerPtr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswerPtr);
                 }
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int IsTypeSupportedEx(char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int IsTypeSupportedEx(char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
-            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswer);
             SilkMarshal.Free((nint)keySystemPtr);
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int IsTypeSupportedEx(char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanplay pAnswer)
+        public readonly unsafe int IsTypeSupportedEx(char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswerPtr);
             }
             SilkMarshal.Free((nint)keySystemPtr);
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int IsTypeSupportedEx(ref char type, char* keySystem, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int IsTypeSupportedEx(ref char type, char* keySystem, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             fixed (char* typePtr = &type)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswer);
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswer);
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int IsTypeSupportedEx(ref char type, char* keySystem, ref MediaEngineCanplay pAnswer)
+        public readonly unsafe int IsTypeSupportedEx(ref char type, char* keySystem, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             fixed (char* typePtr = &type)
             {
-                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
                 {
-                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswerPtr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswerPtr);
                 }
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int IsTypeSupportedEx(ref char type, ref char keySystem, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int IsTypeSupportedEx(ref char type, ref char keySystem, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
@@ -219,14 +219,14 @@ namespace Silk.NET.MediaFoundation
             {
                 fixed (char* keySystemPtr = &keySystem)
                 {
-                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
                 }
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly int IsTypeSupportedEx(ref char type, ref char keySystem, ref MediaEngineCanplay pAnswer)
+        public readonly int IsTypeSupportedEx(ref char type, ref char keySystem, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
@@ -234,9 +234,9 @@ namespace Silk.NET.MediaFoundation
             {
                 fixed (char* keySystemPtr = &keySystem)
                 {
-                    fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                    fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
                     {
-                        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+                        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
                     }
                 }
             }
@@ -244,30 +244,30 @@ namespace Silk.NET.MediaFoundation
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int IsTypeSupportedEx(ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int IsTypeSupportedEx(ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             fixed (char* typePtr = &type)
             {
             var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
-                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
             SilkMarshal.Free((nint)keySystemPtr);
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly int IsTypeSupportedEx(ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanplay pAnswer)
+        public readonly int IsTypeSupportedEx(ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             fixed (char* typePtr = &type)
             {
             var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
-                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
                 {
-                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
                 }
             SilkMarshal.Free((nint)keySystemPtr);
             }
@@ -275,55 +275,55 @@ namespace Silk.NET.MediaFoundation
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
-            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswer);
             SilkMarshal.Free((nint)typePtr);
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, ref MediaEngineCanplay pAnswer)
+        public readonly unsafe int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswerPtr);
             }
             SilkMarshal.Free((nint)typePtr);
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
             fixed (char* keySystemPtr = &keySystem)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
             }
             SilkMarshal.Free((nint)typePtr);
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, ref MediaEngineCanplay pAnswer)
+        public readonly int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
             fixed (char* keySystemPtr = &keySystem)
             {
-                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
                 {
-                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
                 }
             }
             SilkMarshal.Free((nint)typePtr);
@@ -331,28 +331,28 @@ namespace Silk.NET.MediaFoundation
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
             var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
-            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
             SilkMarshal.Free((nint)keySystemPtr);
             SilkMarshal.Free((nint)typePtr);
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanplay pAnswer)
+        public readonly int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
             var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
             }
             SilkMarshal.Free((nint)keySystemPtr);
             SilkMarshal.Free((nint)typePtr);

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFExtendedDRMTypeSupport.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFExtendedDRMTypeSupport.gen.cs
@@ -1,0 +1,381 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("332ec562-3758-468d-a784-e38f23552128")]
+    [NativeName("Name", "IMFExtendedDRMTypeSupport")]
+    public unsafe partial struct IMFExtendedDRMTypeSupport : IComVtbl<IMFExtendedDRMTypeSupport>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("332ec562-3758-468d-a784-e38f23552128");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFExtendedDRMTypeSupport val)
+            => Unsafe.As<IMFExtendedDRMTypeSupport, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFExtendedDRMTypeSupport
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupportedEx(char* type, char* keySystem, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystem, pAnswer);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupportedEx(char* type, char* keySystem, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystem, pAnswerPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupportedEx(char* type, ref char keySystem, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswer);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupportedEx(char* type, ref char keySystem, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswerPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupportedEx(char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswer);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupportedEx(char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswerPtr);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupportedEx(ref char type, char* keySystem, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswer);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupportedEx(ref char type, char* keySystem, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswerPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupportedEx(ref char type, ref char keySystem, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int IsTypeSupportedEx(ref char type, ref char keySystem, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupportedEx(ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+            SilkMarshal.Free((nint)keySystemPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int IsTypeSupportedEx(ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+                }
+            SilkMarshal.Free((nint)keySystemPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswer);
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswerPtr);
+            }
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+            }
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+                }
+            }
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int IsTypeSupportedEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFExtendedDRMTypeSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFHDCPStatus.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFHDCPStatus.gen.cs
@@ -1,0 +1,189 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("de400f54-5bf1-40cf-8964-0bea136b1e3d")]
+    [NativeName("Name", "IMFHDCPStatus")]
+    public unsafe partial struct IMFHDCPStatus : IComVtbl<IMFHDCPStatus>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("de400f54-5bf1-40cf-8964-0bea136b1e3d");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFHDCPStatus val)
+            => Unsafe.As<IMFHDCPStatus, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFHDCPStatus
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFHDCPStatus*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFHDCPStatus*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFHDCPStatus*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFHDCPStatus*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFHDCPStatus*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFHDCPStatus*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int Query(HdcpStatus* pStatus, int* pfStatus)
+        {
+            var @this = (IMFHDCPStatus*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, HdcpStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatus, pfStatus);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int Query(HdcpStatus* pStatus, ref int pfStatus)
+        {
+            var @this = (IMFHDCPStatus*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* pfStatusPtr = &pfStatus)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, HdcpStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatus, pfStatusPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int Query(ref HdcpStatus pStatus, int* pfStatus)
+        {
+            var @this = (IMFHDCPStatus*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (HdcpStatus* pStatusPtr = &pStatus)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, HdcpStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatusPtr, pfStatus);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Query(ref HdcpStatus pStatus, ref int pfStatus)
+        {
+            var @this = (IMFHDCPStatus*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (HdcpStatus* pStatusPtr = &pStatus)
+            {
+                fixed (int* pfStatusPtr = &pfStatus)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, HdcpStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatusPtr, pfStatusPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Set(HdcpStatus status)
+        {
+            var @this = (IMFHDCPStatus*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, HdcpStatus, int>)@this->LpVtbl[4])(@this, status);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFHDCPStatus*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFHDCPStatus*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngine.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngine.gen.cs
@@ -132,11 +132,11 @@ namespace Silk.NET.MediaFoundation
         }
 
         /// <summary>To be documented.</summary>
-        public readonly int SetErrorCode(MediaEngineErr error)
+        public readonly int SetErrorCode(MediaEngineError error)
         {
             var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, MediaEngineErr, int>)@this->LpVtbl[4])(@this, error);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, MediaEngineError, int>)@this->LpVtbl[4])(@this, error);
             return ret;
         }
 
@@ -272,73 +272,73 @@ namespace Silk.NET.MediaFoundation
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int CanPlayType(char* type, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int CanPlayType(char* type, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, type, pAnswer);
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int CanPlayType(char* type, ref MediaEngineCanplay pAnswer)
+        public readonly unsafe int CanPlayType(char* type, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, type, pAnswerPtr);
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int CanPlayType(ref char type, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int CanPlayType(ref char type, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             fixed (char* typePtr = &type)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly int CanPlayType(ref char type, ref MediaEngineCanplay pAnswer)
+        public readonly int CanPlayType(ref char type, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             fixed (char* typePtr = &type)
             {
-                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
                 {
-                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
                 }
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int CanPlayType([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int CanPlayType([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
             SilkMarshal.Free((nint)typePtr);
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly int CanPlayType([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref MediaEngineCanplay pAnswer)
+        public readonly int CanPlayType([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
             }
             SilkMarshal.Free((nint)typePtr);
             return ret;

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngine.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngine.gen.cs
@@ -1,0 +1,1106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("98a1b0bb-03eb-4935-ae7c-93c1fa0e1c93")]
+    [NativeName("Name", "IMFMediaEngine")]
+    public unsafe partial struct IMFMediaEngine : IComVtbl<IMFMediaEngine>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("98a1b0bb-03eb-4935-ae7c-93c1fa0e1c93");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngine val)
+            => Unsafe.As<IMFMediaEngine, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngine
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetError(IMFMediaError** ppError)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaError**, int>)@this->LpVtbl[3])(@this, ppError);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetError(ref IMFMediaError* ppError)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaError** ppErrorPtr = &ppError)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaError**, int>)@this->LpVtbl[3])(@this, ppErrorPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetErrorCode(MediaEngineErr error)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, MediaEngineErr, int>)@this->LpVtbl[4])(@this, error);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int SetSourceElements(IMFMediaEngineSrcElements* pSrcElements)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaEngineSrcElements*, int>)@this->LpVtbl[5])(@this, pSrcElements);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetSourceElements(ref IMFMediaEngineSrcElements pSrcElements)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaEngineSrcElements* pSrcElementsPtr = &pSrcElements)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaEngineSrcElements*, int>)@this->LpVtbl[5])(@this, pSrcElementsPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int SetSource(char* pUrl)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, int>)@this->LpVtbl[6])(@this, pUrl);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetSource(ref char pUrl)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pUrlPtr = &pUrl)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, int>)@this->LpVtbl[6])(@this, pUrlPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetSource([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pUrl)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pUrlPtr = (byte*) SilkMarshal.StringToPtr(pUrl, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, byte*, int>)@this->LpVtbl[6])(@this, pUrlPtr);
+            SilkMarshal.Free((nint)pUrlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCurrentSource(char** ppUrl)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char**, int>)@this->LpVtbl[7])(@this, ppUrl);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCurrentSource(ref char* ppUrl)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** ppUrlPtr = &ppUrl)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char**, int>)@this->LpVtbl[7])(@this, ppUrlPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ushort GetNetworkState()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ushort ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, ushort>)@this->LpVtbl[8])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly MediaEnginePreload GetPreload()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            MediaEnginePreload ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, MediaEnginePreload>)@this->LpVtbl[9])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetPreload(MediaEnginePreload Preload)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, MediaEnginePreload, int>)@this->LpVtbl[10])(@this, Preload);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetBuffered(IMFMediaTimeRange** ppBuffered)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaTimeRange**, int>)@this->LpVtbl[11])(@this, ppBuffered);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetBuffered(ref IMFMediaTimeRange* ppBuffered)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaTimeRange** ppBufferedPtr = &ppBuffered)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaTimeRange**, int>)@this->LpVtbl[11])(@this, ppBufferedPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Load()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, int>)@this->LpVtbl[12])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CanPlayType(char* type, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswer);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CanPlayType(char* type, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswerPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CanPlayType(ref char type, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CanPlayType(ref char type, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CanPlayType([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CanPlayType([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+            }
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ushort GetReadyState()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ushort ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, ushort>)@this->LpVtbl[14])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 IsSeeking()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[15])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetCurrentTime()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double>)@this->LpVtbl[16])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetCurrentTime(double seekTime)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double, int>)@this->LpVtbl[17])(@this, seekTime);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetStartTime()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double>)@this->LpVtbl[18])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetDuration()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double>)@this->LpVtbl[19])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 IsPaused()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[20])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetDefaultPlaybackRate()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double>)@this->LpVtbl[21])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetDefaultPlaybackRate(double Rate)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double, int>)@this->LpVtbl[22])(@this, Rate);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetPlaybackRate()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double>)@this->LpVtbl[23])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetPlaybackRate(double Rate)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double, int>)@this->LpVtbl[24])(@this, Rate);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPlayed(IMFMediaTimeRange** ppPlayed)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaTimeRange**, int>)@this->LpVtbl[25])(@this, ppPlayed);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPlayed(ref IMFMediaTimeRange* ppPlayed)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaTimeRange** ppPlayedPtr = &ppPlayed)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaTimeRange**, int>)@this->LpVtbl[25])(@this, ppPlayedPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSeekable(IMFMediaTimeRange** ppSeekable)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaTimeRange**, int>)@this->LpVtbl[26])(@this, ppSeekable);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSeekable(ref IMFMediaTimeRange* ppSeekable)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaTimeRange** ppSeekablePtr = &ppSeekable)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaTimeRange**, int>)@this->LpVtbl[26])(@this, ppSeekablePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 IsEnded()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[27])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 GetAutoPlay()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[28])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetAutoPlay(Silk.NET.Core.Bool32 AutoPlay)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[29])(@this, AutoPlay);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 GetLoop()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[30])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetLoop(Silk.NET.Core.Bool32 Loop)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[31])(@this, Loop);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Play()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, int>)@this->LpVtbl[32])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Pause()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, int>)@this->LpVtbl[33])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 GetMuted()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[34])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetMuted(Silk.NET.Core.Bool32 Muted)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[35])(@this, Muted);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetVolume()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double>)@this->LpVtbl[36])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetVolume(double Volume)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double, int>)@this->LpVtbl[37])(@this, Volume);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 HasVideo()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[38])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 HasAudio()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[39])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetNativeVideoSize(uint* cx, uint* cy)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cx, cy);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetNativeVideoSize(uint* cx, ref uint cy)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* cyPtr = &cy)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cx, cyPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetNativeVideoSize(ref uint cx, uint* cy)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* cxPtr = &cx)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cxPtr, cy);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetNativeVideoSize(ref uint cx, ref uint cy)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* cxPtr = &cx)
+            {
+                fixed (uint* cyPtr = &cy)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cxPtr, cyPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetVideoAspectRatio(uint* cx, uint* cy)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cx, cy);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetVideoAspectRatio(uint* cx, ref uint cy)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* cyPtr = &cy)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cx, cyPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetVideoAspectRatio(ref uint cx, uint* cy)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* cxPtr = &cx)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cxPtr, cy);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetVideoAspectRatio(ref uint cx, ref uint cy)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* cxPtr = &cx)
+            {
+                fixed (uint* cyPtr = &cy)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cxPtr, cyPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Shutdown()
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, int>)@this->LpVtbl[42])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDst, pBorderClr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDst, pBorderClrPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDstPtr, pBorderClr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDstPtr, pBorderClrPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDst, pBorderClr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDst, pBorderClrPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClrPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDst, pBorderClr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDst, pBorderClrPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClrPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClrPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                    {
+                        fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClrPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int OnVideoStreamTick(long* pPts)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, long*, int>)@this->LpVtbl[44])(@this, pPts);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int OnVideoStreamTick(ref long pPts)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (long* pPtsPtr = &pPts)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, long*, int>)@this->LpVtbl[44])(@this, pPtsPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetError<TI0>(ref ComPtr<TI0> ppError) where TI0 : unmanaged, IComVtbl<IMFMediaError>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetError((IMFMediaError**) ppError.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetSourceElements<TI0>(ComPtr<TI0> pSrcElements) where TI0 : unmanaged, IComVtbl<IMFMediaEngineSrcElements>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->SetSourceElements((IMFMediaEngineSrcElements*) pSrcElements.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetCurrentSource(string[] ppUrlSa)
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var ppUrl = (char**) SilkMarshal.StringArrayToPtr(ppUrlSa);
+            var ret = @this->GetCurrentSource(ppUrl);
+            SilkMarshal.CopyPtrToStringArray((nint) ppUrl, ppUrlSa);
+            SilkMarshal.Free((nint) ppUrl);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetBuffered<TI0>(ref ComPtr<TI0> ppBuffered) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetBuffered((IMFMediaTimeRange**) ppBuffered.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetPlayed<TI0>(ref ComPtr<TI0> ppPlayed) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetPlayed((IMFMediaTimeRange**) ppPlayed.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetSeekable<TI0>(ref ComPtr<TI0> ppSeekable) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetSeekable((IMFMediaTimeRange**) ppSeekable.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, in pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, in pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, in pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, in pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngine*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineAudioEndpointId.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineAudioEndpointId.gen.cs
@@ -1,0 +1,197 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("7a3bac98-0e76-49fb-8c20-8a86fd98eaf2")]
+    [NativeName("Name", "IMFMediaEngineAudioEndpointId")]
+    public unsafe partial struct IMFMediaEngineAudioEndpointId : IComVtbl<IMFMediaEngineAudioEndpointId>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("7a3bac98-0e76-49fb-8c20-8a86fd98eaf2");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineAudioEndpointId val)
+            => Unsafe.As<IMFMediaEngineAudioEndpointId, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineAudioEndpointId
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineAudioEndpointId*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineAudioEndpointId*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineAudioEndpointId*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineAudioEndpointId*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineAudioEndpointId*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineAudioEndpointId*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int SetAudioEndpointId([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* pszEndpointId)
+        {
+            var @this = (IMFMediaEngineAudioEndpointId*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, char*, int>)@this->LpVtbl[3])(@this, pszEndpointId);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetAudioEndpointId([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char pszEndpointId)
+        {
+            var @this = (IMFMediaEngineAudioEndpointId*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pszEndpointIdPtr = &pszEndpointId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, char*, int>)@this->LpVtbl[3])(@this, pszEndpointIdPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetAudioEndpointId([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string pszEndpointId)
+        {
+            var @this = (IMFMediaEngineAudioEndpointId*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pszEndpointIdPtr = (byte*) SilkMarshal.StringToPtr(pszEndpointId, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, byte*, int>)@this->LpVtbl[3])(@this, pszEndpointIdPtr);
+            SilkMarshal.Free((nint)pszEndpointIdPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetAudioEndpointId(char** ppszEndpointId)
+        {
+            var @this = (IMFMediaEngineAudioEndpointId*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, char**, int>)@this->LpVtbl[4])(@this, ppszEndpointId);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetAudioEndpointId(ref char* ppszEndpointId)
+        {
+            var @this = (IMFMediaEngineAudioEndpointId*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** ppszEndpointIdPtr = &ppszEndpointId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, char**, int>)@this->LpVtbl[4])(@this, ppszEndpointIdPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineAudioEndpointId*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetAudioEndpointId(string[] ppszEndpointIdSa)
+        {
+            var @this = (IMFMediaEngineAudioEndpointId*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var ppszEndpointId = (char**) SilkMarshal.StringArrayToPtr(ppszEndpointIdSa);
+            var ret = @this->GetAudioEndpointId(ppszEndpointId);
+            SilkMarshal.CopyPtrToStringArray((nint) ppszEndpointId, ppszEndpointIdSa);
+            SilkMarshal.Free((nint) ppszEndpointId);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineAudioEndpointId*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineClassFactory.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineClassFactory.gen.cs
@@ -1,0 +1,254 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("4d645ace-26aa-4688-9be1-df3516990b93")]
+    [NativeName("Name", "IMFMediaEngineClassFactory")]
+    public unsafe partial struct IMFMediaEngineClassFactory : IComVtbl<IMFMediaEngineClassFactory>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("4d645ace-26aa-4688-9be1-df3516990b93");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineClassFactory val)
+            => Unsafe.As<IMFMediaEngineClassFactory, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineClassFactory
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateInstance(uint dwFlags, IMFAttributes* pAttr, IMFMediaEngine** ppPlayer)
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttr, ppPlayer);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateInstance(uint dwFlags, IMFAttributes* pAttr, ref IMFMediaEngine* ppPlayer)
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaEngine** ppPlayerPtr = &ppPlayer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttr, ppPlayerPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateInstance(uint dwFlags, ref IMFAttributes pAttr, IMFMediaEngine** ppPlayer)
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFAttributes* pAttrPtr = &pAttr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttrPtr, ppPlayer);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateInstance(uint dwFlags, ref IMFAttributes pAttr, ref IMFMediaEngine* ppPlayer)
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFAttributes* pAttrPtr = &pAttr)
+            {
+                fixed (IMFMediaEngine** ppPlayerPtr = &ppPlayer)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttrPtr, ppPlayerPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateTimeRange(IMFMediaTimeRange** ppTimeRange)
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, IMFMediaTimeRange**, int>)@this->LpVtbl[4])(@this, ppTimeRange);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateTimeRange(ref IMFMediaTimeRange* ppTimeRange)
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaTimeRange** ppTimeRangePtr = &ppTimeRange)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, IMFMediaTimeRange**, int>)@this->LpVtbl[4])(@this, ppTimeRangePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateError(IMFMediaError** ppError)
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, IMFMediaError**, int>)@this->LpVtbl[5])(@this, ppError);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateError(ref IMFMediaError* ppError)
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaError** ppErrorPtr = &ppError)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, IMFMediaError**, int>)@this->LpVtbl[5])(@this, ppErrorPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateInstance<TI0>(uint dwFlags, IMFAttributes* pAttr, ref ComPtr<TI0> ppPlayer) where TI0 : unmanaged, IComVtbl<IMFMediaEngine>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateInstance(dwFlags, pAttr, (IMFMediaEngine**) ppPlayer.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateInstance<TI0>(uint dwFlags, ref IMFAttributes pAttr, ref ComPtr<TI0> ppPlayer) where TI0 : unmanaged, IComVtbl<IMFMediaEngine>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateInstance(dwFlags, ref pAttr, (IMFMediaEngine**) ppPlayer.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateTimeRange<TI0>(ref ComPtr<TI0> ppTimeRange) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateTimeRange((IMFMediaTimeRange**) ppTimeRange.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateError<TI0>(ref ComPtr<TI0> ppError) where TI0 : unmanaged, IComVtbl<IMFMediaError>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateError((IMFMediaError**) ppError.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineClassFactory2.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineClassFactory2.gen.cs
@@ -1,0 +1,1185 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("09083cef-867f-4bf6-8776-dee3a7b42fca")]
+    [NativeName("Name", "IMFMediaEngineClassFactory2")]
+    public unsafe partial struct IMFMediaEngineClassFactory2 : IComVtbl<IMFMediaEngineClassFactory2>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("09083cef-867f-4bf6-8776-dee3a7b42fca");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineClassFactory2 val)
+            => Unsafe.As<IMFMediaEngineClassFactory2, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineClassFactory2
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePath, inprivateCdmStorePath, ppKeys);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePath, inprivateCdmStorePath, ppKeysPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeys);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeysPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeys);
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeysPtr);
+            }
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeys);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeysPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+                fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+                fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+                {
+                    fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                }
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeys);
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeysPtr);
+            }
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+            }
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                }
+            }
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+            }
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePath, ppKeys);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePath, ppKeysPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeys);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+                {
+                    fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeysPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeys);
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeysPtr);
+                }
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeys);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+                {
+                    fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeysPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+                {
+                    fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+                {
+                    fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+                    {
+                        fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+                {
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+                {
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+                    fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                    }
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeys);
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeysPtr);
+                }
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+                fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+                }
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+                fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+                {
+                    fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2(ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                }
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePath, ppKeys);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePath, ppKeysPtr);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeys);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeysPtr);
+                }
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeys);
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeysPtr);
+            }
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeys);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeysPtr);
+                }
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+                fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+                }
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+                fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+                {
+                    fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                }
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeys);
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeysPtr);
+            }
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+            }
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                }
+            }
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+            }
+            SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>(char* keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>(char* keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>(char* keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>(char* keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>(char* keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>(char* keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>(char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>(char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>(char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>(ref char keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(ref keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>(ref char keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(ref keySystem, defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>(ref char keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(ref keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>(ref char keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(ref keySystem, ref defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateMediaKeys2<TI0>(ref char keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(ref keySystem, ref defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateMediaKeys2<TI0>(ref char keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(ref keySystem, ref defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>(ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(ref keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateMediaKeys2<TI0>(ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(ref keySystem, defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateMediaKeys2<TI0>(ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(ref keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateMediaKeys2<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateMediaKeys2<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys2<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateMediaKeys2<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateMediaKeys2<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineClassFactory3.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineClassFactory3.gen.cs
@@ -1,0 +1,344 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("3787614f-65f7-4003-b673-ead8293a0e60")]
+    [NativeName("Name", "IMFMediaEngineClassFactory3")]
+    public unsafe partial struct IMFMediaEngineClassFactory3 : IComVtbl<IMFMediaEngineClassFactory3>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("3787614f-65f7-4003-b673-ead8293a0e60");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineClassFactory3 val)
+            => Unsafe.As<IMFMediaEngineClassFactory3, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineClassFactory3
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess(char* keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, IMFMediaKeySystemAccess** ppKeyAccess)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystem, ppSupportedConfigurationsArray, uSize, ppKeyAccess);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess(char* keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, ref IMFMediaKeySystemAccess* ppKeyAccess)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeySystemAccess** ppKeyAccessPtr = &ppKeyAccess)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystem, ppSupportedConfigurationsArray, uSize, ppKeyAccessPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess(char* keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, IMFMediaKeySystemAccess** ppKeyAccess)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IPropertyStore** ppSupportedConfigurationsArrayPtr = &ppSupportedConfigurationsArray)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystem, ppSupportedConfigurationsArrayPtr, uSize, ppKeyAccess);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess(char* keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, ref IMFMediaKeySystemAccess* ppKeyAccess)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IPropertyStore** ppSupportedConfigurationsArrayPtr = &ppSupportedConfigurationsArray)
+            {
+                fixed (IMFMediaKeySystemAccess** ppKeyAccessPtr = &ppKeyAccess)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystem, ppSupportedConfigurationsArrayPtr, uSize, ppKeyAccessPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess(ref char keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, IMFMediaKeySystemAccess** ppKeyAccess)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArray, uSize, ppKeyAccess);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess(ref char keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, ref IMFMediaKeySystemAccess* ppKeyAccess)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (IMFMediaKeySystemAccess** ppKeyAccessPtr = &ppKeyAccess)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArray, uSize, ppKeyAccessPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess(ref char keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, IMFMediaKeySystemAccess** ppKeyAccess)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (IPropertyStore** ppSupportedConfigurationsArrayPtr = &ppSupportedConfigurationsArray)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArrayPtr, uSize, ppKeyAccess);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess(ref char keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, ref IMFMediaKeySystemAccess* ppKeyAccess)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (IPropertyStore** ppSupportedConfigurationsArrayPtr = &ppSupportedConfigurationsArray)
+                {
+                    fixed (IMFMediaKeySystemAccess** ppKeyAccessPtr = &ppKeyAccess)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArrayPtr, uSize, ppKeyAccessPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, IMFMediaKeySystemAccess** ppKeyAccess)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, byte*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArray, uSize, ppKeyAccess);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, ref IMFMediaKeySystemAccess* ppKeyAccess)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeySystemAccess** ppKeyAccessPtr = &ppKeyAccess)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, byte*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArray, uSize, ppKeyAccessPtr);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, IMFMediaKeySystemAccess** ppKeyAccess)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (IPropertyStore** ppSupportedConfigurationsArrayPtr = &ppSupportedConfigurationsArray)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, byte*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArrayPtr, uSize, ppKeyAccess);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, ref IMFMediaKeySystemAccess* ppKeyAccess)
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (IPropertyStore** ppSupportedConfigurationsArrayPtr = &ppSupportedConfigurationsArray)
+            {
+                fixed (IMFMediaKeySystemAccess** ppKeyAccessPtr = &ppKeyAccess)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, byte*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArrayPtr, uSize, ppKeyAccessPtr);
+                }
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess<TI0>(char* keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, ref ComPtr<TI0> ppKeyAccess) where TI0 : unmanaged, IComVtbl<IMFMediaKeySystemAccess>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeySystemAccess(keySystem, ppSupportedConfigurationsArray, uSize, (IMFMediaKeySystemAccess**) ppKeyAccess.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess<TI0>(char* keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, ref ComPtr<TI0> ppKeyAccess) where TI0 : unmanaged, IComVtbl<IMFMediaKeySystemAccess>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeySystemAccess(keySystem, ref ppSupportedConfigurationsArray, uSize, (IMFMediaKeySystemAccess**) ppKeyAccess.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess<TI0>(ref char keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, ref ComPtr<TI0> ppKeyAccess) where TI0 : unmanaged, IComVtbl<IMFMediaKeySystemAccess>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeySystemAccess(ref keySystem, ppSupportedConfigurationsArray, uSize, (IMFMediaKeySystemAccess**) ppKeyAccess.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess<TI0>(ref char keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, ref ComPtr<TI0> ppKeyAccess) where TI0 : unmanaged, IComVtbl<IMFMediaKeySystemAccess>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeySystemAccess(ref keySystem, ref ppSupportedConfigurationsArray, uSize, (IMFMediaKeySystemAccess**) ppKeyAccess.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, ref ComPtr<TI0> ppKeyAccess) where TI0 : unmanaged, IComVtbl<IMFMediaKeySystemAccess>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeySystemAccess(keySystem, ppSupportedConfigurationsArray, uSize, (IMFMediaKeySystemAccess**) ppKeyAccess.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeySystemAccess<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, ref ComPtr<TI0> ppKeyAccess) where TI0 : unmanaged, IComVtbl<IMFMediaKeySystemAccess>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeySystemAccess(keySystem, ref ppSupportedConfigurationsArray, uSize, (IMFMediaKeySystemAccess**) ppKeyAccess.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory3*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineClassFactory4.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineClassFactory4.gen.cs
@@ -1,0 +1,350 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("fbe256c1-43cf-4a9b-8cb8-ce8632a34186")]
+    [NativeName("Name", "IMFMediaEngineClassFactory4")]
+    public unsafe partial struct IMFMediaEngineClassFactory4 : IComVtbl<IMFMediaEngineClassFactory4>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("fbe256c1-43cf-4a9b-8cb8-ce8632a34186");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineClassFactory4 val)
+            => Unsafe.As<IMFMediaEngineClassFactory4, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineClassFactory4
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateContentDecryptionModuleFactory([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* keySystem, Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystem, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateContentDecryptionModuleFactory([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* keySystem, Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystem, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateContentDecryptionModuleFactory([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* keySystem, ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystem, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateContentDecryptionModuleFactory([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* keySystem, ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystem, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateContentDecryptionModuleFactory([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char keySystem, Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riid, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateContentDecryptionModuleFactory([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char keySystem, Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riid, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateContentDecryptionModuleFactory([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char keySystem, ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (Guid* riidPtr = &riid)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riidPtr, ppvObject);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateContentDecryptionModuleFactory([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char keySystem, ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (Guid* riidPtr = &riid)
+                {
+                    fixed (void** ppvObjectPtr = &ppvObject)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riidPtr, ppvObjectPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateContentDecryptionModuleFactory([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string keySystem, Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, byte*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riid, ppvObject);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateContentDecryptionModuleFactory([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string keySystem, Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.LPWStr);
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, byte*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riid, ppvObjectPtr);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateContentDecryptionModuleFactory([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string keySystem, ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.LPWStr);
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, byte*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riidPtr, ppvObject);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateContentDecryptionModuleFactory([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string keySystem, ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.LPWStr);
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, byte*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riidPtr, ppvObjectPtr);
+                }
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateContentDecryptionModuleFactory<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* keySystem, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->CreateContentDecryptionModuleFactory(keySystem, SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateContentDecryptionModuleFactory<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char keySystem, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->CreateContentDecryptionModuleFactory(in keySystem, SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateContentDecryptionModuleFactory<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string keySystem, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->CreateContentDecryptionModuleFactory(keySystem, SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe ComPtr<TI0> CreateContentDecryptionModuleFactory<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* keySystem) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->CreateContentDecryptionModuleFactory(keySystem, out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> CreateContentDecryptionModuleFactory<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char keySystem) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->CreateContentDecryptionModuleFactory(in keySystem, out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> CreateContentDecryptionModuleFactory<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string keySystem) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactory4*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->CreateContentDecryptionModuleFactory(keySystem, out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineClassFactoryEx.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineClassFactoryEx.gen.cs
@@ -1,0 +1,891 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("c56156c6-ea5b-48a5-9df8-fbe035d0929e")]
+    [NativeName("Name", "IMFMediaEngineClassFactoryEx")]
+    public unsafe partial struct IMFMediaEngineClassFactoryEx : IComVtbl<IMFMediaEngineClassFactoryEx>, IComVtbl<IMFMediaEngineClassFactory>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("c56156c6-ea5b-48a5-9df8-fbe035d0929e");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator IMFMediaEngineClassFactory(IMFMediaEngineClassFactoryEx val)
+            => Unsafe.As<IMFMediaEngineClassFactoryEx, IMFMediaEngineClassFactory>(ref val);
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineClassFactoryEx val)
+            => Unsafe.As<IMFMediaEngineClassFactoryEx, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineClassFactoryEx
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateInstance(uint dwFlags, IMFAttributes* pAttr, IMFMediaEngine** ppPlayer)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttr, ppPlayer);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateInstance(uint dwFlags, IMFAttributes* pAttr, ref IMFMediaEngine* ppPlayer)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaEngine** ppPlayerPtr = &ppPlayer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttr, ppPlayerPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateInstance(uint dwFlags, ref IMFAttributes pAttr, IMFMediaEngine** ppPlayer)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFAttributes* pAttrPtr = &pAttr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttrPtr, ppPlayer);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateInstance(uint dwFlags, ref IMFAttributes pAttr, ref IMFMediaEngine* ppPlayer)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFAttributes* pAttrPtr = &pAttr)
+            {
+                fixed (IMFMediaEngine** ppPlayerPtr = &ppPlayer)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttrPtr, ppPlayerPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateTimeRange(IMFMediaTimeRange** ppTimeRange)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[4])(@this, ppTimeRange);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateTimeRange(ref IMFMediaTimeRange* ppTimeRange)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaTimeRange** ppTimeRangePtr = &ppTimeRange)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[4])(@this, ppTimeRangePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateError(IMFMediaError** ppError)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, IMFMediaError**, int>)@this->LpVtbl[5])(@this, ppError);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateError(ref IMFMediaError* ppError)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaError** ppErrorPtr = &ppError)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, IMFMediaError**, int>)@this->LpVtbl[5])(@this, ppErrorPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaSourceExtension(uint dwFlags, IMFAttributes* pAttr, IMFMediaSourceExtension** ppMSE)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaSourceExtension**, int>)@this->LpVtbl[6])(@this, dwFlags, pAttr, ppMSE);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaSourceExtension(uint dwFlags, IMFAttributes* pAttr, ref IMFMediaSourceExtension* ppMSE)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaSourceExtension** ppMSEPtr = &ppMSE)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaSourceExtension**, int>)@this->LpVtbl[6])(@this, dwFlags, pAttr, ppMSEPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaSourceExtension(uint dwFlags, ref IMFAttributes pAttr, IMFMediaSourceExtension** ppMSE)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFAttributes* pAttrPtr = &pAttr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaSourceExtension**, int>)@this->LpVtbl[6])(@this, dwFlags, pAttrPtr, ppMSE);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaSourceExtension(uint dwFlags, ref IMFAttributes pAttr, ref IMFMediaSourceExtension* ppMSE)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFAttributes* pAttrPtr = &pAttr)
+            {
+                fixed (IMFMediaSourceExtension** ppMSEPtr = &ppMSE)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaSourceExtension**, int>)@this->LpVtbl[6])(@this, dwFlags, pAttrPtr, ppMSEPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(char* keySystem, char* cdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystem, cdmStorePath, ppKeys);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(char* keySystem, char* cdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystem, cdmStorePath, ppKeysPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(char* keySystem, ref char cdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* cdmStorePathPtr = &cdmStorePath)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystem, cdmStorePathPtr, ppKeys);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(char* keySystem, ref char cdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* cdmStorePathPtr = &cdmStorePath)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystem, cdmStorePathPtr, ppKeysPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var cdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(cdmStorePath, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystem, cdmStorePathPtr, ppKeys);
+            SilkMarshal.Free((nint)cdmStorePathPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var cdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(cdmStorePath, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystem, cdmStorePathPtr, ppKeysPtr);
+            }
+            SilkMarshal.Free((nint)cdmStorePathPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(ref char keySystem, char* cdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePath, ppKeys);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(ref char keySystem, char* cdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePath, ppKeysPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(ref char keySystem, ref char cdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (char* cdmStorePathPtr = &cdmStorePath)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeys);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(ref char keySystem, ref char cdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (char* cdmStorePathPtr = &cdmStorePath)
+                {
+                    fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeysPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+            var cdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(cdmStorePath, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeys);
+            SilkMarshal.Free((nint)cdmStorePathPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+            var cdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(cdmStorePath, NativeStringEncoding.BStr);
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeysPtr);
+                }
+            SilkMarshal.Free((nint)cdmStorePathPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* cdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePath, ppKeys);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* cdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePath, ppKeysPtr);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char cdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (char* cdmStorePathPtr = &cdmStorePath)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeys);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char cdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (char* cdmStorePathPtr = &cdmStorePath)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeysPtr);
+                }
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, IMFMediaKeys** ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            var cdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(cdmStorePath, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeys);
+            SilkMarshal.Free((nint)cdmStorePathPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, ref IMFMediaKeys* ppKeys)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            var cdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(cdmStorePath, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeysPtr);
+            }
+            SilkMarshal.Free((nint)cdmStorePathPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupported(char* type, char* keySystem, int* isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, type, keySystem, isSupported);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupported(char* type, char* keySystem, ref int isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* isSupportedPtr = &isSupported)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, type, keySystem, isSupportedPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupported(char* type, ref char keySystem, int* isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, type, keySystemPtr, isSupported);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupported(char* type, ref char keySystem, ref int isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (int* isSupportedPtr = &isSupported)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, type, keySystemPtr, isSupportedPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupported(char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, int* isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, int*, int>)@this->LpVtbl[8])(@this, type, keySystemPtr, isSupported);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupported(char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref int isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (int* isSupportedPtr = &isSupported)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, int*, int>)@this->LpVtbl[8])(@this, type, keySystemPtr, isSupportedPtr);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupported(ref char type, char* keySystem, int* isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystem, isSupported);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupported(ref char type, char* keySystem, ref int isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                fixed (int* isSupportedPtr = &isSupported)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystem, isSupportedPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupported(ref char type, ref char keySystem, int* isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupported);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int IsTypeSupported(ref char type, ref char keySystem, ref int isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    fixed (int* isSupportedPtr = &isSupported)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupportedPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupported(ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, int* isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupported);
+            SilkMarshal.Free((nint)keySystemPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int IsTypeSupported(ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref int isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                fixed (int* isSupportedPtr = &isSupported)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupportedPtr);
+                }
+            SilkMarshal.Free((nint)keySystemPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupported([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, int* isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystem, isSupported);
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupported([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, ref int isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            fixed (int* isSupportedPtr = &isSupported)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystem, isSupportedPtr);
+            }
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupported([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, int* isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupported);
+            }
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int IsTypeSupported([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, ref int isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (int* isSupportedPtr = &isSupported)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupportedPtr);
+                }
+            }
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTypeSupported([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, int* isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, byte*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupported);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int IsTypeSupported([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref int isSupported)
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (int* isSupportedPtr = &isSupported)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, byte*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupportedPtr);
+            }
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateInstance<TI0>(uint dwFlags, IMFAttributes* pAttr, ref ComPtr<TI0> ppPlayer) where TI0 : unmanaged, IComVtbl<IMFMediaEngine>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateInstance(dwFlags, pAttr, (IMFMediaEngine**) ppPlayer.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateInstance<TI0>(uint dwFlags, ref IMFAttributes pAttr, ref ComPtr<TI0> ppPlayer) where TI0 : unmanaged, IComVtbl<IMFMediaEngine>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateInstance(dwFlags, ref pAttr, (IMFMediaEngine**) ppPlayer.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateTimeRange<TI0>(ref ComPtr<TI0> ppTimeRange) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateTimeRange((IMFMediaTimeRange**) ppTimeRange.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateError<TI0>(ref ComPtr<TI0> ppError) where TI0 : unmanaged, IComVtbl<IMFMediaError>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateError((IMFMediaError**) ppError.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaSourceExtension<TI0>(uint dwFlags, IMFAttributes* pAttr, ref ComPtr<TI0> ppMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaSourceExtension(dwFlags, pAttr, (IMFMediaSourceExtension**) ppMSE.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateMediaSourceExtension<TI0>(uint dwFlags, ref IMFAttributes pAttr, ref ComPtr<TI0> ppMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaSourceExtension(dwFlags, ref pAttr, (IMFMediaSourceExtension**) ppMSE.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys<TI0>(char* keySystem, char* cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys(keySystem, cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys<TI0>(char* keySystem, ref char cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys(keySystem, ref cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys<TI0>(char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys(keySystem, cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys<TI0>(ref char keySystem, char* cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys(ref keySystem, cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateMediaKeys<TI0>(ref char keySystem, ref char cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys(ref keySystem, ref cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateMediaKeys<TI0>(ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys(ref keySystem, cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys(keySystem, cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateMediaKeys<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys(keySystem, ref cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateMediaKeys<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys(keySystem, cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineClassFactoryEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineEME.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineEME.gen.cs
@@ -1,0 +1,190 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("50dc93e4-ba4f-4275-ae66-83e836e57469")]
+    [NativeName("Name", "IMFMediaEngineEME")]
+    public unsafe partial struct IMFMediaEngineEME : IComVtbl<IMFMediaEngineEME>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("50dc93e4-ba4f-4275-ae66-83e836e57469");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineEME val)
+            => Unsafe.As<IMFMediaEngineEME, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineEME
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineEME*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineEME*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineEME*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineEME*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineEME*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineEME*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeys(IMFMediaKeys** keys)
+        {
+            var @this = (IMFMediaEngineEME*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keys);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeys(ref IMFMediaKeys* keys)
+        {
+            var @this = (IMFMediaEngineEME*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeys** keysPtr = &keys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keysPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int SetMediaKeys(IMFMediaKeys* keys)
+        {
+            var @this = (IMFMediaEngineEME*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, IMFMediaKeys*, int>)@this->LpVtbl[4])(@this, keys);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetMediaKeys(ref IMFMediaKeys keys)
+        {
+            var @this = (IMFMediaEngineEME*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeys* keysPtr = &keys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, IMFMediaKeys*, int>)@this->LpVtbl[4])(@this, keysPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEME*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetKeys<TI0>(ref ComPtr<TI0> keys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEME*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetKeys((IMFMediaKeys**) keys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetMediaKeys<TI0>(ComPtr<TI0> keys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEME*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->SetMediaKeys((IMFMediaKeys*) keys.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEME*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineEMENotify.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineEMENotify.gen.cs
@@ -1,0 +1,232 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("9e184d15-cdb7-4f86-b49e-566689f4a601")]
+    [NativeName("Name", "IMFMediaEngineEMENotify")]
+    public unsafe partial struct IMFMediaEngineEMENotify : IComVtbl<IMFMediaEngineEMENotify>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("9e184d15-cdb7-4f86-b49e-566689f4a601");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineEMENotify val)
+            => Unsafe.As<IMFMediaEngineEMENotify, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineEMENotify
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void Encrypted([Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbInitData, uint cb, char* bstrInitDataType)
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, char*, void>)@this->LpVtbl[3])(@this, pbInitData, cb, bstrInitDataType);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void Encrypted([Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbInitData, uint cb, ref char bstrInitDataType)
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (char* bstrInitDataTypePtr = &bstrInitDataType)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, char*, void>)@this->LpVtbl[3])(@this, pbInitData, cb, bstrInitDataTypePtr);
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void Encrypted([Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbInitData, uint cb, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrInitDataType)
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var bstrInitDataTypePtr = (byte*) SilkMarshal.StringToPtr(bstrInitDataType, NativeStringEncoding.BStr);
+            ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, byte*, void>)@this->LpVtbl[3])(@this, pbInitData, cb, bstrInitDataTypePtr);
+            SilkMarshal.Free((nint)bstrInitDataTypePtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void Encrypted([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbInitData, uint cb, char* bstrInitDataType)
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (byte* pbInitDataPtr = &pbInitData)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, char*, void>)@this->LpVtbl[3])(@this, pbInitDataPtr, cb, bstrInitDataType);
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void Encrypted([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbInitData, uint cb, ref char bstrInitDataType)
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (byte* pbInitDataPtr = &pbInitData)
+            {
+                fixed (char* bstrInitDataTypePtr = &bstrInitDataType)
+                {
+                    ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, char*, void>)@this->LpVtbl[3])(@this, pbInitDataPtr, cb, bstrInitDataTypePtr);
+                }
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void Encrypted([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbInitData, uint cb, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrInitDataType)
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (byte* pbInitDataPtr = &pbInitData)
+            {
+            var bstrInitDataTypePtr = (byte*) SilkMarshal.StringToPtr(bstrInitDataType, NativeStringEncoding.BStr);
+                ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, byte*, void>)@this->LpVtbl[3])(@this, pbInitDataPtr, cb, bstrInitDataTypePtr);
+            SilkMarshal.Free((nint)bstrInitDataTypePtr);
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void Encrypted([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbInitData, uint cb, char* bstrInitDataType)
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var pbInitDataPtr = (byte*) SilkMarshal.StringToPtr(pbInitData, NativeStringEncoding.UTF8);
+            ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, char*, void>)@this->LpVtbl[3])(@this, pbInitDataPtr, cb, bstrInitDataType);
+            SilkMarshal.Free((nint)pbInitDataPtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void Encrypted([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbInitData, uint cb, ref char bstrInitDataType)
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var pbInitDataPtr = (byte*) SilkMarshal.StringToPtr(pbInitData, NativeStringEncoding.UTF8);
+            fixed (char* bstrInitDataTypePtr = &bstrInitDataType)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, char*, void>)@this->LpVtbl[3])(@this, pbInitDataPtr, cb, bstrInitDataTypePtr);
+            }
+            SilkMarshal.Free((nint)pbInitDataPtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void Encrypted([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbInitData, uint cb, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrInitDataType)
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var pbInitDataPtr = (byte*) SilkMarshal.StringToPtr(pbInitData, NativeStringEncoding.UTF8);
+            var bstrInitDataTypePtr = (byte*) SilkMarshal.StringToPtr(bstrInitDataType, NativeStringEncoding.BStr);
+            ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, byte*, void>)@this->LpVtbl[3])(@this, pbInitDataPtr, cb, bstrInitDataTypePtr);
+            SilkMarshal.Free((nint)bstrInitDataTypePtr);
+            SilkMarshal.Free((nint)pbInitDataPtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void WaitingForKey()
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, void>)@this->LpVtbl[4])(@this);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEMENotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineEx.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineEx.gen.cs
@@ -1,0 +1,1867 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("83015ead-b1e6-40d0-a98a-37145ffe1ad1")]
+    [NativeName("Name", "IMFMediaEngineEx")]
+    public unsafe partial struct IMFMediaEngineEx : IComVtbl<IMFMediaEngineEx>, IComVtbl<IMFMediaEngine>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("83015ead-b1e6-40d0-a98a-37145ffe1ad1");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator IMFMediaEngine(IMFMediaEngineEx val)
+            => Unsafe.As<IMFMediaEngineEx, IMFMediaEngine>(ref val);
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineEx val)
+            => Unsafe.As<IMFMediaEngineEx, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineEx
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetError(IMFMediaError** ppError)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaError**, int>)@this->LpVtbl[3])(@this, ppError);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetError(ref IMFMediaError* ppError)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaError** ppErrorPtr = &ppError)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaError**, int>)@this->LpVtbl[3])(@this, ppErrorPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetErrorCode(MediaEngineErr error)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineErr, int>)@this->LpVtbl[4])(@this, error);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int SetSourceElements(IMFMediaEngineSrcElements* pSrcElements)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaEngineSrcElements*, int>)@this->LpVtbl[5])(@this, pSrcElements);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetSourceElements(ref IMFMediaEngineSrcElements pSrcElements)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaEngineSrcElements* pSrcElementsPtr = &pSrcElements)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaEngineSrcElements*, int>)@this->LpVtbl[5])(@this, pSrcElementsPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int SetSource(char* pUrl)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, int>)@this->LpVtbl[6])(@this, pUrl);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetSource(ref char pUrl)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pUrlPtr = &pUrl)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, int>)@this->LpVtbl[6])(@this, pUrlPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetSource([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pUrl)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pUrlPtr = (byte*) SilkMarshal.StringToPtr(pUrl, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, byte*, int>)@this->LpVtbl[6])(@this, pUrlPtr);
+            SilkMarshal.Free((nint)pUrlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCurrentSource(char** ppUrl)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char**, int>)@this->LpVtbl[7])(@this, ppUrl);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCurrentSource(ref char* ppUrl)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** ppUrlPtr = &ppUrl)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char**, int>)@this->LpVtbl[7])(@this, ppUrlPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ushort GetNetworkState()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ushort ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, ushort>)@this->LpVtbl[8])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly MediaEnginePreload GetPreload()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            MediaEnginePreload ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEnginePreload>)@this->LpVtbl[9])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetPreload(MediaEnginePreload Preload)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEnginePreload, int>)@this->LpVtbl[10])(@this, Preload);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetBuffered(IMFMediaTimeRange** ppBuffered)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[11])(@this, ppBuffered);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetBuffered(ref IMFMediaTimeRange* ppBuffered)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaTimeRange** ppBufferedPtr = &ppBuffered)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[11])(@this, ppBufferedPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Load()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int>)@this->LpVtbl[12])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CanPlayType(char* type, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswer);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CanPlayType(char* type, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswerPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CanPlayType(ref char type, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CanPlayType(ref char type, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CanPlayType([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CanPlayType([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+            }
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ushort GetReadyState()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ushort ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, ushort>)@this->LpVtbl[14])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 IsSeeking()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[15])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetCurrentTime()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double>)@this->LpVtbl[16])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetCurrentTime(double seekTime)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, int>)@this->LpVtbl[17])(@this, seekTime);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetStartTime()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double>)@this->LpVtbl[18])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetDuration()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double>)@this->LpVtbl[19])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 IsPaused()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[20])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetDefaultPlaybackRate()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double>)@this->LpVtbl[21])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetDefaultPlaybackRate(double Rate)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, int>)@this->LpVtbl[22])(@this, Rate);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetPlaybackRate()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double>)@this->LpVtbl[23])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetPlaybackRate(double Rate)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, int>)@this->LpVtbl[24])(@this, Rate);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPlayed(IMFMediaTimeRange** ppPlayed)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[25])(@this, ppPlayed);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPlayed(ref IMFMediaTimeRange* ppPlayed)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaTimeRange** ppPlayedPtr = &ppPlayed)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[25])(@this, ppPlayedPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSeekable(IMFMediaTimeRange** ppSeekable)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[26])(@this, ppSeekable);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSeekable(ref IMFMediaTimeRange* ppSeekable)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaTimeRange** ppSeekablePtr = &ppSeekable)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[26])(@this, ppSeekablePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 IsEnded()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[27])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 GetAutoPlay()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[28])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetAutoPlay(Silk.NET.Core.Bool32 AutoPlay)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[29])(@this, AutoPlay);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 GetLoop()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[30])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetLoop(Silk.NET.Core.Bool32 Loop)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[31])(@this, Loop);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Play()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int>)@this->LpVtbl[32])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Pause()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int>)@this->LpVtbl[33])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 GetMuted()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[34])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetMuted(Silk.NET.Core.Bool32 Muted)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[35])(@this, Muted);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetVolume()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double>)@this->LpVtbl[36])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetVolume(double Volume)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, int>)@this->LpVtbl[37])(@this, Volume);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 HasVideo()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[38])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 HasAudio()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[39])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetNativeVideoSize(uint* cx, uint* cy)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cx, cy);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetNativeVideoSize(uint* cx, ref uint cy)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* cyPtr = &cy)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cx, cyPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetNativeVideoSize(ref uint cx, uint* cy)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* cxPtr = &cx)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cxPtr, cy);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetNativeVideoSize(ref uint cx, ref uint cy)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* cxPtr = &cx)
+            {
+                fixed (uint* cyPtr = &cy)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cxPtr, cyPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetVideoAspectRatio(uint* cx, uint* cy)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cx, cy);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetVideoAspectRatio(uint* cx, ref uint cy)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* cyPtr = &cy)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cx, cyPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetVideoAspectRatio(ref uint cx, uint* cy)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* cxPtr = &cx)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cxPtr, cy);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetVideoAspectRatio(ref uint cx, ref uint cy)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* cxPtr = &cx)
+            {
+                fixed (uint* cyPtr = &cy)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cxPtr, cyPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Shutdown()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int>)@this->LpVtbl[42])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDst, pBorderClr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDst, pBorderClrPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDstPtr, pBorderClr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDstPtr, pBorderClrPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDst, pBorderClr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDst, pBorderClrPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClrPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDst, pBorderClr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDst, pBorderClrPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClrPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClrPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                    {
+                        fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClrPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int OnVideoStreamTick(long* pPts)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, long*, int>)@this->LpVtbl[44])(@this, pPts);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int OnVideoStreamTick(ref long pPts)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (long* pPtsPtr = &pPts)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, long*, int>)@this->LpVtbl[44])(@this, pPtsPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int SetSourceFromByteStream(IMFByteStream* pByteStream, char* pURL)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFByteStream*, char*, int>)@this->LpVtbl[45])(@this, pByteStream, pURL);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int SetSourceFromByteStream(IMFByteStream* pByteStream, ref char pURL)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFByteStream*, char*, int>)@this->LpVtbl[45])(@this, pByteStream, pURLPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int SetSourceFromByteStream(IMFByteStream* pByteStream, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFByteStream*, byte*, int>)@this->LpVtbl[45])(@this, pByteStream, pURLPtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int SetSourceFromByteStream(ref IMFByteStream pByteStream, char* pURL)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFByteStream*, char*, int>)@this->LpVtbl[45])(@this, pByteStreamPtr, pURL);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetSourceFromByteStream(ref IMFByteStream pByteStream, ref char pURL)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (char* pURLPtr = &pURL)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFByteStream*, char*, int>)@this->LpVtbl[45])(@this, pByteStreamPtr, pURLPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetSourceFromByteStream(ref IMFByteStream pByteStream, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFByteStream*, byte*, int>)@this->LpVtbl[45])(@this, pByteStreamPtr, pURLPtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetStatistics(MediaEngineStatistic StatisticID, tagPROPVARIANT* pStatistic)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineStatistic, tagPROPVARIANT*, int>)@this->LpVtbl[46])(@this, StatisticID, pStatistic);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetStatistics(MediaEngineStatistic StatisticID, ref tagPROPVARIANT pStatistic)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (tagPROPVARIANT* pStatisticPtr = &pStatistic)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineStatistic, tagPROPVARIANT*, int>)@this->LpVtbl[46])(@this, StatisticID, pStatisticPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int UpdateVideoStream([Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrc, pDst, pBorderClr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int UpdateVideoStream([Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrc, pDst, pBorderClrPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int UpdateVideoStream([Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrc, pDstPtr, pBorderClr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int UpdateVideoStream([Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrc, pDstPtr, pBorderClrPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int UpdateVideoStream([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrcPtr, pDst, pBorderClr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int UpdateVideoStream([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrcPtr, pDst, pBorderClrPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int UpdateVideoStream([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrcPtr, pDstPtr, pBorderClr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int UpdateVideoStream([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrcPtr, pDstPtr, pBorderClrPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetBalance()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double>)@this->LpVtbl[48])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetBalance(double balance)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, int>)@this->LpVtbl[49])(@this, balance);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 IsPlaybackRateSupported(double rate)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, Silk.NET.Core.Bool32>)@this->LpVtbl[50])(@this, rate);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int FrameStep(Silk.NET.Core.Bool32 Forward)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[51])(@this, Forward);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetResourceCharacteristics(uint* pCharacteristics)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[52])(@this, pCharacteristics);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetResourceCharacteristics(ref uint pCharacteristics)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* pCharacteristicsPtr = &pCharacteristics)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[52])(@this, pCharacteristicsPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPresentationAttribute(Guid* guidMFAttribute, tagPROPVARIANT* pvValue)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[53])(@this, guidMFAttribute, pvValue);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPresentationAttribute(Guid* guidMFAttribute, ref tagPROPVARIANT pvValue)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (tagPROPVARIANT* pvValuePtr = &pvValue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[53])(@this, guidMFAttribute, pvValuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPresentationAttribute(ref Guid guidMFAttribute, tagPROPVARIANT* pvValue)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* guidMFAttributePtr = &guidMFAttribute)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[53])(@this, guidMFAttributePtr, pvValue);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetPresentationAttribute(ref Guid guidMFAttribute, ref tagPROPVARIANT pvValue)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* guidMFAttributePtr = &guidMFAttribute)
+            {
+                fixed (tagPROPVARIANT* pvValuePtr = &pvValue)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[53])(@this, guidMFAttributePtr, pvValuePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetNumberOfStreams(uint* pdwStreamCount)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[54])(@this, pdwStreamCount);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetNumberOfStreams(ref uint pdwStreamCount)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* pdwStreamCountPtr = &pdwStreamCount)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[54])(@this, pdwStreamCountPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetStreamAttribute(uint dwStreamIndex, Guid* guidMFAttribute, tagPROPVARIANT* pvValue)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[55])(@this, dwStreamIndex, guidMFAttribute, pvValue);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetStreamAttribute(uint dwStreamIndex, Guid* guidMFAttribute, ref tagPROPVARIANT pvValue)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (tagPROPVARIANT* pvValuePtr = &pvValue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[55])(@this, dwStreamIndex, guidMFAttribute, pvValuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetStreamAttribute(uint dwStreamIndex, ref Guid guidMFAttribute, tagPROPVARIANT* pvValue)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* guidMFAttributePtr = &guidMFAttribute)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[55])(@this, dwStreamIndex, guidMFAttributePtr, pvValue);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetStreamAttribute(uint dwStreamIndex, ref Guid guidMFAttribute, ref tagPROPVARIANT pvValue)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* guidMFAttributePtr = &guidMFAttribute)
+            {
+                fixed (tagPROPVARIANT* pvValuePtr = &pvValue)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[55])(@this, dwStreamIndex, guidMFAttributePtr, pvValuePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetStreamSelection(uint dwStreamIndex, int* pEnabled)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, int*, int>)@this->LpVtbl[56])(@this, dwStreamIndex, pEnabled);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetStreamSelection(uint dwStreamIndex, ref int pEnabled)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* pEnabledPtr = &pEnabled)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, int*, int>)@this->LpVtbl[56])(@this, dwStreamIndex, pEnabledPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetStreamSelection(uint dwStreamIndex, Silk.NET.Core.Bool32 Enabled)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, Silk.NET.Core.Bool32, int>)@this->LpVtbl[57])(@this, dwStreamIndex, Enabled);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int ApplyStreamSelections()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int>)@this->LpVtbl[58])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsProtected(int* pProtected)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int*, int>)@this->LpVtbl[59])(@this, pProtected);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int IsProtected(ref int pProtected)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* pProtectedPtr = &pProtected)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int*, int>)@this->LpVtbl[59])(@this, pProtectedPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int InsertVideoEffect(Silk.NET.Core.Native.IUnknown* pEffect, Silk.NET.Core.Bool32 fOptional)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[60])(@this, pEffect, fOptional);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int InsertVideoEffect(ref Silk.NET.Core.Native.IUnknown pEffect, Silk.NET.Core.Bool32 fOptional)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pEffectPtr = &pEffect)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[60])(@this, pEffectPtr, fOptional);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int InsertAudioEffect(Silk.NET.Core.Native.IUnknown* pEffect, Silk.NET.Core.Bool32 fOptional)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[61])(@this, pEffect, fOptional);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int InsertAudioEffect(ref Silk.NET.Core.Native.IUnknown pEffect, Silk.NET.Core.Bool32 fOptional)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pEffectPtr = &pEffect)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[61])(@this, pEffectPtr, fOptional);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int RemoveAllEffects()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int>)@this->LpVtbl[62])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetTimelineMarkerTimer(double timeToFire)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, int>)@this->LpVtbl[63])(@this, timeToFire);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTimelineMarkerTimer(double* pTimeToFire)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double*, int>)@this->LpVtbl[64])(@this, pTimeToFire);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetTimelineMarkerTimer(ref double pTimeToFire)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pTimeToFirePtr = &pTimeToFire)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double*, int>)@this->LpVtbl[64])(@this, pTimeToFirePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CancelTimelineMarkerTimer()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int>)@this->LpVtbl[65])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 IsStereo3D()
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[66])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetStereo3DFramePackingMode(MediaEngineS3DPackingMode* packMode)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineS3DPackingMode*, int>)@this->LpVtbl[67])(@this, packMode);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetStereo3DFramePackingMode(ref MediaEngineS3DPackingMode packMode)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (MediaEngineS3DPackingMode* packModePtr = &packMode)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineS3DPackingMode*, int>)@this->LpVtbl[67])(@this, packModePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetStereo3DFramePackingMode(MediaEngineS3DPackingMode packMode)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineS3DPackingMode, int>)@this->LpVtbl[68])(@this, packMode);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetStereo3DRenderMode(_MF3DVideoOutputType* outputType)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, _MF3DVideoOutputType*, int>)@this->LpVtbl[69])(@this, outputType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetStereo3DRenderMode(ref _MF3DVideoOutputType outputType)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MF3DVideoOutputType* outputTypePtr = &outputType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, _MF3DVideoOutputType*, int>)@this->LpVtbl[69])(@this, outputTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetStereo3DRenderMode(_MF3DVideoOutputType outputType)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, _MF3DVideoOutputType, int>)@this->LpVtbl[70])(@this, outputType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int EnableWindowlessSwapchainMode(Silk.NET.Core.Bool32 fEnable)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[71])(@this, fEnable);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetVideoSwapchainHandle(void** phSwapchain)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, void**, int>)@this->LpVtbl[72])(@this, phSwapchain);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetVideoSwapchainHandle(ref void* phSwapchain)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** phSwapchainPtr = &phSwapchain)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, void**, int>)@this->LpVtbl[72])(@this, phSwapchainPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int EnableHorizontalMirrorMode(Silk.NET.Core.Bool32 fEnable)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[73])(@this, fEnable);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetAudioStreamCategory(uint* pCategory)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[74])(@this, pCategory);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetAudioStreamCategory(ref uint pCategory)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* pCategoryPtr = &pCategory)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[74])(@this, pCategoryPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetAudioStreamCategory(uint category)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, int>)@this->LpVtbl[75])(@this, category);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetAudioEndpointRole(uint* pRole)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[76])(@this, pRole);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetAudioEndpointRole(ref uint pRole)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* pRolePtr = &pRole)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[76])(@this, pRolePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetAudioEndpointRole(uint role)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, int>)@this->LpVtbl[77])(@this, role);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetRealTimeMode(int* pfEnabled)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int*, int>)@this->LpVtbl[78])(@this, pfEnabled);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetRealTimeMode(ref int pfEnabled)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* pfEnabledPtr = &pfEnabled)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int*, int>)@this->LpVtbl[78])(@this, pfEnabledPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetRealTimeMode(Silk.NET.Core.Bool32 fEnable)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[79])(@this, fEnable);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetCurrentTimeEx(double seekTime, MediaEngineSeekMode seekMode)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, MediaEngineSeekMode, int>)@this->LpVtbl[80])(@this, seekTime, seekMode);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int EnableTimeUpdateTimer(Silk.NET.Core.Bool32 fEnableTimer)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[81])(@this, fEnableTimer);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetError<TI0>(ref ComPtr<TI0> ppError) where TI0 : unmanaged, IComVtbl<IMFMediaError>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetError((IMFMediaError**) ppError.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetSourceElements<TI0>(ComPtr<TI0> pSrcElements) where TI0 : unmanaged, IComVtbl<IMFMediaEngineSrcElements>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->SetSourceElements((IMFMediaEngineSrcElements*) pSrcElements.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetCurrentSource(string[] ppUrlSa)
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var ppUrl = (char**) SilkMarshal.StringArrayToPtr(ppUrlSa);
+            var ret = @this->GetCurrentSource(ppUrl);
+            SilkMarshal.CopyPtrToStringArray((nint) ppUrl, ppUrlSa);
+            SilkMarshal.Free((nint) ppUrl);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetBuffered<TI0>(ref ComPtr<TI0> ppBuffered) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetBuffered((IMFMediaTimeRange**) ppBuffered.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetPlayed<TI0>(ref ComPtr<TI0> ppPlayed) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetPlayed((IMFMediaTimeRange**) ppPlayed.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetSeekable<TI0>(ref ComPtr<TI0> ppSeekable) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetSeekable((IMFMediaTimeRange**) ppSeekable.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, in pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, in pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, in pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, in pBorderClr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int InsertVideoEffect<TI0>(ComPtr<TI0> pEffect, Silk.NET.Core.Bool32 fOptional) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->InsertVideoEffect((Silk.NET.Core.Native.IUnknown*) pEffect.Handle, fOptional);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int InsertAudioEffect<TI0>(ComPtr<TI0> pEffect, Silk.NET.Core.Bool32 fOptional) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->InsertAudioEffect((Silk.NET.Core.Native.IUnknown*) pEffect.Handle, fOptional);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineEx.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineEx.gen.cs
@@ -135,11 +135,11 @@ namespace Silk.NET.MediaFoundation
         }
 
         /// <summary>To be documented.</summary>
-        public readonly int SetErrorCode(MediaEngineErr error)
+        public readonly int SetErrorCode(MediaEngineError error)
         {
             var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineErr, int>)@this->LpVtbl[4])(@this, error);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineError, int>)@this->LpVtbl[4])(@this, error);
             return ret;
         }
 
@@ -275,73 +275,73 @@ namespace Silk.NET.MediaFoundation
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int CanPlayType(char* type, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int CanPlayType(char* type, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, type, pAnswer);
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int CanPlayType(char* type, ref MediaEngineCanplay pAnswer)
+        public readonly unsafe int CanPlayType(char* type, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, type, pAnswerPtr);
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int CanPlayType(ref char type, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int CanPlayType(ref char type, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             fixed (char* typePtr = &type)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly int CanPlayType(ref char type, ref MediaEngineCanplay pAnswer)
+        public readonly int CanPlayType(ref char type, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             fixed (char* typePtr = &type)
             {
-                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
                 {
-                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
                 }
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int CanPlayType([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int CanPlayType([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
             SilkMarshal.Free((nint)typePtr);
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly int CanPlayType([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref MediaEngineCanplay pAnswer)
+        public readonly int CanPlayType([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFMediaEngineEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
             }
             SilkMarshal.Free((nint)typePtr);
             return ret;

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineExtension.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineExtension.gen.cs
@@ -111,73 +111,73 @@ namespace Silk.NET.MediaFoundation
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, char* MimeType, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, char* MimeType, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeType, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeType, pAnswer);
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, char* MimeType, ref MediaEngineCanplay pAnswer)
+        public readonly unsafe int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, char* MimeType, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeType, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeType, pAnswerPtr);
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, ref char MimeType, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, ref char MimeType, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             fixed (char* MimeTypePtr = &MimeType)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswer);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswer);
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, ref char MimeType, ref MediaEngineCanplay pAnswer)
+        public readonly int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, ref char MimeType, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             fixed (char* MimeTypePtr = &MimeType)
             {
-                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
                 {
-                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswerPtr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswerPtr);
                 }
             }
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly unsafe int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, MediaEngineCanplay* pAnswer)
+        public readonly unsafe int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, MediaEngineCanPlay* pAnswer)
         {
             var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             var MimeTypePtr = (byte*) SilkMarshal.StringToPtr(MimeType, NativeStringEncoding.BStr);
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswer);
             SilkMarshal.Free((nint)MimeTypePtr);
             return ret;
         }
 
         /// <summary>To be documented.</summary>
-        public readonly int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, ref MediaEngineCanplay pAnswer)
+        public readonly int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, ref MediaEngineCanPlay pAnswer)
         {
             var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
             var MimeTypePtr = (byte*) SilkMarshal.StringToPtr(MimeType, NativeStringEncoding.BStr);
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswerPtr);
             }
             SilkMarshal.Free((nint)MimeTypePtr);
             return ret;

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineExtension.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineExtension.gen.cs
@@ -1,0 +1,1386 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("2f69d622-20b5-41e9-afdf-89ced1dda04e")]
+    [NativeName("Name", "IMFMediaEngineExtension")]
+    public unsafe partial struct IMFMediaEngineExtension : IComVtbl<IMFMediaEngineExtension>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("2f69d622-20b5-41e9-afdf-89ced1dda04e");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineExtension val)
+            => Unsafe.As<IMFMediaEngineExtension, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineExtension
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, char* MimeType, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeType, pAnswer);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, char* MimeType, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeType, pAnswerPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, ref char MimeType, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* MimeTypePtr = &MimeType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswer);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, ref char MimeType, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* MimeTypePtr = &MimeType)
+            {
+                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswerPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, MediaEngineCanplay* pAnswer)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var MimeTypePtr = (byte*) SilkMarshal.StringToPtr(MimeType, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswer);
+            SilkMarshal.Free((nint)MimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CanPlayType(Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, ref MediaEngineCanplay pAnswer)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var MimeTypePtr = (byte*) SilkMarshal.StringToPtr(MimeType, NativeStringEncoding.BStr);
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswerPtr);
+            }
+            SilkMarshal.Free((nint)MimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookie, pCallback, punkState);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookie, pCallback, punkStatePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookie, pCallbackPtr, punkState);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookie, pCallbackPtr, punkStatePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookiePtr, pCallback, punkState);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookiePtr, pCallback, punkStatePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkState);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkStatePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallback, punkState);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallback, punkStatePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallbackPtr, punkState);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallbackPtr, punkStatePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallback, punkState);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallback, punkStatePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkState);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                    {
+                        fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkStatePtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallback, punkState);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallback, punkStatePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallbackPtr, punkState);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallbackPtr, punkStatePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallback, punkState);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallback, punkStatePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkState);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                    {
+                        fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkStatePtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallback, punkState);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallback, punkStatePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+                {
+                    fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallbackPtr, punkState);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+                {
+                    fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                    {
+                        fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallbackPtr, punkStatePtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallback, punkState);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                    {
+                        fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallback, punkStatePtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                    {
+                        fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkState);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject(ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrURLPtr = &bstrURL)
+            {
+                fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                    {
+                        fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                        {
+                            fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                            {
+                                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkStatePtr);
+                            }
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallback, punkState);
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallback, punkStatePtr);
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallbackPtr, punkState);
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallbackPtr, punkStatePtr);
+                }
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallback, punkState);
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallback, punkStatePtr);
+                }
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkState);
+                }
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkStatePtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallback, punkState);
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallback, punkStatePtr);
+                }
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallbackPtr, punkState);
+                }
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallbackPtr, punkStatePtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallback, punkState);
+                }
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallback, punkStatePtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkState);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                    {
+                        fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkStatePtr);
+                        }
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)bstrURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CancelObjectCreation(Silk.NET.Core.Native.IUnknown* pIUnknownCancelCookie)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[5])(@this, pIUnknownCancelCookie);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CancelObjectCreation(ref Silk.NET.Core.Native.IUnknown pIUnknownCancelCookie)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pIUnknownCancelCookiePtr = &pIUnknownCancelCookie)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[5])(@this, pIUnknownCancelCookiePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int EndCreateObject(IMFAsyncResult* pResult, Silk.NET.Core.Native.IUnknown** ppObject)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, IMFAsyncResult*, Silk.NET.Core.Native.IUnknown**, int>)@this->LpVtbl[6])(@this, pResult, ppObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int EndCreateObject(IMFAsyncResult* pResult, ref Silk.NET.Core.Native.IUnknown* ppObject)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown** ppObjectPtr = &ppObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, IMFAsyncResult*, Silk.NET.Core.Native.IUnknown**, int>)@this->LpVtbl[6])(@this, pResult, ppObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int EndCreateObject(ref IMFAsyncResult pResult, Silk.NET.Core.Native.IUnknown** ppObject)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFAsyncResult* pResultPtr = &pResult)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, IMFAsyncResult*, Silk.NET.Core.Native.IUnknown**, int>)@this->LpVtbl[6])(@this, pResultPtr, ppObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int EndCreateObject(ref IMFAsyncResult pResult, ref Silk.NET.Core.Native.IUnknown* ppObject)
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFAsyncResult* pResultPtr = &pResult)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppObjectPtr = &ppObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, IMFAsyncResult*, Silk.NET.Core.Native.IUnknown**, int>)@this->LpVtbl[6])(@this, pResultPtr, ppObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0, TI1>(char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, ref punkState);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0, TI1>(char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, ref punkState);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0, TI1>(char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, ref punkState);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0, TI1>(char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, ref punkState);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, ref pByteStream, type, ref ppIUnknownCancelCookie, pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, ref pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0, TI1>(ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(ref bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(ref bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, ref punkState);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0, TI1>(ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(ref bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(ref bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, ref punkState);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(ref bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(ref bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0, TI1>(ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(ref bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(ref bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, ref punkState);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int BeginCreateObject<TI0, TI1>(ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(ref bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int BeginCreateObject<TI0>(ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(ref bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, ref punkState);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(ref bstrURL, ref pByteStream, type, ref ppIUnknownCancelCookie, pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>(ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(ref bstrURL, ref pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, ref punkState);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, ref punkState);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, ref punkState);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int BeginCreateObject<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int BeginCreateObject<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, ref punkState);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, ref pByteStream, type, ref ppIUnknownCancelCookie, pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int BeginCreateObject<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->BeginCreateObject(bstrURL, ref pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CancelObjectCreation<TI0>(ComPtr<TI0> pIUnknownCancelCookie) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CancelObjectCreation((Silk.NET.Core.Native.IUnknown*) pIUnknownCancelCookie.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int EndCreateObject<TI0>(IMFAsyncResult* pResult, ref ComPtr<TI0> ppObject) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->EndCreateObject(pResult, (Silk.NET.Core.Native.IUnknown**) ppObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int EndCreateObject<TI0>(ref IMFAsyncResult pResult, ref ComPtr<TI0> ppObject) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->EndCreateObject(ref pResult, (Silk.NET.Core.Native.IUnknown**) ppObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineNeedKeyNotify.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineNeedKeyNotify.gen.cs
@@ -1,0 +1,158 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("46a30204-a696-4b18-8804-246b8f031bb1")]
+    [NativeName("Name", "IMFMediaEngineNeedKeyNotify")]
+    public unsafe partial struct IMFMediaEngineNeedKeyNotify : IComVtbl<IMFMediaEngineNeedKeyNotify>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("46a30204-a696-4b18-8804-246b8f031bb1");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineNeedKeyNotify val)
+            => Unsafe.As<IMFMediaEngineNeedKeyNotify, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineNeedKeyNotify
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineNeedKeyNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineNeedKeyNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineNeedKeyNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineNeedKeyNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineNeedKeyNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineNeedKeyNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void NeedKey([Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb)
+        {
+            var @this = (IMFMediaEngineNeedKeyNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, byte*, uint, void>)@this->LpVtbl[3])(@this, initData, cb);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void NeedKey([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb)
+        {
+            var @this = (IMFMediaEngineNeedKeyNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (byte* initDataPtr = &initData)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, byte*, uint, void>)@this->LpVtbl[3])(@this, initDataPtr, cb);
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void NeedKey([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb)
+        {
+            var @this = (IMFMediaEngineNeedKeyNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, byte*, uint, void>)@this->LpVtbl[3])(@this, initDataPtr, cb);
+            SilkMarshal.Free((nint)initDataPtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineNeedKeyNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineNeedKeyNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineNotify.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineNotify.gen.cs
@@ -1,0 +1,141 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("fee7c112-e776-42b5-9bbf-0048524e2bd5")]
+    [NativeName("Name", "IMFMediaEngineNotify")]
+    public unsafe partial struct IMFMediaEngineNotify : IComVtbl<IMFMediaEngineNotify>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("fee7c112-e776-42b5-9bbf-0048524e2bd5");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineNotify val)
+            => Unsafe.As<IMFMediaEngineNotify, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineNotify
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNotify*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNotify*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int EventNotify(uint @event, nuint param1, uint param2)
+        {
+            var @this = (IMFMediaEngineNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNotify*, uint, nuint, uint, int>)@this->LpVtbl[3])(@this, @event, param1, param2);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineOPMInfo.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineOPMInfo.gen.cs
@@ -1,0 +1,180 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("765763e6-6c01-4b01-bb0f-b829f60ed28c")]
+    [NativeName("Name", "IMFMediaEngineOPMInfo")]
+    public unsafe partial struct IMFMediaEngineOPMInfo : IComVtbl<IMFMediaEngineOPMInfo>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("765763e6-6c01-4b01-bb0f-b829f60ed28c");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineOPMInfo val)
+            => Unsafe.As<IMFMediaEngineOPMInfo, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineOPMInfo
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineOPMInfo*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineOPMInfo*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineOPMInfo*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineOPMInfo*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineOPMInfo*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineOPMInfo*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetOPMInfo(MediaEngineOpmStatus* pStatus, int* pConstricted)
+        {
+            var @this = (IMFMediaEngineOPMInfo*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, MediaEngineOpmStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatus, pConstricted);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetOPMInfo(MediaEngineOpmStatus* pStatus, ref int pConstricted)
+        {
+            var @this = (IMFMediaEngineOPMInfo*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* pConstrictedPtr = &pConstricted)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, MediaEngineOpmStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatus, pConstrictedPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetOPMInfo(ref MediaEngineOpmStatus pStatus, int* pConstricted)
+        {
+            var @this = (IMFMediaEngineOPMInfo*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (MediaEngineOpmStatus* pStatusPtr = &pStatus)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, MediaEngineOpmStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatusPtr, pConstricted);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetOPMInfo(ref MediaEngineOpmStatus pStatus, ref int pConstricted)
+        {
+            var @this = (IMFMediaEngineOPMInfo*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (MediaEngineOpmStatus* pStatusPtr = &pStatus)
+            {
+                fixed (int* pConstrictedPtr = &pConstricted)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, MediaEngineOpmStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatusPtr, pConstrictedPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineOPMInfo*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineOPMInfo*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineProtectedContent.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineProtectedContent.gen.cs
@@ -1,0 +1,900 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("9f8021e8-9c8c-487e-bb5c-79aa4779938c")]
+    [NativeName("Name", "IMFMediaEngineProtectedContent")]
+    public unsafe partial struct IMFMediaEngineProtectedContent : IComVtbl<IMFMediaEngineProtectedContent>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("9f8021e8-9c8c-487e-bb5c-79aa4779938c");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineProtectedContent val)
+            => Unsafe.As<IMFMediaEngineProtectedContent, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineProtectedContent
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int ShareResources(Silk.NET.Core.Native.IUnknown* pUnkDeviceContext)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[3])(@this, pUnkDeviceContext);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int ShareResources(ref Silk.NET.Core.Native.IUnknown pUnkDeviceContext)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pUnkDeviceContextPtr = &pUnkDeviceContext)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[3])(@this, pUnkDeviceContextPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetRequiredProtections(uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, uint*, int>)@this->LpVtbl[4])(@this, pFrameProtectionFlags);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetRequiredProtections(ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, uint*, int>)@this->LpVtbl[4])(@this, pFrameProtectionFlagsPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetOPMWindow(nint hwnd)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, nint, int>)@this->LpVtbl[5])(@this, hwnd);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDst, pBorderClr, pFrameProtectionFlags);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDst, pBorderClr, pFrameProtectionFlagsPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDst, pBorderClrPtr, pFrameProtectionFlags);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDst, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDstPtr, pBorderClr, pFrameProtectionFlags);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDstPtr, pBorderClr, pFrameProtectionFlagsPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDstPtr, pBorderClrPtr, pFrameProtectionFlags);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDstPtr, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDst, pBorderClr, pFrameProtectionFlags);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDst, pBorderClr, pFrameProtectionFlagsPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDst, pBorderClrPtr, pFrameProtectionFlags);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDst, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClr, pFrameProtectionFlags);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClr, pFrameProtectionFlagsPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClrPtr, pFrameProtectionFlags);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDst, pBorderClr, pFrameProtectionFlags);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDst, pBorderClr, pFrameProtectionFlagsPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDst, pBorderClrPtr, pFrameProtectionFlags);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDst, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClr, pFrameProtectionFlags);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClr, pFrameProtectionFlagsPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClrPtr, pFrameProtectionFlags);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClr, pFrameProtectionFlags);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClr, pFrameProtectionFlagsPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClrPtr, pFrameProtectionFlags);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClr, pFrameProtectionFlags);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                    {
+                        fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClr, pFrameProtectionFlagsPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                    {
+                        fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClrPtr, pFrameProtectionFlags);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int TransferVideoFrame(ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+            {
+                fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+                {
+                    fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                    {
+                        fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                        {
+                            fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                            {
+                                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                            }
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int SetContentProtectionManager(IMFContentProtectionManager* pCPM)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, IMFContentProtectionManager*, int>)@this->LpVtbl[7])(@this, pCPM);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetContentProtectionManager(ref IMFContentProtectionManager pCPM)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFContentProtectionManager* pCPMPtr = &pCPM)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, IMFContentProtectionManager*, int>)@this->LpVtbl[7])(@this, pCPMPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int SetApplicationCertificate([Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbBlob, uint cbBlob)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, byte*, uint, int>)@this->LpVtbl[8])(@this, pbBlob, cbBlob);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetApplicationCertificate([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbBlob, uint cbBlob)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* pbBlobPtr = &pbBlob)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, byte*, uint, int>)@this->LpVtbl[8])(@this, pbBlobPtr, cbBlob);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetApplicationCertificate([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbBlob, uint cbBlob)
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pbBlobPtr = (byte*) SilkMarshal.StringToPtr(pbBlob, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, byte*, uint, int>)@this->LpVtbl[8])(@this, pbBlobPtr, cbBlob);
+            SilkMarshal.Free((nint)pbBlobPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int ShareResources<TI0>(ComPtr<TI0> pUnkDeviceContext) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->ShareResources((Silk.NET.Core.Native.IUnknown*) pUnkDeviceContext.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, pBorderClr, pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, pBorderClr, ref pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, in pBorderClr, pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, in pBorderClr, ref pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, pBorderClr, pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, pBorderClr, ref pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, in pBorderClr, pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, in pBorderClr, ref pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, pBorderClr, pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, pBorderClr, ref pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, in pBorderClr, pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, in pBorderClr, ref pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, pBorderClr, pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, pBorderClr, ref pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, in pBorderClr, pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int TransferVideoFrame<TI0>(ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, in pBorderClr, ref pFrameProtectionFlags);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineProtectedContent*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineSrcElements.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineSrcElements.gen.cs
@@ -1,0 +1,627 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("7a5e5354-b114-4c72-b991-3131d75032ea")]
+    [NativeName("Name", "IMFMediaEngineSrcElements")]
+    public unsafe partial struct IMFMediaEngineSrcElements : IComVtbl<IMFMediaEngineSrcElements>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("7a5e5354-b114-4c72-b991-3131d75032ea");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineSrcElements val)
+            => Unsafe.As<IMFMediaEngineSrcElements, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineSrcElements
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint GetLength()
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint>)@this->LpVtbl[3])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetURL(uint index, char** pURL)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint, char**, int>)@this->LpVtbl[4])(@this, index, pURL);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetURL(uint index, ref char* pURL)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** pURLPtr = &pURL)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint, char**, int>)@this->LpVtbl[4])(@this, index, pURLPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetType(uint index, char** pType)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint, char**, int>)@this->LpVtbl[5])(@this, index, pType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetType(uint index, ref char* pType)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** pTypePtr = &pType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint, char**, int>)@this->LpVtbl[5])(@this, index, pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetMedia(uint index, char** pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint, char**, int>)@this->LpVtbl[6])(@this, index, pMedia);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetMedia(uint index, ref char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint, char**, int>)@this->LpVtbl[6])(@this, index, pMediaPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, char* pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pType, pMedia);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, char* pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pType, pMediaPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURL, pType, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, ref char pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMedia);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, ref char pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMedia);
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+            }
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, byte*, byte*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(ref char pURL, char* pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMedia);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(ref char pURL, char* pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(ref char pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(ref char pURL, ref char pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement(ref char pURL, ref char pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+                    fixed (char* pMediaPtr = &pMedia)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement(ref char pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+                }
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, byte*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMedia);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+                }
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+            }
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, byte*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int RemoveAllElements()
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, int>)@this->LpVtbl[8])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetURL(uint index, string[] pURLSa)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var pURL = (char**) SilkMarshal.StringArrayToPtr(pURLSa);
+            var ret = @this->GetURL(index, pURL);
+            SilkMarshal.CopyPtrToStringArray((nint) pURL, pURLSa);
+            SilkMarshal.Free((nint) pURL);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetType(uint index, string[] pTypeSa)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var pType = (char**) SilkMarshal.StringArrayToPtr(pTypeSa);
+            var ret = @this->GetType(index, pType);
+            SilkMarshal.CopyPtrToStringArray((nint) pType, pTypeSa);
+            SilkMarshal.Free((nint) pType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetMedia(uint index, string[] pMediaSa)
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var pMedia = (char**) SilkMarshal.StringArrayToPtr(pMediaSa);
+            var ret = @this->GetMedia(index, pMedia);
+            SilkMarshal.CopyPtrToStringArray((nint) pMedia, pMediaSa);
+            SilkMarshal.Free((nint) pMedia);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineSrcElements*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineSrcElementsEx.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineSrcElementsEx.gen.cs
@@ -1,0 +1,1932 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("654a6bb3-e1a3-424a-9908-53a43a0dfda0")]
+    [NativeName("Name", "IMFMediaEngineSrcElementsEx")]
+    public unsafe partial struct IMFMediaEngineSrcElementsEx : IComVtbl<IMFMediaEngineSrcElementsEx>, IComVtbl<IMFMediaEngineSrcElements>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("654a6bb3-e1a3-424a-9908-53a43a0dfda0");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator IMFMediaEngineSrcElements(IMFMediaEngineSrcElementsEx val)
+            => Unsafe.As<IMFMediaEngineSrcElementsEx, IMFMediaEngineSrcElements>(ref val);
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineSrcElementsEx val)
+            => Unsafe.As<IMFMediaEngineSrcElementsEx, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineSrcElementsEx
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint GetLength()
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint>)@this->LpVtbl[3])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetURL(uint index, char** pURL)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[4])(@this, index, pURL);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetURL(uint index, ref char* pURL)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** pURLPtr = &pURL)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[4])(@this, index, pURLPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetType(uint index, char** pType)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[5])(@this, index, pType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetType(uint index, ref char* pType)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** pTypePtr = &pType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[5])(@this, index, pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetMedia(uint index, char** pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[6])(@this, index, pMedia);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetMedia(uint index, ref char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[6])(@this, index, pMediaPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, char* pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pType, pMedia);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, char* pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pType, pMediaPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURL, pType, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, ref char pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMedia);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, ref char pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMedia);
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+            }
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(ref char pURL, char* pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMedia);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(ref char pURL, char* pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(ref char pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(ref char pURL, ref char pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement(ref char pURL, ref char pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+                    fixed (char* pMediaPtr = &pMedia)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement(ref char pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+                }
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMedia);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+                }
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+            }
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElement([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int RemoveAllElements()
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, int>)@this->LpVtbl[8])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, char* pType, char* pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMedia, keySystem);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, char* pType, char* pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMedia, keySystemPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, char* pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMedia, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, char* pType, ref char pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMediaPtr, keySystem);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, char* pType, ref char pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMediaPtr, keySystemPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, char* pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pMediaPtr = &pMedia)
+            {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMediaPtr, keySystem);
+            SilkMarshal.Free((nint)pMediaPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMediaPtr, keySystemPtr);
+            }
+            SilkMarshal.Free((nint)pMediaPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, ref char pType, char* pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMedia, keySystem);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, ref char pType, char* pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMedia, keySystemPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, ref char pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMedia, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, ref char pType, ref char pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystem);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, ref char pType, ref char pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    fixed (char* keySystemPtr = &keySystem)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, ref char pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystem);
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+                }
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pTypePtr = &pType)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMedia, keySystem);
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMedia, keySystemPtr);
+            }
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMedia, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystem);
+            }
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+                }
+            }
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            }
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystem);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+            }
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, char* pType, char* pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMedia, keySystem);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, char* pType, char* pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMedia, keySystemPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, char* pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMedia, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, char* pType, ref char pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystem);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, char* pType, ref char pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    fixed (char* keySystemPtr = &keySystem)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, char* pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystem);
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+                }
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, ref char pType, char* pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystem);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, ref char pType, char* pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+                    fixed (char* keySystemPtr = &keySystem)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, ref char pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, ref char pType, ref char pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+                    fixed (char* pMediaPtr = &pMedia)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx(ref char pURL, ref char pType, ref char pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+                    fixed (char* pMediaPtr = &pMedia)
+                    {
+                        fixed (char* keySystemPtr = &keySystem)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx(ref char pURL, ref char pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+                    fixed (char* pMediaPtr = &pMedia)
+                    {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+            SilkMarshal.Free((nint)pMediaPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx(ref char pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                    fixed (char* keySystemPtr = &keySystem)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+                    }
+            SilkMarshal.Free((nint)pMediaPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx(ref char pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+                fixed (char* pTypePtr = &pType)
+                {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystem);
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+                }
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+                }
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    fixed (char* keySystemPtr = &keySystem)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+                fixed (char* pMediaPtr = &pMedia)
+                {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+                }
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+                }
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx(ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* pURLPtr = &pURL)
+            {
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, char* pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMedia, keySystem);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, char* pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMedia, keySystemPtr);
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMedia, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, ref char pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystem);
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, ref char pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+                }
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystem);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+            }
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, char* pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystem);
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, char* pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+                }
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, ref char pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+                }
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, ref char pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    fixed (char* keySystemPtr = &keySystem)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+                }
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+                }
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            fixed (char* pTypePtr = &pType)
+            {
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            }
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystem);
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+            }
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+            }
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+                }
+            }
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            }
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+            }
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddElementEx([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+            SilkMarshal.Free((nint)keySystemPtr);
+            SilkMarshal.Free((nint)pMediaPtr);
+            SilkMarshal.Free((nint)pTypePtr);
+            SilkMarshal.Free((nint)pURLPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeySystem(uint index, char** pType)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[10])(@this, index, pType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeySystem(uint index, ref char* pType)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** pTypePtr = &pType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[10])(@this, index, pTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetURL(uint index, string[] pURLSa)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var pURL = (char**) SilkMarshal.StringArrayToPtr(pURLSa);
+            var ret = @this->GetURL(index, pURL);
+            SilkMarshal.CopyPtrToStringArray((nint) pURL, pURLSa);
+            SilkMarshal.Free((nint) pURL);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetType(uint index, string[] pTypeSa)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var pType = (char**) SilkMarshal.StringArrayToPtr(pTypeSa);
+            var ret = @this->GetType(index, pType);
+            SilkMarshal.CopyPtrToStringArray((nint) pType, pTypeSa);
+            SilkMarshal.Free((nint) pType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetMedia(uint index, string[] pMediaSa)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var pMedia = (char**) SilkMarshal.StringArrayToPtr(pMediaSa);
+            var ret = @this->GetMedia(index, pMedia);
+            SilkMarshal.CopyPtrToStringArray((nint) pMedia, pMediaSa);
+            SilkMarshal.Free((nint) pMedia);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetKeySystem(uint index, string[] pTypeSa)
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var pType = (char**) SilkMarshal.StringArrayToPtr(pTypeSa);
+            var ret = @this->GetKeySystem(index, pType);
+            SilkMarshal.CopyPtrToStringArray((nint) pType, pTypeSa);
+            SilkMarshal.Free((nint) pType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineSrcElementsEx*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineSupportsSourceTransfer.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineSupportsSourceTransfer.gen.cs
@@ -1,0 +1,433 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("a724b056-1b2e-4642-a6f3-db9420c52908")]
+    [NativeName("Name", "IMFMediaEngineSupportsSourceTransfer")]
+    public unsafe partial struct IMFMediaEngineSupportsSourceTransfer : IComVtbl<IMFMediaEngineSupportsSourceTransfer>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("a724b056-1b2e-4642-a6f3-db9420c52908");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineSupportsSourceTransfer val)
+            => Unsafe.As<IMFMediaEngineSupportsSourceTransfer, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineSupportsSourceTransfer
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int ShouldTransferSource(int* pfShouldTransfer)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, int*, int>)@this->LpVtbl[3])(@this, pfShouldTransfer);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int ShouldTransferSource(ref int pfShouldTransfer)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* pfShouldTransferPtr = &pfShouldTransfer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, int*, int>)@this->LpVtbl[3])(@this, pfShouldTransferPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int DetachMediaSource(IMFByteStream** ppByteStream, IMFMediaSource** ppMediaSource, IMFMediaSourceExtension** ppMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStream, ppMediaSource, ppMSE);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int DetachMediaSource(IMFByteStream** ppByteStream, IMFMediaSource** ppMediaSource, ref IMFMediaSourceExtension* ppMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaSourceExtension** ppMSEPtr = &ppMSE)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStream, ppMediaSource, ppMSEPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int DetachMediaSource(IMFByteStream** ppByteStream, ref IMFMediaSource* ppMediaSource, IMFMediaSourceExtension** ppMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaSource** ppMediaSourcePtr = &ppMediaSource)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStream, ppMediaSourcePtr, ppMSE);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int DetachMediaSource(IMFByteStream** ppByteStream, ref IMFMediaSource* ppMediaSource, ref IMFMediaSourceExtension* ppMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaSource** ppMediaSourcePtr = &ppMediaSource)
+            {
+                fixed (IMFMediaSourceExtension** ppMSEPtr = &ppMSE)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStream, ppMediaSourcePtr, ppMSEPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int DetachMediaSource(ref IMFByteStream* ppByteStream, IMFMediaSource** ppMediaSource, IMFMediaSourceExtension** ppMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream** ppByteStreamPtr = &ppByteStream)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStreamPtr, ppMediaSource, ppMSE);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int DetachMediaSource(ref IMFByteStream* ppByteStream, IMFMediaSource** ppMediaSource, ref IMFMediaSourceExtension* ppMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream** ppByteStreamPtr = &ppByteStream)
+            {
+                fixed (IMFMediaSourceExtension** ppMSEPtr = &ppMSE)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStreamPtr, ppMediaSource, ppMSEPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int DetachMediaSource(ref IMFByteStream* ppByteStream, ref IMFMediaSource* ppMediaSource, IMFMediaSourceExtension** ppMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream** ppByteStreamPtr = &ppByteStream)
+            {
+                fixed (IMFMediaSource** ppMediaSourcePtr = &ppMediaSource)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStreamPtr, ppMediaSourcePtr, ppMSE);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int DetachMediaSource(ref IMFByteStream* ppByteStream, ref IMFMediaSource* ppMediaSource, ref IMFMediaSourceExtension* ppMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream** ppByteStreamPtr = &ppByteStream)
+            {
+                fixed (IMFMediaSource** ppMediaSourcePtr = &ppMediaSource)
+                {
+                    fixed (IMFMediaSourceExtension** ppMSEPtr = &ppMSE)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStreamPtr, ppMediaSourcePtr, ppMSEPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AttachMediaSource(IMFByteStream* pByteStream, IMFMediaSource* pMediaSource, IMFMediaSourceExtension* pMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStream, pMediaSource, pMSE);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AttachMediaSource(IMFByteStream* pByteStream, IMFMediaSource* pMediaSource, ref IMFMediaSourceExtension pMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaSourceExtension* pMSEPtr = &pMSE)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStream, pMediaSource, pMSEPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AttachMediaSource(IMFByteStream* pByteStream, ref IMFMediaSource pMediaSource, IMFMediaSourceExtension* pMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaSource* pMediaSourcePtr = &pMediaSource)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStream, pMediaSourcePtr, pMSE);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AttachMediaSource(IMFByteStream* pByteStream, ref IMFMediaSource pMediaSource, ref IMFMediaSourceExtension pMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaSource* pMediaSourcePtr = &pMediaSource)
+            {
+                fixed (IMFMediaSourceExtension* pMSEPtr = &pMSE)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStream, pMediaSourcePtr, pMSEPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AttachMediaSource(ref IMFByteStream pByteStream, IMFMediaSource* pMediaSource, IMFMediaSourceExtension* pMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStreamPtr, pMediaSource, pMSE);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AttachMediaSource(ref IMFByteStream pByteStream, IMFMediaSource* pMediaSource, ref IMFMediaSourceExtension pMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (IMFMediaSourceExtension* pMSEPtr = &pMSE)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStreamPtr, pMediaSource, pMSEPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AttachMediaSource(ref IMFByteStream pByteStream, ref IMFMediaSource pMediaSource, IMFMediaSourceExtension* pMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (IMFMediaSource* pMediaSourcePtr = &pMediaSource)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStreamPtr, pMediaSourcePtr, pMSE);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AttachMediaSource(ref IMFByteStream pByteStream, ref IMFMediaSource pMediaSource, ref IMFMediaSourceExtension pMSE)
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (IMFMediaSource* pMediaSourcePtr = &pMediaSource)
+                {
+                    fixed (IMFMediaSourceExtension* pMSEPtr = &pMSE)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStreamPtr, pMediaSourcePtr, pMSEPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int DetachMediaSource<TI0>(IMFByteStream** ppByteStream, IMFMediaSource** ppMediaSource, ref ComPtr<TI0> ppMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->DetachMediaSource(ppByteStream, ppMediaSource, (IMFMediaSourceExtension**) ppMSE.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int DetachMediaSource<TI0>(IMFByteStream** ppByteStream, ref IMFMediaSource* ppMediaSource, ref ComPtr<TI0> ppMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->DetachMediaSource(ppByteStream, ref ppMediaSource, (IMFMediaSourceExtension**) ppMSE.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int DetachMediaSource<TI0>(ref IMFByteStream* ppByteStream, IMFMediaSource** ppMediaSource, ref ComPtr<TI0> ppMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->DetachMediaSource(ref ppByteStream, ppMediaSource, (IMFMediaSourceExtension**) ppMSE.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int DetachMediaSource<TI0>(ref IMFByteStream* ppByteStream, ref IMFMediaSource* ppMediaSource, ref ComPtr<TI0> ppMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->DetachMediaSource(ref ppByteStream, ref ppMediaSource, (IMFMediaSourceExtension**) ppMSE.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AttachMediaSource<TI0>(IMFByteStream* pByteStream, IMFMediaSource* pMediaSource, ComPtr<TI0> pMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AttachMediaSource(pByteStream, pMediaSource, (IMFMediaSourceExtension*) pMSE.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AttachMediaSource<TI0>(IMFByteStream* pByteStream, ref IMFMediaSource pMediaSource, ComPtr<TI0> pMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AttachMediaSource(pByteStream, ref pMediaSource, (IMFMediaSourceExtension*) pMSE.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AttachMediaSource<TI0>(ref IMFByteStream pByteStream, IMFMediaSource* pMediaSource, ComPtr<TI0> pMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AttachMediaSource(ref pByteStream, pMediaSource, (IMFMediaSourceExtension*) pMSE.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AttachMediaSource<TI0>(ref IMFByteStream pByteStream, ref IMFMediaSource pMediaSource, ComPtr<TI0> pMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AttachMediaSource(ref pByteStream, ref pMediaSource, (IMFMediaSourceExtension*) pMSE.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineSupportsSourceTransfer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineTransferSource.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineTransferSource.gen.cs
@@ -1,0 +1,161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("24230452-fe54-40cc-94f3-fcc394c340d6")]
+    [NativeName("Name", "IMFMediaEngineTransferSource")]
+    public unsafe partial struct IMFMediaEngineTransferSource : IComVtbl<IMFMediaEngineTransferSource>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("24230452-fe54-40cc-94f3-fcc394c340d6");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineTransferSource val)
+            => Unsafe.As<IMFMediaEngineTransferSource, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineTransferSource
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineTransferSource*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineTransferSource*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineTransferSource*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineTransferSource*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineTransferSource*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineTransferSource*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int TransferSourceToMediaEngine(IMFMediaEngine* destination)
+        {
+            var @this = (IMFMediaEngineTransferSource*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, IMFMediaEngine*, int>)@this->LpVtbl[3])(@this, destination);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int TransferSourceToMediaEngine(ref IMFMediaEngine destination)
+        {
+            var @this = (IMFMediaEngineTransferSource*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaEngine* destinationPtr = &destination)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, IMFMediaEngine*, int>)@this->LpVtbl[3])(@this, destinationPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineTransferSource*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int TransferSourceToMediaEngine<TI0>(ComPtr<TI0> destination) where TI0 : unmanaged, IComVtbl<IMFMediaEngine>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineTransferSource*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->TransferSourceToMediaEngine((IMFMediaEngine*) destination.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineTransferSource*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineWebSupport.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaEngineWebSupport.gen.cs
@@ -1,0 +1,179 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("ba2743a1-07e0-48ef-84b6-9a2ed023ca6c")]
+    [NativeName("Name", "IMFMediaEngineWebSupport")]
+    public unsafe partial struct IMFMediaEngineWebSupport : IComVtbl<IMFMediaEngineWebSupport>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("ba2743a1-07e0-48ef-84b6-9a2ed023ca6c");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaEngineWebSupport val)
+            => Unsafe.As<IMFMediaEngineWebSupport, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaEngineWebSupport
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineWebSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineWebSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaEngineWebSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaEngineWebSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaEngineWebSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaEngineWebSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 ShouldDelayTheLoadEvent()
+        {
+            var @this = (IMFMediaEngineWebSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, Silk.NET.Core.Bool32>)@this->LpVtbl[3])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int ConnectWebAudio(uint dwSampleRate, IAudioSourceProvider** ppSourceProvider)
+        {
+            var @this = (IMFMediaEngineWebSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, uint, IAudioSourceProvider**, int>)@this->LpVtbl[4])(@this, dwSampleRate, ppSourceProvider);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int ConnectWebAudio(uint dwSampleRate, ref IAudioSourceProvider* ppSourceProvider)
+        {
+            var @this = (IMFMediaEngineWebSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IAudioSourceProvider** ppSourceProviderPtr = &ppSourceProvider)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, uint, IAudioSourceProvider**, int>)@this->LpVtbl[4])(@this, dwSampleRate, ppSourceProviderPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int DisconnectWebAudio()
+        {
+            var @this = (IMFMediaEngineWebSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, int>)@this->LpVtbl[5])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineWebSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int ConnectWebAudio<TI0>(uint dwSampleRate, ref ComPtr<TI0> ppSourceProvider) where TI0 : unmanaged, IComVtbl<IAudioSourceProvider>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineWebSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->ConnectWebAudio(dwSampleRate, (IAudioSourceProvider**) ppSourceProvider.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaEngineWebSupport*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaError.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaError.gen.cs
@@ -129,11 +129,11 @@ namespace Silk.NET.MediaFoundation
         }
 
         /// <summary>To be documented.</summary>
-        public readonly int SetErrorCode(MediaEngineErr error)
+        public readonly int SetErrorCode(MediaEngineError error)
         {
             var @this = (IMFMediaError*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
             int ret = default;
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, MediaEngineErr, int>)@this->LpVtbl[5])(@this, error);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, MediaEngineError, int>)@this->LpVtbl[5])(@this, error);
             return ret;
         }
 

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaError.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaError.gen.cs
@@ -1,0 +1,168 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("fc0e10d2-ab2a-4501-a951-06bb1075184c")]
+    [NativeName("Name", "IMFMediaError")]
+    public unsafe partial struct IMFMediaError : IComVtbl<IMFMediaError>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("fc0e10d2-ab2a-4501-a951-06bb1075184c");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaError val)
+            => Unsafe.As<IMFMediaError, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaError
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaError*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaError*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaError*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaError*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaError*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaError*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ushort GetErrorCode()
+        {
+            var @this = (IMFMediaError*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ushort ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, ushort>)@this->LpVtbl[3])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetExtendedErrorCode()
+        {
+            var @this = (IMFMediaError*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, int>)@this->LpVtbl[4])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetErrorCode(MediaEngineErr error)
+        {
+            var @this = (IMFMediaError*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, MediaEngineErr, int>)@this->LpVtbl[5])(@this, error);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetExtendedErrorCode(int error)
+        {
+            var @this = (IMFMediaError*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, int, int>)@this->LpVtbl[6])(@this, error);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaError*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaError*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaKeySession.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaKeySession.gen.cs
@@ -1,0 +1,287 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("24fa67d5-d1d0-4dc5-995c-c0efdc191fb5")]
+    [NativeName("Name", "IMFMediaKeySession")]
+    public unsafe partial struct IMFMediaKeySession : IComVtbl<IMFMediaKeySession>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("24fa67d5-d1d0-4dc5-995c-c0efdc191fb5");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaKeySession val)
+            => Unsafe.As<IMFMediaKeySession, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaKeySession
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetError(ushort* code, uint* systemCode)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, code, systemCode);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetError(ushort* code, ref uint systemCode)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* systemCodePtr = &systemCode)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, code, systemCodePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetError(ref ushort code, uint* systemCode)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (ushort* codePtr = &code)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, codePtr, systemCode);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetError(ref ushort code, ref uint systemCode)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (ushort* codePtr = &code)
+            {
+                fixed (uint* systemCodePtr = &systemCode)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, codePtr, systemCodePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeySystem(char** keySystem)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, char**, int>)@this->LpVtbl[4])(@this, keySystem);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeySystem(ref char* keySystem)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, char**, int>)@this->LpVtbl[4])(@this, keySystemPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSessionId(char** sessionId)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, char**, int>)@this->LpVtbl[5])(@this, sessionId);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSessionId(ref char* sessionId)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** sessionIdPtr = &sessionId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, char**, int>)@this->LpVtbl[5])(@this, sessionIdPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int Update([Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* key, uint cb)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, byte*, uint, int>)@this->LpVtbl[6])(@this, key, cb);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Update([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte key, uint cb)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* keyPtr = &key)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, byte*, uint, int>)@this->LpVtbl[6])(@this, keyPtr, cb);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Update([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string key, uint cb)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keyPtr = (byte*) SilkMarshal.StringToPtr(key, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, byte*, uint, int>)@this->LpVtbl[6])(@this, keyPtr, cb);
+            SilkMarshal.Free((nint)keyPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Close()
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, int>)@this->LpVtbl[7])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetKeySystem(string[] keySystemSa)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var keySystem = (char**) SilkMarshal.StringArrayToPtr(keySystemSa);
+            var ret = @this->GetKeySystem(keySystem);
+            SilkMarshal.CopyPtrToStringArray((nint) keySystem, keySystemSa);
+            SilkMarshal.Free((nint) keySystem);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetSessionId(string[] sessionIdSa)
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var sessionId = (char**) SilkMarshal.StringArrayToPtr(sessionIdSa);
+            var ret = @this->GetSessionId(sessionId);
+            SilkMarshal.CopyPtrToStringArray((nint) sessionId, sessionIdSa);
+            SilkMarshal.Free((nint) sessionId);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeySession*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaKeySession2.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaKeySession2.gen.cs
@@ -1,0 +1,561 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("e9707e05-6d55-4636-b185-3de21210bd75")]
+    [NativeName("Name", "IMFMediaKeySession2")]
+    public unsafe partial struct IMFMediaKeySession2 : IComVtbl<IMFMediaKeySession2>, IComVtbl<IMFMediaKeySession>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("e9707e05-6d55-4636-b185-3de21210bd75");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator IMFMediaKeySession(IMFMediaKeySession2 val)
+            => Unsafe.As<IMFMediaKeySession2, IMFMediaKeySession>(ref val);
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaKeySession2 val)
+            => Unsafe.As<IMFMediaKeySession2, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaKeySession2
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetError(ushort* code, uint* systemCode)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, code, systemCode);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetError(ushort* code, ref uint systemCode)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* systemCodePtr = &systemCode)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, code, systemCodePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetError(ref ushort code, uint* systemCode)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (ushort* codePtr = &code)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, codePtr, systemCode);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetError(ref ushort code, ref uint systemCode)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (ushort* codePtr = &code)
+            {
+                fixed (uint* systemCodePtr = &systemCode)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, codePtr, systemCodePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeySystem(char** keySystem)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char**, int>)@this->LpVtbl[4])(@this, keySystem);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeySystem(ref char* keySystem)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char**, int>)@this->LpVtbl[4])(@this, keySystemPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSessionId(char** sessionId)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char**, int>)@this->LpVtbl[5])(@this, sessionId);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSessionId(ref char* sessionId)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** sessionIdPtr = &sessionId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char**, int>)@this->LpVtbl[5])(@this, sessionIdPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int Update([Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* key, uint cb)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, uint, int>)@this->LpVtbl[6])(@this, key, cb);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Update([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte key, uint cb)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* keyPtr = &key)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, uint, int>)@this->LpVtbl[6])(@this, keyPtr, cb);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Update([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string key, uint cb)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var keyPtr = (byte*) SilkMarshal.StringToPtr(key, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, uint, int>)@this->LpVtbl[6])(@this, keyPtr, cb);
+            SilkMarshal.Free((nint)keyPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Close()
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, int>)@this->LpVtbl[7])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeyStatuses(MFMediaKeyStatus** pKeyStatusesArray, uint* puSize)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, MFMediaKeyStatus**, uint*, int>)@this->LpVtbl[8])(@this, pKeyStatusesArray, puSize);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeyStatuses(MFMediaKeyStatus** pKeyStatusesArray, ref uint puSize)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* puSizePtr = &puSize)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, MFMediaKeyStatus**, uint*, int>)@this->LpVtbl[8])(@this, pKeyStatusesArray, puSizePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeyStatuses(ref MFMediaKeyStatus* pKeyStatusesArray, uint* puSize)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (MFMediaKeyStatus** pKeyStatusesArrayPtr = &pKeyStatusesArray)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, MFMediaKeyStatus**, uint*, int>)@this->LpVtbl[8])(@this, pKeyStatusesArrayPtr, puSize);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeyStatuses(ref MFMediaKeyStatus* pKeyStatusesArray, ref uint puSize)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (MFMediaKeyStatus** pKeyStatusesArrayPtr = &pKeyStatusesArray)
+            {
+                fixed (uint* puSizePtr = &puSize)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, MFMediaKeyStatus**, uint*, int>)@this->LpVtbl[8])(@this, pKeyStatusesArrayPtr, puSizePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int Load(char* bstrSessionId, int* pfLoaded)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, int*, int>)@this->LpVtbl[9])(@this, bstrSessionId, pfLoaded);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int Load(char* bstrSessionId, ref int pfLoaded)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* pfLoadedPtr = &pfLoaded)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, int*, int>)@this->LpVtbl[9])(@this, bstrSessionId, pfLoadedPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int Load(ref char bstrSessionId, int* pfLoaded)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrSessionIdPtr = &bstrSessionId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, int*, int>)@this->LpVtbl[9])(@this, bstrSessionIdPtr, pfLoaded);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Load(ref char bstrSessionId, ref int pfLoaded)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* bstrSessionIdPtr = &bstrSessionId)
+            {
+                fixed (int* pfLoadedPtr = &pfLoaded)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, int*, int>)@this->LpVtbl[9])(@this, bstrSessionIdPtr, pfLoadedPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int Load([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrSessionId, int* pfLoaded)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrSessionIdPtr = (byte*) SilkMarshal.StringToPtr(bstrSessionId, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, int*, int>)@this->LpVtbl[9])(@this, bstrSessionIdPtr, pfLoaded);
+            SilkMarshal.Free((nint)bstrSessionIdPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Load([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrSessionId, ref int pfLoaded)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var bstrSessionIdPtr = (byte*) SilkMarshal.StringToPtr(bstrSessionId, NativeStringEncoding.BStr);
+            fixed (int* pfLoadedPtr = &pfLoaded)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, int*, int>)@this->LpVtbl[9])(@this, bstrSessionIdPtr, pfLoadedPtr);
+            }
+            SilkMarshal.Free((nint)bstrSessionIdPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GenerateRequest(char* initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbInitData, uint cb)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataType, pbInitData, cb);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GenerateRequest(char* initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbInitData, uint cb)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* pbInitDataPtr = &pbInitData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataType, pbInitDataPtr, cb);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GenerateRequest(char* initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbInitData, uint cb)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pbInitDataPtr = (byte*) SilkMarshal.StringToPtr(pbInitData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataType, pbInitDataPtr, cb);
+            SilkMarshal.Free((nint)pbInitDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GenerateRequest(ref char initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbInitData, uint cb)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* initDataTypePtr = &initDataType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataTypePtr, pbInitData, cb);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GenerateRequest(ref char initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbInitData, uint cb)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* initDataTypePtr = &initDataType)
+            {
+                fixed (byte* pbInitDataPtr = &pbInitData)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataTypePtr, pbInitDataPtr, cb);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GenerateRequest(ref char initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbInitData, uint cb)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* initDataTypePtr = &initDataType)
+            {
+            var pbInitDataPtr = (byte*) SilkMarshal.StringToPtr(pbInitData, NativeStringEncoding.UTF8);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataTypePtr, pbInitDataPtr, cb);
+            SilkMarshal.Free((nint)pbInitDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GenerateRequest([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbInitData, uint cb)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataTypePtr = (byte*) SilkMarshal.StringToPtr(initDataType, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataTypePtr, pbInitData, cb);
+            SilkMarshal.Free((nint)initDataTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GenerateRequest([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbInitData, uint cb)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataTypePtr = (byte*) SilkMarshal.StringToPtr(initDataType, NativeStringEncoding.BStr);
+            fixed (byte* pbInitDataPtr = &pbInitData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataTypePtr, pbInitDataPtr, cb);
+            }
+            SilkMarshal.Free((nint)initDataTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GenerateRequest([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbInitData, uint cb)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataTypePtr = (byte*) SilkMarshal.StringToPtr(initDataType, NativeStringEncoding.BStr);
+            var pbInitDataPtr = (byte*) SilkMarshal.StringToPtr(pbInitData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataTypePtr, pbInitDataPtr, cb);
+            SilkMarshal.Free((nint)pbInitDataPtr);
+            SilkMarshal.Free((nint)initDataTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetExpiration(double* dblExpiration)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, double*, int>)@this->LpVtbl[11])(@this, dblExpiration);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetExpiration(ref double dblExpiration)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* dblExpirationPtr = &dblExpiration)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, double*, int>)@this->LpVtbl[11])(@this, dblExpirationPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Remove()
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, int>)@this->LpVtbl[12])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Shutdown()
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, int>)@this->LpVtbl[13])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetKeySystem(string[] keySystemSa)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var keySystem = (char**) SilkMarshal.StringArrayToPtr(keySystemSa);
+            var ret = @this->GetKeySystem(keySystem);
+            SilkMarshal.CopyPtrToStringArray((nint) keySystem, keySystemSa);
+            SilkMarshal.Free((nint) keySystem);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetSessionId(string[] sessionIdSa)
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var sessionId = (char**) SilkMarshal.StringArrayToPtr(sessionIdSa);
+            var ret = @this->GetSessionId(sessionId);
+            SilkMarshal.CopyPtrToStringArray((nint) sessionId, sessionIdSa);
+            SilkMarshal.Free((nint) sessionId);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeySession2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaKeySessionNotify.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaKeySessionNotify.gen.cs
@@ -1,0 +1,239 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("6a0083f9-8947-4c1d-9ce0-cdee22b23135")]
+    [NativeName("Name", "IMFMediaKeySessionNotify")]
+    public unsafe partial struct IMFMediaKeySessionNotify : IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("6a0083f9-8947-4c1d-9ce0-cdee22b23135");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaKeySessionNotify val)
+            => Unsafe.As<IMFMediaKeySessionNotify, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaKeySessionNotify
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage(char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURL, message, cb);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage(char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (byte* messagePtr = &message)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURL, messagePtr, cb);
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage(char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var messagePtr = (byte*) SilkMarshal.StringToPtr(message, NativeStringEncoding.UTF8);
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURL, messagePtr, cb);
+            SilkMarshal.Free((nint)messagePtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage(ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (char* destinationURLPtr = &destinationURL)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, message, cb);
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyMessage(ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (char* destinationURLPtr = &destinationURL)
+            {
+                fixed (byte* messagePtr = &message)
+                {
+                    ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+                }
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyMessage(ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (char* destinationURLPtr = &destinationURL)
+            {
+            var messagePtr = (byte*) SilkMarshal.StringToPtr(message, NativeStringEncoding.UTF8);
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+            SilkMarshal.Free((nint)messagePtr);
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, byte*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, message, cb);
+            SilkMarshal.Free((nint)destinationURLPtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyMessage([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+            fixed (byte* messagePtr = &message)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, byte*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+            }
+            SilkMarshal.Free((nint)destinationURLPtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyMessage([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+            var messagePtr = (byte*) SilkMarshal.StringToPtr(message, NativeStringEncoding.UTF8);
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, byte*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+            SilkMarshal.Free((nint)messagePtr);
+            SilkMarshal.Free((nint)destinationURLPtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyAdded()
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, void>)@this->LpVtbl[4])(@this);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyError(ushort code, uint systemCode)
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, ushort, uint, void>)@this->LpVtbl[5])(@this, code, systemCode);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeySessionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaKeySessionNotify2.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaKeySessionNotify2.gen.cs
@@ -1,0 +1,342 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("c3a9e92a-da88-46b0-a110-6cf953026cb9")]
+    [NativeName("Name", "IMFMediaKeySessionNotify2")]
+    public unsafe partial struct IMFMediaKeySessionNotify2 : IComVtbl<IMFMediaKeySessionNotify2>, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("c3a9e92a-da88-46b0-a110-6cf953026cb9");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator IMFMediaKeySessionNotify(IMFMediaKeySessionNotify2 val)
+            => Unsafe.As<IMFMediaKeySessionNotify2, IMFMediaKeySessionNotify>(ref val);
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaKeySessionNotify2 val)
+            => Unsafe.As<IMFMediaKeySessionNotify2, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaKeySessionNotify2
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage(char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURL, message, cb);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage(char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (byte* messagePtr = &message)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURL, messagePtr, cb);
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage(char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var messagePtr = (byte*) SilkMarshal.StringToPtr(message, NativeStringEncoding.UTF8);
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURL, messagePtr, cb);
+            SilkMarshal.Free((nint)messagePtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage(ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (char* destinationURLPtr = &destinationURL)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, message, cb);
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyMessage(ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (char* destinationURLPtr = &destinationURL)
+            {
+                fixed (byte* messagePtr = &message)
+                {
+                    ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+                }
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyMessage(ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (char* destinationURLPtr = &destinationURL)
+            {
+            var messagePtr = (byte*) SilkMarshal.StringToPtr(message, NativeStringEncoding.UTF8);
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+            SilkMarshal.Free((nint)messagePtr);
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, byte*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, message, cb);
+            SilkMarshal.Free((nint)destinationURLPtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyMessage([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+            fixed (byte* messagePtr = &message)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, byte*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+            }
+            SilkMarshal.Free((nint)destinationURLPtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyMessage([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string message, uint cb)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+            var messagePtr = (byte*) SilkMarshal.StringToPtr(message, NativeStringEncoding.UTF8);
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, byte*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+            SilkMarshal.Free((nint)messagePtr);
+            SilkMarshal.Free((nint)destinationURLPtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyAdded()
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, void>)@this->LpVtbl[4])(@this);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyError(ushort code, uint systemCode)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, ushort, uint, void>)@this->LpVtbl[5])(@this, code, systemCode);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage2(MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbMessage, uint cbMessage)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, char*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURL, pbMessage, cbMessage);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage2(MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbMessage, uint cbMessage)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (byte* pbMessagePtr = &pbMessage)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, char*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURL, pbMessagePtr, cbMessage);
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage2(MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbMessage, uint cbMessage)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var pbMessagePtr = (byte*) SilkMarshal.StringToPtr(pbMessage, NativeStringEncoding.UTF8);
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, char*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURL, pbMessagePtr, cbMessage);
+            SilkMarshal.Free((nint)pbMessagePtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage2(MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbMessage, uint cbMessage)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (char* destinationURLPtr = &destinationURL)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, char*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURLPtr, pbMessage, cbMessage);
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyMessage2(MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbMessage, uint cbMessage)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (char* destinationURLPtr = &destinationURL)
+            {
+                fixed (byte* pbMessagePtr = &pbMessage)
+                {
+                    ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, char*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURLPtr, pbMessagePtr, cbMessage);
+                }
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyMessage2(MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbMessage, uint cbMessage)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (char* destinationURLPtr = &destinationURL)
+            {
+            var pbMessagePtr = (byte*) SilkMarshal.StringToPtr(pbMessage, NativeStringEncoding.UTF8);
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, char*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURLPtr, pbMessagePtr, cbMessage);
+            SilkMarshal.Free((nint)pbMessagePtr);
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void KeyMessage2(MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbMessage, uint cbMessage)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, byte*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURLPtr, pbMessage, cbMessage);
+            SilkMarshal.Free((nint)destinationURLPtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyMessage2(MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbMessage, uint cbMessage)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+            fixed (byte* pbMessagePtr = &pbMessage)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, byte*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURLPtr, pbMessagePtr, cbMessage);
+            }
+            SilkMarshal.Free((nint)destinationURLPtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyMessage2(MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbMessage, uint cbMessage)
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+            var pbMessagePtr = (byte*) SilkMarshal.StringToPtr(pbMessage, NativeStringEncoding.UTF8);
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, byte*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURLPtr, pbMessagePtr, cbMessage);
+            SilkMarshal.Free((nint)pbMessagePtr);
+            SilkMarshal.Free((nint)destinationURLPtr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void KeyStatusChange()
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, void>)@this->LpVtbl[7])(@this);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeySessionNotify2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaKeySystemAccess.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaKeySystemAccess.gen.cs
@@ -1,0 +1,250 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("aec63fda-7a97-4944-b35c-6c6df8085cc3")]
+    [NativeName("Name", "IMFMediaKeySystemAccess")]
+    public unsafe partial struct IMFMediaKeySystemAccess : IComVtbl<IMFMediaKeySystemAccess>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("aec63fda-7a97-4944-b35c-6c6df8085cc3");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaKeySystemAccess val)
+            => Unsafe.As<IMFMediaKeySystemAccess, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaKeySystemAccess
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(IPropertyStore* pCdmCustomConfig, IMFMediaKeys2** ppKeys)
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, IPropertyStore*, IMFMediaKeys2**, int>)@this->LpVtbl[3])(@this, pCdmCustomConfig, ppKeys);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(IPropertyStore* pCdmCustomConfig, ref IMFMediaKeys2* ppKeys)
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeys2** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, IPropertyStore*, IMFMediaKeys2**, int>)@this->LpVtbl[3])(@this, pCdmCustomConfig, ppKeysPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(ref IPropertyStore pCdmCustomConfig, IMFMediaKeys2** ppKeys)
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IPropertyStore* pCdmCustomConfigPtr = &pCdmCustomConfig)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, IPropertyStore*, IMFMediaKeys2**, int>)@this->LpVtbl[3])(@this, pCdmCustomConfigPtr, ppKeys);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys(ref IPropertyStore pCdmCustomConfig, ref IMFMediaKeys2* ppKeys)
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IPropertyStore* pCdmCustomConfigPtr = &pCdmCustomConfig)
+            {
+                fixed (IMFMediaKeys2** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, IPropertyStore*, IMFMediaKeys2**, int>)@this->LpVtbl[3])(@this, pCdmCustomConfigPtr, ppKeysPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSupportedConfiguration(IPropertyStore** ppSupportedConfiguration)
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, IPropertyStore**, int>)@this->LpVtbl[4])(@this, ppSupportedConfiguration);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSupportedConfiguration(ref IPropertyStore* ppSupportedConfiguration)
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IPropertyStore** ppSupportedConfigurationPtr = &ppSupportedConfiguration)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, IPropertyStore**, int>)@this->LpVtbl[4])(@this, ppSupportedConfigurationPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeySystem(char** pKeySystem)
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, char**, int>)@this->LpVtbl[5])(@this, pKeySystem);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeySystem(ref char* pKeySystem)
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** pKeySystemPtr = &pKeySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, char**, int>)@this->LpVtbl[5])(@this, pKeySystemPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateMediaKeys<TI0>(IPropertyStore* pCdmCustomConfig, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys2>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys(pCdmCustomConfig, (IMFMediaKeys2**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateMediaKeys<TI0>(ref IPropertyStore pCdmCustomConfig, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys2>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateMediaKeys(ref pCdmCustomConfig, (IMFMediaKeys2**) ppKeys.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetKeySystem(string[] pKeySystemSa)
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var pKeySystem = (char**) SilkMarshal.StringArrayToPtr(pKeySystemSa);
+            var ret = @this->GetKeySystem(pKeySystem);
+            SilkMarshal.CopyPtrToStringArray((nint) pKeySystem, pKeySystemSa);
+            SilkMarshal.Free((nint) pKeySystem);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeySystemAccess*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaKeys.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaKeys.gen.cs
@@ -1,0 +1,2687 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("5cb31c05-61ff-418f-afda-caaf41421a38")]
+    [NativeName("Name", "IMFMediaKeys")]
+    public unsafe partial struct IMFMediaKeys : IComVtbl<IMFMediaKeys>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("5cb31c05-61ff-418f-afda-caaf41421a38");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaKeys val)
+            => Unsafe.As<IMFMediaKeys, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaKeys
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notify, ppSession);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSession);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    fixed (byte* customDataPtr = &customData)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    fixed (byte* customDataPtr = &customData)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    fixed (byte* customDataPtr = &customData)
+                    {
+                        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    fixed (byte* customDataPtr = &customData)
+                    {
+                        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                        {
+                            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                            {
+                                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                            }
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                    }
+            SilkMarshal.Free((nint)customDataPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                    }
+            SilkMarshal.Free((nint)customDataPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                        }
+                    }
+            SilkMarshal.Free((nint)customDataPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+                }
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+                }
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                fixed (byte* customDataPtr = &customData)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+                }
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                    }
+                }
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                        }
+                    }
+                }
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                        }
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeySystem(char** keySystem)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char**, int>)@this->LpVtbl[4])(@this, keySystem);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeySystem(ref char* keySystem)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char**, int>)@this->LpVtbl[4])(@this, keySystemPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Shutdown()
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, int>)@this->LpVtbl[5])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSuspendNotify(IMFCdmSuspendNotify** notify)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, IMFCdmSuspendNotify**, int>)@this->LpVtbl[6])(@this, notify);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSuspendNotify(ref IMFCdmSuspendNotify* notify)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFCdmSuspendNotify** notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, IMFCdmSuspendNotify**, int>)@this->LpVtbl[6])(@this, notifyPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetKeySystem(string[] keySystemSa)
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var keySystem = (char**) SilkMarshal.StringArrayToPtr(keySystemSa);
+            var ret = @this->GetKeySystem(keySystem);
+            SilkMarshal.CopyPtrToStringArray((nint) keySystem, keySystemSa);
+            SilkMarshal.Free((nint) keySystem);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetSuspendNotify<TI0>(ref ComPtr<TI0> notify) where TI0 : unmanaged, IComVtbl<IMFCdmSuspendNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetSuspendNotify((IMFCdmSuspendNotify**) notify.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaKeys2.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaKeys2.gen.cs
@@ -1,0 +1,2815 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("45892507-ad66-4de2-83a2-acbb13cd8d43")]
+    [NativeName("Name", "IMFMediaKeys2")]
+    public unsafe partial struct IMFMediaKeys2 : IComVtbl<IMFMediaKeys2>, IComVtbl<IMFMediaKeys>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("45892507-ad66-4de2-83a2-acbb13cd8d43");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator IMFMediaKeys(IMFMediaKeys2 val)
+            => Unsafe.As<IMFMediaKeys2, IMFMediaKeys>(ref val);
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaKeys2 val)
+            => Unsafe.As<IMFMediaKeys2, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaKeys2
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notify, ppSession);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSession);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    fixed (byte* customDataPtr = &customData)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    fixed (byte* customDataPtr = &customData)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    fixed (byte* customDataPtr = &customData)
+                    {
+                        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+                    fixed (byte* customDataPtr = &customData)
+                    {
+                        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                        {
+                            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                            {
+                                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                            }
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                    }
+            SilkMarshal.Free((nint)customDataPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                    }
+            SilkMarshal.Free((nint)customDataPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+                fixed (byte* initDataPtr = &initData)
+                {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                        }
+                    }
+            SilkMarshal.Free((nint)customDataPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+                }
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+                }
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                fixed (byte* customDataPtr = &customData)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+                }
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                    }
+                }
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                        }
+                    }
+                }
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* mimeTypePtr = &mimeType)
+            {
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                        }
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            fixed (byte* initDataPtr = &initData)
+            {
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)customDataPtr);
+            }
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+            var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+            SilkMarshal.Free((nint)customDataPtr);
+            SilkMarshal.Free((nint)initDataPtr);
+            SilkMarshal.Free((nint)mimeTypePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeySystem(char** keySystem)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char**, int>)@this->LpVtbl[4])(@this, keySystem);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetKeySystem(ref char* keySystem)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char**, int>)@this->LpVtbl[4])(@this, keySystemPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Shutdown()
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, int>)@this->LpVtbl[5])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSuspendNotify(IMFCdmSuspendNotify** notify)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, IMFCdmSuspendNotify**, int>)@this->LpVtbl[6])(@this, notify);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSuspendNotify(ref IMFCdmSuspendNotify* notify)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFCdmSuspendNotify** notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, IMFCdmSuspendNotify**, int>)@this->LpVtbl[6])(@this, notifyPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession2(MF_MEDIAKEYSESSION_TYPE eSessionType, IMFMediaKeySessionNotify2* pMFMediaKeySessionNotify2, IMFMediaKeySession2** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, MF_MEDIAKEYSESSION_TYPE, IMFMediaKeySessionNotify2*, IMFMediaKeySession2**, int>)@this->LpVtbl[7])(@this, eSessionType, pMFMediaKeySessionNotify2, ppSession);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession2(MF_MEDIAKEYSESSION_TYPE eSessionType, IMFMediaKeySessionNotify2* pMFMediaKeySessionNotify2, ref IMFMediaKeySession2* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeySession2** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, MF_MEDIAKEYSESSION_TYPE, IMFMediaKeySessionNotify2*, IMFMediaKeySession2**, int>)@this->LpVtbl[7])(@this, eSessionType, pMFMediaKeySessionNotify2, ppSessionPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession2(MF_MEDIAKEYSESSION_TYPE eSessionType, ref IMFMediaKeySessionNotify2 pMFMediaKeySessionNotify2, IMFMediaKeySession2** ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeySessionNotify2* pMFMediaKeySessionNotify2Ptr = &pMFMediaKeySessionNotify2)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, MF_MEDIAKEYSESSION_TYPE, IMFMediaKeySessionNotify2*, IMFMediaKeySession2**, int>)@this->LpVtbl[7])(@this, eSessionType, pMFMediaKeySessionNotify2Ptr, ppSession);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession2(MF_MEDIAKEYSESSION_TYPE eSessionType, ref IMFMediaKeySessionNotify2 pMFMediaKeySessionNotify2, ref IMFMediaKeySession2* ppSession)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaKeySessionNotify2* pMFMediaKeySessionNotify2Ptr = &pMFMediaKeySessionNotify2)
+            {
+                fixed (IMFMediaKeySession2** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, MF_MEDIAKEYSESSION_TYPE, IMFMediaKeySessionNotify2*, IMFMediaKeySession2**, int>)@this->LpVtbl[7])(@this, eSessionType, pMFMediaKeySessionNotify2Ptr, ppSessionPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int SetServerCertificate([Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbServerCertificate, uint cb)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, uint, int>)@this->LpVtbl[8])(@this, pbServerCertificate, cb);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetServerCertificate([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbServerCertificate, uint cb)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* pbServerCertificatePtr = &pbServerCertificate)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, uint, int>)@this->LpVtbl[8])(@this, pbServerCertificatePtr, cb);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetServerCertificate([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbServerCertificate, uint cb)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pbServerCertificatePtr = (byte*) SilkMarshal.StringToPtr(pbServerCertificate, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, uint, int>)@this->LpVtbl[8])(@this, pbServerCertificatePtr, cb);
+            SilkMarshal.Free((nint)pbServerCertificatePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetDOMException(int systemCode, int* code)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, int, int*, int>)@this->LpVtbl[9])(@this, systemCode, code);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetDOMException(int systemCode, ref int code)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* codePtr = &code)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, int, int*, int>)@this->LpVtbl[9])(@this, systemCode, codePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>(ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetKeySystem(string[] keySystemSa)
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var keySystem = (char**) SilkMarshal.StringArrayToPtr(keySystemSa);
+            var ret = @this->GetKeySystem(keySystem);
+            SilkMarshal.CopyPtrToStringArray((nint) keySystem, keySystemSa);
+            SilkMarshal.Free((nint) keySystem);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetSuspendNotify<TI0>(ref ComPtr<TI0> notify) where TI0 : unmanaged, IComVtbl<IMFCdmSuspendNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetSuspendNotify((IMFCdmSuspendNotify**) notify.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession2<TI0, TI1>(MF_MEDIAKEYSESSION_TYPE eSessionType, ComPtr<TI0> pMFMediaKeySessionNotify2, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify2>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession2>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession2(eSessionType, (IMFMediaKeySessionNotify2*) pMFMediaKeySessionNotify2.Handle, (IMFMediaKeySession2**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int CreateSession2<TI0>(MF_MEDIAKEYSESSION_TYPE eSessionType, ComPtr<TI0> pMFMediaKeySessionNotify2, ref IMFMediaKeySession2* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify2>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession2(eSessionType, (IMFMediaKeySessionNotify2*) pMFMediaKeySessionNotify2.Handle, ref ppSession);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int CreateSession2<TI0>(MF_MEDIAKEYSESSION_TYPE eSessionType, ref IMFMediaKeySessionNotify2 pMFMediaKeySessionNotify2, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession2>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->CreateSession2(eSessionType, ref pMFMediaKeySessionNotify2, (IMFMediaKeySession2**) ppSession.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaKeys2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaSourceExtension.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaSourceExtension.gen.cs
@@ -1,0 +1,492 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("e467b94e-a713-4562-a802-816a42e9008a")]
+    [NativeName("Name", "IMFMediaSourceExtension")]
+    public unsafe partial struct IMFMediaSourceExtension : IComVtbl<IMFMediaSourceExtension>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("e467b94e-a713-4562-a802-816a42e9008a");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaSourceExtension val)
+            => Unsafe.As<IMFMediaSourceExtension, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaSourceExtension
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe IMFSourceBufferList* GetSourceBuffers()
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            IMFSourceBufferList* ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, IMFSourceBufferList*>)@this->LpVtbl[3])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe IMFSourceBufferList* GetActiveSourceBuffers()
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            IMFSourceBufferList* ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, IMFSourceBufferList*>)@this->LpVtbl[4])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly MseReady GetReadyState()
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            MseReady ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, MseReady>)@this->LpVtbl[5])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetDuration()
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, double>)@this->LpVtbl[6])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetDuration(double duration)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, double, int>)@this->LpVtbl[7])(@this, duration);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer(char* type, IMFSourceBufferNotify* pNotify, IMFSourceBuffer** ppSourceBuffer)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, type, pNotify, ppSourceBuffer);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer(char* type, IMFSourceBufferNotify* pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFSourceBuffer** ppSourceBufferPtr = &ppSourceBuffer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, type, pNotify, ppSourceBufferPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer(char* type, ref IMFSourceBufferNotify pNotify, IMFSourceBuffer** ppSourceBuffer)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFSourceBufferNotify* pNotifyPtr = &pNotify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, type, pNotifyPtr, ppSourceBuffer);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer(char* type, ref IMFSourceBufferNotify pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFSourceBufferNotify* pNotifyPtr = &pNotify)
+            {
+                fixed (IMFSourceBuffer** ppSourceBufferPtr = &ppSourceBuffer)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, type, pNotifyPtr, ppSourceBufferPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer(ref char type, IMFSourceBufferNotify* pNotify, IMFSourceBuffer** ppSourceBuffer)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotify, ppSourceBuffer);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer(ref char type, IMFSourceBufferNotify* pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                fixed (IMFSourceBuffer** ppSourceBufferPtr = &ppSourceBuffer)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotify, ppSourceBufferPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer(ref char type, ref IMFSourceBufferNotify pNotify, IMFSourceBuffer** ppSourceBuffer)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                fixed (IMFSourceBufferNotify* pNotifyPtr = &pNotify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotifyPtr, ppSourceBuffer);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer(ref char type, ref IMFSourceBufferNotify pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* typePtr = &type)
+            {
+                fixed (IMFSourceBufferNotify* pNotifyPtr = &pNotify)
+                {
+                    fixed (IMFSourceBuffer** ppSourceBufferPtr = &ppSourceBuffer)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotifyPtr, ppSourceBufferPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, IMFSourceBufferNotify* pNotify, IMFSourceBuffer** ppSourceBuffer)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, byte*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotify, ppSourceBuffer);
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, IMFSourceBufferNotify* pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            fixed (IMFSourceBuffer** ppSourceBufferPtr = &ppSourceBuffer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, byte*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotify, ppSourceBufferPtr);
+            }
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref IMFSourceBufferNotify pNotify, IMFSourceBuffer** ppSourceBuffer)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            fixed (IMFSourceBufferNotify* pNotifyPtr = &pNotify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, byte*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotifyPtr, ppSourceBuffer);
+            }
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref IMFSourceBufferNotify pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            fixed (IMFSourceBufferNotify* pNotifyPtr = &pNotify)
+            {
+                fixed (IMFSourceBuffer** ppSourceBufferPtr = &ppSourceBuffer)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, byte*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotifyPtr, ppSourceBufferPtr);
+                }
+            }
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int RemoveSourceBuffer(IMFSourceBuffer* pSourceBuffer)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, IMFSourceBuffer*, int>)@this->LpVtbl[9])(@this, pSourceBuffer);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int RemoveSourceBuffer(ref IMFSourceBuffer pSourceBuffer)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFSourceBuffer* pSourceBufferPtr = &pSourceBuffer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, IMFSourceBuffer*, int>)@this->LpVtbl[9])(@this, pSourceBufferPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetEndOfStream(MseError error)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, MseError, int>)@this->LpVtbl[10])(@this, error);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe Silk.NET.Core.Bool32 IsTypeSupported(char* type)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, Silk.NET.Core.Bool32>)@this->LpVtbl[11])(@this, type);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 IsTypeSupported(ref char type)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            fixed (char* typePtr = &type)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, Silk.NET.Core.Bool32>)@this->LpVtbl[11])(@this, typePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 IsTypeSupported([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, byte*, Silk.NET.Core.Bool32>)@this->LpVtbl[11])(@this, typePtr);
+            SilkMarshal.Free((nint)typePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe IMFSourceBuffer* GetSourceBuffer(uint dwStreamIndex)
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            IMFSourceBuffer* ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, uint, IMFSourceBuffer*>)@this->LpVtbl[12])(@this, dwStreamIndex);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer<TI0, TI1>(char* type, ComPtr<TI0> pNotify, ref ComPtr<TI1> ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBufferNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFSourceBuffer>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddSourceBuffer(type, (IMFSourceBufferNotify*) pNotify.Handle, (IMFSourceBuffer**) ppSourceBuffer.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer<TI0>(char* type, ComPtr<TI0> pNotify, ref IMFSourceBuffer* ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBufferNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddSourceBuffer(type, (IMFSourceBufferNotify*) pNotify.Handle, ref ppSourceBuffer);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer<TI0>(char* type, ref IMFSourceBufferNotify pNotify, ref ComPtr<TI0> ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBuffer>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddSourceBuffer(type, ref pNotify, (IMFSourceBuffer**) ppSourceBuffer.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddSourceBuffer<TI0, TI1>(ref char type, ComPtr<TI0> pNotify, ref ComPtr<TI1> ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBufferNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFSourceBuffer>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddSourceBuffer(ref type, (IMFSourceBufferNotify*) pNotify.Handle, (IMFSourceBuffer**) ppSourceBuffer.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer<TI0>(ref char type, ComPtr<TI0> pNotify, ref IMFSourceBuffer* ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBufferNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddSourceBuffer(ref type, (IMFSourceBufferNotify*) pNotify.Handle, ref ppSourceBuffer);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddSourceBuffer<TI0>(ref char type, ref IMFSourceBufferNotify pNotify, ref ComPtr<TI0> ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBuffer>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddSourceBuffer(ref type, ref pNotify, (IMFSourceBuffer**) ppSourceBuffer.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddSourceBuffer<TI0, TI1>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ComPtr<TI0> pNotify, ref ComPtr<TI1> ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBufferNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFSourceBuffer>, IComVtbl<TI1>
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddSourceBuffer(type, (IMFSourceBufferNotify*) pNotify.Handle, (IMFSourceBuffer**) ppSourceBuffer.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddSourceBuffer<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ComPtr<TI0> pNotify, ref IMFSourceBuffer* ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBufferNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddSourceBuffer(type, (IMFSourceBufferNotify*) pNotify.Handle, ref ppSourceBuffer);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddSourceBuffer<TI0>([UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref IMFSourceBufferNotify pNotify, ref ComPtr<TI0> ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBuffer>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddSourceBuffer(type, ref pNotify, (IMFSourceBuffer**) ppSourceBuffer.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int RemoveSourceBuffer<TI0>(ComPtr<TI0> pSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBuffer>, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->RemoveSourceBuffer((IMFSourceBuffer*) pSourceBuffer.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaSourceExtension*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaSourceExtensionLiveSeekableRange.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaSourceExtensionLiveSeekableRange.gen.cs
@@ -1,0 +1,150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("5d1abfd6-450a-4d92-9efc-d6b6cbc1f4da")]
+    [NativeName("Name", "IMFMediaSourceExtensionLiveSeekableRange")]
+    public unsafe partial struct IMFMediaSourceExtensionLiveSeekableRange : IComVtbl<IMFMediaSourceExtensionLiveSeekableRange>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("5d1abfd6-450a-4d92-9efc-d6b6cbc1f4da");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaSourceExtensionLiveSeekableRange val)
+            => Unsafe.As<IMFMediaSourceExtensionLiveSeekableRange, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaSourceExtensionLiveSeekableRange
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaSourceExtensionLiveSeekableRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaSourceExtensionLiveSeekableRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaSourceExtensionLiveSeekableRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaSourceExtensionLiveSeekableRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaSourceExtensionLiveSeekableRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaSourceExtensionLiveSeekableRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetLiveSeekableRange(double start, double end)
+        {
+            var @this = (IMFMediaSourceExtensionLiveSeekableRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, double, double, int>)@this->LpVtbl[3])(@this, start, end);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int ClearLiveSeekableRange()
+        {
+            var @this = (IMFMediaSourceExtensionLiveSeekableRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, int>)@this->LpVtbl[4])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaSourceExtensionLiveSeekableRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaSourceExtensionLiveSeekableRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaSourceExtensionNotify.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaSourceExtensionNotify.gen.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("a7901327-05dd-4469-a7b7-0e01979e361d")]
+    [NativeName("Name", "IMFMediaSourceExtensionNotify")]
+    public unsafe partial struct IMFMediaSourceExtensionNotify : IComVtbl<IMFMediaSourceExtensionNotify>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("a7901327-05dd-4469-a7b7-0e01979e361d");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaSourceExtensionNotify val)
+            => Unsafe.As<IMFMediaSourceExtensionNotify, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaSourceExtensionNotify
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaSourceExtensionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaSourceExtensionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaSourceExtensionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaSourceExtensionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaSourceExtensionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaSourceExtensionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void OnSourceOpen()
+        {
+            var @this = (IMFMediaSourceExtensionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, void>)@this->LpVtbl[3])(@this);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void OnSourceEnded()
+        {
+            var @this = (IMFMediaSourceExtensionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, void>)@this->LpVtbl[4])(@this);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void OnSourceClose()
+        {
+            var @this = (IMFMediaSourceExtensionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, void>)@this->LpVtbl[5])(@this);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaSourceExtensionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaSourceExtensionNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaTimeRange.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFMediaTimeRange.gen.cs
@@ -1,0 +1,210 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("db71a2fc-078a-414e-9df9-8c2531b0aa6c")]
+    [NativeName("Name", "IMFMediaTimeRange")]
+    public unsafe partial struct IMFMediaTimeRange : IComVtbl<IMFMediaTimeRange>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("db71a2fc-078a-414e-9df9-8c2531b0aa6c");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFMediaTimeRange val)
+            => Unsafe.As<IMFMediaTimeRange, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFMediaTimeRange
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint GetLength()
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, uint>)@this->LpVtbl[3])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetStart(uint index, double* pStart)
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, uint, double*, int>)@this->LpVtbl[4])(@this, index, pStart);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetStart(uint index, ref double pStart)
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pStartPtr = &pStart)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, uint, double*, int>)@this->LpVtbl[4])(@this, index, pStartPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetEnd(uint index, double* pEnd)
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, uint, double*, int>)@this->LpVtbl[5])(@this, index, pEnd);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetEnd(uint index, ref double pEnd)
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pEndPtr = &pEnd)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, uint, double*, int>)@this->LpVtbl[5])(@this, index, pEndPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 ContainsTime(double time)
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, double, Silk.NET.Core.Bool32>)@this->LpVtbl[6])(@this, time);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddRange(double startTime, double endTime)
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, double, double, int>)@this->LpVtbl[7])(@this, startTime, endTime);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Clear()
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, int>)@this->LpVtbl[8])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFMediaTimeRange*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFSourceBuffer.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFSourceBuffer.gen.cs
@@ -1,0 +1,322 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("e2cd3a4b-af25-4d3d-9110-da0e6f8ee877")]
+    [NativeName("Name", "IMFSourceBuffer")]
+    public unsafe partial struct IMFSourceBuffer : IComVtbl<IMFSourceBuffer>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("e2cd3a4b-af25-4d3d-9110-da0e6f8ee877");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFSourceBuffer val)
+            => Unsafe.As<IMFSourceBuffer, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFSourceBuffer
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 GetUpdating()
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, Silk.NET.Core.Bool32>)@this->LpVtbl[3])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetBuffered(IMFMediaTimeRange** ppBuffered)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, IMFMediaTimeRange**, int>)@this->LpVtbl[4])(@this, ppBuffered);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetBuffered(ref IMFMediaTimeRange* ppBuffered)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFMediaTimeRange** ppBufferedPtr = &ppBuffered)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, IMFMediaTimeRange**, int>)@this->LpVtbl[4])(@this, ppBufferedPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetTimeStampOffset()
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, double>)@this->LpVtbl[5])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetTimeStampOffset(double offset)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, double, int>)@this->LpVtbl[6])(@this, offset);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetAppendWindowStart()
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, double>)@this->LpVtbl[7])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetAppendWindowStart(double time)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, double, int>)@this->LpVtbl[8])(@this, time);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetAppendWindowEnd()
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, double>)@this->LpVtbl[9])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetAppendWindowEnd(double time)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, double, int>)@this->LpVtbl[10])(@this, time);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int Append([Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pData, uint len)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, byte*, uint, int>)@this->LpVtbl[11])(@this, pData, len);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Append([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pData, uint len)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* pDataPtr = &pData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, byte*, uint, int>)@this->LpVtbl[11])(@this, pDataPtr, len);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Append([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pData, uint len)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var pDataPtr = (byte*) SilkMarshal.StringToPtr(pData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, byte*, uint, int>)@this->LpVtbl[11])(@this, pDataPtr, len);
+            SilkMarshal.Free((nint)pDataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AppendByteStream(IMFByteStream* pStream, ulong* pMaxLen)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, IMFByteStream*, ulong*, int>)@this->LpVtbl[12])(@this, pStream, pMaxLen);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AppendByteStream(IMFByteStream* pStream, ref ulong pMaxLen)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (ulong* pMaxLenPtr = &pMaxLen)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, IMFByteStream*, ulong*, int>)@this->LpVtbl[12])(@this, pStream, pMaxLenPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AppendByteStream(ref IMFByteStream pStream, ulong* pMaxLen)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pStreamPtr = &pStream)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, IMFByteStream*, ulong*, int>)@this->LpVtbl[12])(@this, pStreamPtr, pMaxLen);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AppendByteStream(ref IMFByteStream pStream, ref ulong pMaxLen)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* pStreamPtr = &pStream)
+            {
+                fixed (ulong* pMaxLenPtr = &pMaxLen)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, IMFByteStream*, ulong*, int>)@this->LpVtbl[12])(@this, pStreamPtr, pMaxLenPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Abort()
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, int>)@this->LpVtbl[13])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int Remove(double start, double end)
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, double, double, int>)@this->LpVtbl[14])(@this, start, end);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetBuffered<TI0>(ref ComPtr<TI0> ppBuffered) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetBuffered((IMFMediaTimeRange**) ppBuffered.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFSourceBuffer*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFSourceBufferAppendMode.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFSourceBufferAppendMode.gen.cs
@@ -1,0 +1,150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("19666fb4-babe-4c55-bc03-0a074da37e2a")]
+    [NativeName("Name", "IMFSourceBufferAppendMode")]
+    public unsafe partial struct IMFSourceBufferAppendMode : IComVtbl<IMFSourceBufferAppendMode>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("19666fb4-babe-4c55-bc03-0a074da37e2a");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFSourceBufferAppendMode val)
+            => Unsafe.As<IMFSourceBufferAppendMode, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFSourceBufferAppendMode
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFSourceBufferAppendMode*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFSourceBufferAppendMode*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFSourceBufferAppendMode*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFSourceBufferAppendMode*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFSourceBufferAppendMode*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFSourceBufferAppendMode*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly MseAppendMode GetAppendMode()
+        {
+            var @this = (IMFSourceBufferAppendMode*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            MseAppendMode ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, MseAppendMode>)@this->LpVtbl[3])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetAppendMode(MseAppendMode mode)
+        {
+            var @this = (IMFSourceBufferAppendMode*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, MseAppendMode, int>)@this->LpVtbl[4])(@this, mode);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFSourceBufferAppendMode*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFSourceBufferAppendMode*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFSourceBufferList.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFSourceBufferList.gen.cs
@@ -1,0 +1,150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("249981f8-8325-41f3-b80c-3b9e3aad0cbe")]
+    [NativeName("Name", "IMFSourceBufferList")]
+    public unsafe partial struct IMFSourceBufferList : IComVtbl<IMFSourceBufferList>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("249981f8-8325-41f3-b80c-3b9e3aad0cbe");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFSourceBufferList val)
+            => Unsafe.As<IMFSourceBufferList, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFSourceBufferList
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFSourceBufferList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFSourceBufferList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFSourceBufferList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFSourceBufferList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFSourceBufferList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFSourceBufferList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint GetLength()
+        {
+            var @this = (IMFSourceBufferList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, uint>)@this->LpVtbl[3])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe IMFSourceBuffer* GetSourceBuffer(uint index)
+        {
+            var @this = (IMFSourceBufferList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            IMFSourceBuffer* ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, uint, IMFSourceBuffer*>)@this->LpVtbl[4])(@this, index);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFSourceBufferList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFSourceBufferList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFSourceBufferNotify.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFSourceBufferNotify.gen.cs
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("87e47623-2ceb-45d6-9b88-d8520c4dcbbc")]
+    [NativeName("Name", "IMFSourceBufferNotify")]
+    public unsafe partial struct IMFSourceBufferNotify : IComVtbl<IMFSourceBufferNotify>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("87e47623-2ceb-45d6-9b88-d8520c4dcbbc");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFSourceBufferNotify val)
+            => Unsafe.As<IMFSourceBufferNotify, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFSourceBufferNotify
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFSourceBufferNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFSourceBufferNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFSourceBufferNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFSourceBufferNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFSourceBufferNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFSourceBufferNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void OnUpdateStart()
+        {
+            var @this = (IMFSourceBufferNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, void>)@this->LpVtbl[3])(@this);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void OnAbort()
+        {
+            var @this = (IMFSourceBufferNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, void>)@this->LpVtbl[4])(@this);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void OnError(int hr)
+        {
+            var @this = (IMFSourceBufferNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, int, void>)@this->LpVtbl[5])(@this, hr);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void OnUpdate()
+        {
+            var @this = (IMFSourceBufferNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, void>)@this->LpVtbl[6])(@this);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void OnUpdateEnd()
+        {
+            var @this = (IMFSourceBufferNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, void>)@this->LpVtbl[7])(@this);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFSourceBufferNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFSourceBufferNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedText.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedText.gen.cs
@@ -1,0 +1,2073 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("1f2a94c9-a3df-430d-9d0f-acd85ddc29af")]
+    [NativeName("Name", "IMFTimedText")]
+    public unsafe partial struct IMFTimedText : IComVtbl<IMFTimedText>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("1f2a94c9-a3df-430d-9d0f-acd85ddc29af");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFTimedText val)
+            => Unsafe.As<IMFTimedText, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFTimedText
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int RegisterNotifications(IMFTimedTextNotify* notify)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextNotify*, int>)@this->LpVtbl[3])(@this, notify);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int RegisterNotifications(ref IMFTimedTextNotify notify)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextNotify*, int>)@this->LpVtbl[3])(@this, notifyPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SelectTrack(uint trackId, Silk.NET.Core.Bool32 selected)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, uint, Silk.NET.Core.Bool32, int>)@this->LpVtbl[4])(@this, trackId, selected);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, label, language, kind, isDefault, trackId);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, label, language, kind, isDefault, trackIdPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, label, languagePtr, kind, isDefault, trackId);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* languagePtr = &language)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, label, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, label, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, label, languagePtr, kind, isDefault, trackIdPtr);
+            }
+            SilkMarshal.Free((nint)languagePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, language, kind, isDefault, trackId);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, language, kind, isDefault, trackIdPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackId);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    fixed (uint* trackIdPtr = &trackId)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            SilkMarshal.Free((nint)languagePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, language, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, language, kind, isDefault, trackIdPtr);
+            }
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackId);
+            }
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (char* languagePtr = &language)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            }
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+            }
+            SilkMarshal.Free((nint)languagePtr);
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, label, language, kind, isDefault, trackId);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, label, language, kind, isDefault, trackIdPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, label, languagePtr, kind, isDefault, trackId);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    fixed (uint* trackIdPtr = &trackId)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, label, languagePtr, kind, isDefault, trackIdPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, label, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, label, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            SilkMarshal.Free((nint)languagePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+                fixed (char* labelPtr = &label)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, language, kind, isDefault, trackId);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+                fixed (char* labelPtr = &label)
+                {
+                    fixed (uint* trackIdPtr = &trackId)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, language, kind, isDefault, trackIdPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+                fixed (char* labelPtr = &label)
+                {
+                    fixed (char* languagePtr = &language)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+                fixed (char* labelPtr = &label)
+                {
+                    fixed (char* languagePtr = &language)
+                    {
+                        fixed (uint* trackIdPtr = &trackId)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+                fixed (char* labelPtr = &label)
+                {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+                fixed (char* labelPtr = &label)
+                {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                    fixed (uint* trackIdPtr = &trackId)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                    }
+            SilkMarshal.Free((nint)languagePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, language, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)labelPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, language, kind, isDefault, trackIdPtr);
+                }
+            SilkMarshal.Free((nint)labelPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+                fixed (char* languagePtr = &language)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+                }
+            SilkMarshal.Free((nint)labelPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+                fixed (char* languagePtr = &language)
+                {
+                    fixed (uint* trackIdPtr = &trackId)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)labelPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+            SilkMarshal.Free((nint)labelPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddDataSource(ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFByteStream* byteStreamPtr = &byteStream)
+            {
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            SilkMarshal.Free((nint)languagePtr);
+            SilkMarshal.Free((nint)labelPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, label, language, kind, isDefault, trackId);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, label, language, kind, isDefault, trackIdPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, label, languagePtr, kind, isDefault, trackId);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* languagePtr = &language)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, label, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, label, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, label, languagePtr, kind, isDefault, trackIdPtr);
+            }
+            SilkMarshal.Free((nint)languagePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, language, kind, isDefault, trackId);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, language, kind, isDefault, trackIdPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackId);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    fixed (uint* trackIdPtr = &trackId)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            SilkMarshal.Free((nint)languagePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, language, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, language, kind, isDefault, trackIdPtr);
+            }
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackId);
+            }
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (char* languagePtr = &language)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            }
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+            }
+            SilkMarshal.Free((nint)languagePtr);
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, language, kind, isDefault, trackId);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, language, kind, isDefault, trackIdPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackId);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    fixed (uint* trackIdPtr = &trackId)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackIdPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            SilkMarshal.Free((nint)languagePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+                fixed (char* labelPtr = &label)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackId);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+                fixed (char* labelPtr = &label)
+                {
+                    fixed (uint* trackIdPtr = &trackId)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackIdPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+                fixed (char* labelPtr = &label)
+                {
+                    fixed (char* languagePtr = &language)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+                fixed (char* labelPtr = &label)
+                {
+                    fixed (char* languagePtr = &language)
+                    {
+                        fixed (uint* trackIdPtr = &trackId)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+                fixed (char* labelPtr = &label)
+                {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+                fixed (char* labelPtr = &label)
+                {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                    fixed (uint* trackIdPtr = &trackId)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                    }
+            SilkMarshal.Free((nint)languagePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)labelPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackIdPtr);
+                }
+            SilkMarshal.Free((nint)labelPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+                fixed (char* languagePtr = &language)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+                }
+            SilkMarshal.Free((nint)labelPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+                fixed (char* languagePtr = &language)
+                {
+                    fixed (uint* trackIdPtr = &trackId)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                    }
+                }
+            SilkMarshal.Free((nint)labelPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+            SilkMarshal.Free((nint)labelPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* urlPtr = &url)
+            {
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            SilkMarshal.Free((nint)languagePtr);
+            SilkMarshal.Free((nint)labelPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, language, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, language, kind, isDefault, trackIdPtr);
+            }
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackId);
+            }
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            fixed (char* languagePtr = &language)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            }
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackIdPtr);
+            }
+            SilkMarshal.Free((nint)languagePtr);
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            fixed (char* labelPtr = &label)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackId);
+            }
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            fixed (char* labelPtr = &label)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackIdPtr);
+                }
+            }
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            fixed (char* labelPtr = &label)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+                }
+            }
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            fixed (char* labelPtr = &label)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    fixed (uint* trackIdPtr = &trackId)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                    }
+                }
+            }
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            fixed (char* labelPtr = &label)
+            {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+            }
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            fixed (char* labelPtr = &label)
+            {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            SilkMarshal.Free((nint)languagePtr);
+            }
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)labelPtr);
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackIdPtr);
+            }
+            SilkMarshal.Free((nint)labelPtr);
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+            }
+            SilkMarshal.Free((nint)labelPtr);
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (char* languagePtr = &language)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            }
+            SilkMarshal.Free((nint)labelPtr);
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+            SilkMarshal.Free((nint)languagePtr);
+            SilkMarshal.Free((nint)labelPtr);
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddDataSourceFromUrl([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+            }
+            SilkMarshal.Free((nint)languagePtr);
+            SilkMarshal.Free((nint)labelPtr);
+            SilkMarshal.Free((nint)urlPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, label, language, kind, track);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextTrack** trackPtr = &track)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, label, language, kind, trackPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, label, languagePtr, kind, track);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* languagePtr = &language)
+            {
+                fixed (IMFTimedTextTrack** trackPtr = &track)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, label, languagePtr, kind, trackPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, label, languagePtr, kind, track);
+            SilkMarshal.Free((nint)languagePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (IMFTimedTextTrack** trackPtr = &track)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, label, languagePtr, kind, trackPtr);
+            }
+            SilkMarshal.Free((nint)languagePtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, language, kind, track);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+                fixed (IMFTimedTextTrack** trackPtr = &track)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, language, kind, trackPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, track);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    fixed (IMFTimedTextTrack** trackPtr = &track)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, trackPtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, track);
+            SilkMarshal.Free((nint)languagePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                fixed (IMFTimedTextTrack** trackPtr = &track)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, trackPtr);
+                }
+            SilkMarshal.Free((nint)languagePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, language, kind, track);
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (IMFTimedTextTrack** trackPtr = &track)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, language, kind, trackPtr);
+            }
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, track);
+            }
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (char* languagePtr = &language)
+            {
+                fixed (IMFTimedTextTrack** trackPtr = &track)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, trackPtr);
+                }
+            }
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, track);
+            SilkMarshal.Free((nint)languagePtr);
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (IMFTimedTextTrack** trackPtr = &track)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, trackPtr);
+            }
+            SilkMarshal.Free((nint)languagePtr);
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int RemoveTrack(IMFTimedTextTrack* track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrack*, int>)@this->LpVtbl[8])(@this, track);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int RemoveTrack(ref IMFTimedTextTrack track)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextTrack* trackPtr = &track)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrack*, int>)@this->LpVtbl[8])(@this, trackPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCueTimeOffset(double* offset)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, double*, int>)@this->LpVtbl[9])(@this, offset);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetCueTimeOffset(ref double offset)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* offsetPtr = &offset)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, double*, int>)@this->LpVtbl[9])(@this, offsetPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetCueTimeOffset(double offset)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, double, int>)@this->LpVtbl[10])(@this, offset);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTracks(IMFTimedTextTrackList** tracks)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[11])(@this, tracks);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTracks(ref IMFTimedTextTrackList* tracks)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextTrackList** tracksPtr = &tracks)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[11])(@this, tracksPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetActiveTracks(IMFTimedTextTrackList** activeTracks)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[12])(@this, activeTracks);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetActiveTracks(ref IMFTimedTextTrackList* activeTracks)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextTrackList** activeTracksPtr = &activeTracks)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[12])(@this, activeTracksPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextTracks(IMFTimedTextTrackList** textTracks)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[13])(@this, textTracks);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextTracks(ref IMFTimedTextTrackList* textTracks)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextTrackList** textTracksPtr = &textTracks)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[13])(@this, textTracksPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetMetadataTracks(IMFTimedTextTrackList** metadataTracks)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[14])(@this, metadataTracks);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetMetadataTracks(ref IMFTimedTextTrackList* metadataTracks)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextTrackList** metadataTracksPtr = &metadataTracks)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[14])(@this, metadataTracksPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetInBandEnabled(Silk.NET.Core.Bool32 enabled)
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[15])(@this, enabled);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 IsInBandEnabled()
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, Silk.NET.Core.Bool32>)@this->LpVtbl[16])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int RegisterNotifications<TI0>(ComPtr<TI0> notify) where TI0 : unmanaged, IComVtbl<IMFTimedTextNotify>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->RegisterNotifications((IMFTimedTextNotify*) notify.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddTrack(label, language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddTrack(label, in language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddTrack(label, language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddTrack(in label, language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddTrack<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddTrack(in label, in language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddTrack<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddTrack(in label, language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTrack<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddTrack(label, language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddTrack<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddTrack(label, in language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddTrack<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddTrack(label, language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int RemoveTrack<TI0>(ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->RemoveTrack((IMFTimedTextTrack*) track.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetTracks<TI0>(ref ComPtr<TI0> tracks) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrackList>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetTracks((IMFTimedTextTrackList**) tracks.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetActiveTracks<TI0>(ref ComPtr<TI0> activeTracks) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrackList>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetActiveTracks((IMFTimedTextTrackList**) activeTracks.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetTextTracks<TI0>(ref ComPtr<TI0> textTracks) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrackList>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetTextTracks((IMFTimedTextTrackList**) textTracks.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetMetadataTracks<TI0>(ref ComPtr<TI0> metadataTracks) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrackList>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetMetadataTracks((IMFTimedTextTrackList**) metadataTracks.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextBinary.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextBinary.gen.cs
@@ -1,0 +1,204 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("4ae3a412-0545-43c4-bf6f-6b97a5c6c432")]
+    [NativeName("Name", "IMFTimedTextBinary")]
+    public unsafe partial struct IMFTimedTextBinary : IComVtbl<IMFTimedTextBinary>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("4ae3a412-0545-43c4-bf6f-6b97a5c6c432");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFTimedTextBinary val)
+            => Unsafe.As<IMFTimedTextBinary, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFTimedTextBinary
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextBinary*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextBinary*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextBinary*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextBinary*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFTimedTextBinary*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFTimedTextBinary*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetData([Flow(Silk.NET.Core.Native.FlowDirection.In)] byte** data, uint* length)
+        {
+            var @this = (IMFTimedTextBinary*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, byte**, uint*, int>)@this->LpVtbl[3])(@this, data, length);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetData([Flow(Silk.NET.Core.Native.FlowDirection.In)] byte** data, ref uint length)
+        {
+            var @this = (IMFTimedTextBinary*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* lengthPtr = &length)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, byte**, uint*, int>)@this->LpVtbl[3])(@this, data, lengthPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetData([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte* data, uint* length)
+        {
+            var @this = (IMFTimedTextBinary*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte** dataPtr = &data)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, byte**, uint*, int>)@this->LpVtbl[3])(@this, dataPtr, length);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetData([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte* data, ref uint length)
+        {
+            var @this = (IMFTimedTextBinary*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte** dataPtr = &data)
+            {
+                fixed (uint* lengthPtr = &length)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, byte**, uint*, int>)@this->LpVtbl[3])(@this, dataPtr, lengthPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextBinary*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetData([Flow(Silk.NET.Core.Native.FlowDirection.In)] string[] dataSa, uint* length)
+        {
+            var @this = (IMFTimedTextBinary*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var data = (byte**) SilkMarshal.StringArrayToPtr(dataSa);
+            var ret = @this->GetData(data, length);
+            SilkMarshal.CopyPtrToStringArray((nint) data, dataSa);
+            SilkMarshal.Free((nint) data);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetData([Flow(Silk.NET.Core.Native.FlowDirection.In)] string[] dataSa, ref uint length)
+        {
+            var @this = (IMFTimedTextBinary*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var data = (byte**) SilkMarshal.StringArrayToPtr(dataSa);
+            var ret = @this->GetData(data, ref length);
+            SilkMarshal.CopyPtrToStringArray((nint) data, dataSa);
+            SilkMarshal.Free((nint) data);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextBinary*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextBouten.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextBouten.gen.cs
@@ -1,0 +1,195 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("3c5f3e8a-90c0-464e-8136-898d2975f847")]
+    [NativeName("Name", "IMFTimedTextBouten")]
+    public unsafe partial struct IMFTimedTextBouten : IComVtbl<IMFTimedTextBouten>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("3c5f3e8a-90c0-464e-8136-898d2975f847");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFTimedTextBouten val)
+            => Unsafe.As<IMFTimedTextBouten, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFTimedTextBouten
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextBouten*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextBouten*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextBouten*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextBouten*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFTimedTextBouten*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFTimedTextBouten*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetBoutenType(TimedTextBoutenType* value)
+        {
+            var @this = (IMFTimedTextBouten*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, TimedTextBoutenType*, int>)@this->LpVtbl[3])(@this, value);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetBoutenType(ref TimedTextBoutenType value)
+        {
+            var @this = (IMFTimedTextBouten*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextBoutenType* valuePtr = &value)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, TimedTextBoutenType*, int>)@this->LpVtbl[3])(@this, valuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetBoutenColor(_MFARGB* value)
+        {
+            var @this = (IMFTimedTextBouten*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, _MFARGB*, int>)@this->LpVtbl[4])(@this, value);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetBoutenColor(ref _MFARGB value)
+        {
+            var @this = (IMFTimedTextBouten*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* valuePtr = &value)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, _MFARGB*, int>)@this->LpVtbl[4])(@this, valuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetBoutenPosition(TimedTextBoutenPosition* value)
+        {
+            var @this = (IMFTimedTextBouten*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, TimedTextBoutenPosition*, int>)@this->LpVtbl[5])(@this, value);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetBoutenPosition(ref TimedTextBoutenPosition value)
+        {
+            var @this = (IMFTimedTextBouten*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextBoutenPosition* valuePtr = &value)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, TimedTextBoutenPosition*, int>)@this->LpVtbl[5])(@this, valuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextBouten*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextBouten*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextCue.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextCue.gen.cs
@@ -1,0 +1,335 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("1e560447-9a2b-43e1-a94c-b0aaabfbfbc9")]
+    [NativeName("Name", "IMFTimedTextCue")]
+    public unsafe partial struct IMFTimedTextCue : IComVtbl<IMFTimedTextCue>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("1e560447-9a2b-43e1-a94c-b0aaabfbfbc9");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFTimedTextCue val)
+            => Unsafe.As<IMFTimedTextCue, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFTimedTextCue
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint GetId()
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, uint>)@this->LpVtbl[3])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetOriginalId(char** originalId)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, char**, int>)@this->LpVtbl[4])(@this, originalId);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetOriginalId(ref char* originalId)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** originalIdPtr = &originalId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, char**, int>)@this->LpVtbl[4])(@this, originalIdPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly TimedTextTrackKind GetCueKind()
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            TimedTextTrackKind ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, TimedTextTrackKind>)@this->LpVtbl[5])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetStartTime()
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, double>)@this->LpVtbl[6])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly double GetDuration()
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            double ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, double>)@this->LpVtbl[7])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint GetTrackId()
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, uint>)@this->LpVtbl[8])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetData(IMFTimedTextBinary** data)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, IMFTimedTextBinary**, int>)@this->LpVtbl[9])(@this, data);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetData(ref IMFTimedTextBinary* data)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextBinary** dataPtr = &data)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, IMFTimedTextBinary**, int>)@this->LpVtbl[9])(@this, dataPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetRegion(IMFTimedTextRegion** region)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, IMFTimedTextRegion**, int>)@this->LpVtbl[10])(@this, region);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetRegion(ref IMFTimedTextRegion* region)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextRegion** regionPtr = &region)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, IMFTimedTextRegion**, int>)@this->LpVtbl[10])(@this, regionPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetStyle(IMFTimedTextStyle** style)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, IMFTimedTextStyle**, int>)@this->LpVtbl[11])(@this, style);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetStyle(ref IMFTimedTextStyle* style)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextStyle** stylePtr = &style)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, IMFTimedTextStyle**, int>)@this->LpVtbl[11])(@this, stylePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint GetLineCount()
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, uint>)@this->LpVtbl[12])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetLine(uint index, IMFTimedTextFormattedText** line)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, uint, IMFTimedTextFormattedText**, int>)@this->LpVtbl[13])(@this, index, line);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetLine(uint index, ref IMFTimedTextFormattedText* line)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextFormattedText** linePtr = &line)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, uint, IMFTimedTextFormattedText**, int>)@this->LpVtbl[13])(@this, index, linePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetOriginalId(string[] originalIdSa)
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var originalId = (char**) SilkMarshal.StringArrayToPtr(originalIdSa);
+            var ret = @this->GetOriginalId(originalId);
+            SilkMarshal.CopyPtrToStringArray((nint) originalId, originalIdSa);
+            SilkMarshal.Free((nint) originalId);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetData<TI0>(ref ComPtr<TI0> data) where TI0 : unmanaged, IComVtbl<IMFTimedTextBinary>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetData((IMFTimedTextBinary**) data.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetRegion<TI0>(ref ComPtr<TI0> region) where TI0 : unmanaged, IComVtbl<IMFTimedTextRegion>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetRegion((IMFTimedTextRegion**) region.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetStyle<TI0>(ref ComPtr<TI0> style) where TI0 : unmanaged, IComVtbl<IMFTimedTextStyle>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetStyle((IMFTimedTextStyle**) style.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetLine<TI0>(uint index, ref ComPtr<TI0> line) where TI0 : unmanaged, IComVtbl<IMFTimedTextFormattedText>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetLine(index, (IMFTimedTextFormattedText**) line.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCue*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextCueList.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextCueList.gen.cs
@@ -1,0 +1,519 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("ad128745-211b-40a0-9981-fe65f166d0fd")]
+    [NativeName("Name", "IMFTimedTextCueList")]
+    public unsafe partial struct IMFTimedTextCueList : IComVtbl<IMFTimedTextCueList>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("ad128745-211b-40a0-9981-fe65f166d0fd");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFTimedTextCueList val)
+            => Unsafe.As<IMFTimedTextCueList, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFTimedTextCueList
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint GetLength()
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, uint>)@this->LpVtbl[3])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCueByIndex(uint index, IMFTimedTextCue** cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[4])(@this, index, cue);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCueByIndex(uint index, ref IMFTimedTextCue* cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextCue** cuePtr = &cue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[4])(@this, index, cuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCueById(uint id, IMFTimedTextCue** cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[5])(@this, id, cue);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCueById(uint id, ref IMFTimedTextCue* cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextCue** cuePtr = &cue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[5])(@this, id, cuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCueByOriginalId([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* originalId, IMFTimedTextCue** cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, char*, IMFTimedTextCue**, int>)@this->LpVtbl[6])(@this, originalId, cue);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCueByOriginalId([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* originalId, ref IMFTimedTextCue* cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextCue** cuePtr = &cue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, char*, IMFTimedTextCue**, int>)@this->LpVtbl[6])(@this, originalId, cuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCueByOriginalId([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char originalId, IMFTimedTextCue** cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* originalIdPtr = &originalId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, char*, IMFTimedTextCue**, int>)@this->LpVtbl[6])(@this, originalIdPtr, cue);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCueByOriginalId([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char originalId, ref IMFTimedTextCue* cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* originalIdPtr = &originalId)
+            {
+                fixed (IMFTimedTextCue** cuePtr = &cue)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, char*, IMFTimedTextCue**, int>)@this->LpVtbl[6])(@this, originalIdPtr, cuePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCueByOriginalId([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string originalId, IMFTimedTextCue** cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var originalIdPtr = (byte*) SilkMarshal.StringToPtr(originalId, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, byte*, IMFTimedTextCue**, int>)@this->LpVtbl[6])(@this, originalIdPtr, cue);
+            SilkMarshal.Free((nint)originalIdPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCueByOriginalId([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string originalId, ref IMFTimedTextCue* cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var originalIdPtr = (byte*) SilkMarshal.StringToPtr(originalId, NativeStringEncoding.LPWStr);
+            fixed (IMFTimedTextCue** cuePtr = &cue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, byte*, IMFTimedTextCue**, int>)@this->LpVtbl[6])(@this, originalIdPtr, cuePtr);
+            }
+            SilkMarshal.Free((nint)originalIdPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTextCue(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* text, IMFTimedTextCue** cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, char*, IMFTimedTextCue**, int>)@this->LpVtbl[7])(@this, start, duration, text, cue);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTextCue(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* text, ref IMFTimedTextCue* cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextCue** cuePtr = &cue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, char*, IMFTimedTextCue**, int>)@this->LpVtbl[7])(@this, start, duration, text, cuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTextCue(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char text, IMFTimedTextCue** cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* textPtr = &text)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, char*, IMFTimedTextCue**, int>)@this->LpVtbl[7])(@this, start, duration, textPtr, cue);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTextCue(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char text, ref IMFTimedTextCue* cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* textPtr = &text)
+            {
+                fixed (IMFTimedTextCue** cuePtr = &cue)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, char*, IMFTimedTextCue**, int>)@this->LpVtbl[7])(@this, start, duration, textPtr, cuePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTextCue(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string text, IMFTimedTextCue** cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var textPtr = (byte*) SilkMarshal.StringToPtr(text, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, IMFTimedTextCue**, int>)@this->LpVtbl[7])(@this, start, duration, textPtr, cue);
+            SilkMarshal.Free((nint)textPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTextCue(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string text, ref IMFTimedTextCue* cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var textPtr = (byte*) SilkMarshal.StringToPtr(text, NativeStringEncoding.LPWStr);
+            fixed (IMFTimedTextCue** cuePtr = &cue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, IMFTimedTextCue**, int>)@this->LpVtbl[7])(@this, start, duration, textPtr, cuePtr);
+            }
+            SilkMarshal.Free((nint)textPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataCue(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* data, uint dataSize, IMFTimedTextCue** cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[8])(@this, start, duration, data, dataSize, cue);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataCue(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* data, uint dataSize, ref IMFTimedTextCue* cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextCue** cuePtr = &cue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[8])(@this, start, duration, data, dataSize, cuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataCue(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte data, uint dataSize, IMFTimedTextCue** cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* dataPtr = &data)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[8])(@this, start, duration, dataPtr, dataSize, cue);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataCue(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte data, uint dataSize, ref IMFTimedTextCue* cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (byte* dataPtr = &data)
+            {
+                fixed (IMFTimedTextCue** cuePtr = &cue)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[8])(@this, start, duration, dataPtr, dataSize, cuePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataCue(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string data, uint dataSize, IMFTimedTextCue** cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var dataPtr = (byte*) SilkMarshal.StringToPtr(data, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[8])(@this, start, duration, dataPtr, dataSize, cue);
+            SilkMarshal.Free((nint)dataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataCue(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string data, uint dataSize, ref IMFTimedTextCue* cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var dataPtr = (byte*) SilkMarshal.StringToPtr(data, NativeStringEncoding.UTF8);
+            fixed (IMFTimedTextCue** cuePtr = &cue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[8])(@this, start, duration, dataPtr, dataSize, cuePtr);
+            }
+            SilkMarshal.Free((nint)dataPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int RemoveCue(IMFTimedTextCue* cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, IMFTimedTextCue*, int>)@this->LpVtbl[9])(@this, cue);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int RemoveCue(ref IMFTimedTextCue cue)
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextCue* cuePtr = &cue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, IMFTimedTextCue*, int>)@this->LpVtbl[9])(@this, cuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetCueByIndex<TI0>(uint index, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetCueByIndex(index, (IMFTimedTextCue**) cue.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetCueById<TI0>(uint id, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetCueById(id, (IMFTimedTextCue**) cue.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCueByOriginalId<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* originalId, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetCueByOriginalId(originalId, (IMFTimedTextCue**) cue.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetCueByOriginalId<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char originalId, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetCueByOriginalId(in originalId, (IMFTimedTextCue**) cue.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetCueByOriginalId<TI0>([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string originalId, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetCueByOriginalId(originalId, (IMFTimedTextCue**) cue.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddTextCue<TI0>(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* text, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddTextCue(start, duration, text, (IMFTimedTextCue**) cue.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddTextCue<TI0>(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char text, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddTextCue(start, duration, in text, (IMFTimedTextCue**) cue.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddTextCue<TI0>(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string text, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddTextCue(start, duration, text, (IMFTimedTextCue**) cue.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int AddDataCue<TI0>(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* data, uint dataSize, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddDataCue(start, duration, data, dataSize, (IMFTimedTextCue**) cue.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddDataCue<TI0>(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte data, uint dataSize, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddDataCue(start, duration, in data, dataSize, (IMFTimedTextCue**) cue.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int AddDataCue<TI0>(double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string data, uint dataSize, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->AddDataCue(start, duration, data, dataSize, (IMFTimedTextCue**) cue.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int RemoveCue<TI0>(ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->RemoveCue((IMFTimedTextCue*) cue.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextCueList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextFormattedText.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextFormattedText.gen.cs
@@ -1,0 +1,314 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("e13af3c1-4d47-4354-b1f5-e83ae0ecae60")]
+    [NativeName("Name", "IMFTimedTextFormattedText")]
+    public unsafe partial struct IMFTimedTextFormattedText : IComVtbl<IMFTimedTextFormattedText>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("e13af3c1-4d47-4354-b1f5-e83ae0ecae60");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFTimedTextFormattedText val)
+            => Unsafe.As<IMFTimedTextFormattedText, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFTimedTextFormattedText
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetText(char** text)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, char**, int>)@this->LpVtbl[3])(@this, text);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetText(ref char* text)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** textPtr = &text)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, char**, int>)@this->LpVtbl[3])(@this, textPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint GetSubformattingCount()
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint>)@this->LpVtbl[4])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSubformatting(uint index, uint* firstChar, uint* charLength, IMFTimedTextStyle** style)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstChar, charLength, style);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSubformatting(uint index, uint* firstChar, uint* charLength, ref IMFTimedTextStyle* style)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextStyle** stylePtr = &style)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstChar, charLength, stylePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSubformatting(uint index, uint* firstChar, ref uint charLength, IMFTimedTextStyle** style)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* charLengthPtr = &charLength)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstChar, charLengthPtr, style);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSubformatting(uint index, uint* firstChar, ref uint charLength, ref IMFTimedTextStyle* style)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* charLengthPtr = &charLength)
+            {
+                fixed (IMFTimedTextStyle** stylePtr = &style)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstChar, charLengthPtr, stylePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSubformatting(uint index, ref uint firstChar, uint* charLength, IMFTimedTextStyle** style)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* firstCharPtr = &firstChar)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstCharPtr, charLength, style);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSubformatting(uint index, ref uint firstChar, uint* charLength, ref IMFTimedTextStyle* style)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* firstCharPtr = &firstChar)
+            {
+                fixed (IMFTimedTextStyle** stylePtr = &style)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstCharPtr, charLength, stylePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSubformatting(uint index, ref uint firstChar, ref uint charLength, IMFTimedTextStyle** style)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* firstCharPtr = &firstChar)
+            {
+                fixed (uint* charLengthPtr = &charLength)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstCharPtr, charLengthPtr, style);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSubformatting(uint index, ref uint firstChar, ref uint charLength, ref IMFTimedTextStyle* style)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* firstCharPtr = &firstChar)
+            {
+                fixed (uint* charLengthPtr = &charLength)
+                {
+                    fixed (IMFTimedTextStyle** stylePtr = &style)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstCharPtr, charLengthPtr, stylePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetText(string[] textSa)
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var text = (char**) SilkMarshal.StringArrayToPtr(textSa);
+            var ret = @this->GetText(text);
+            SilkMarshal.CopyPtrToStringArray((nint) text, textSa);
+            SilkMarshal.Free((nint) text);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSubformatting<TI0>(uint index, uint* firstChar, uint* charLength, ref ComPtr<TI0> style) where TI0 : unmanaged, IComVtbl<IMFTimedTextStyle>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetSubformatting(index, firstChar, charLength, (IMFTimedTextStyle**) style.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSubformatting<TI0>(uint index, uint* firstChar, ref uint charLength, ref ComPtr<TI0> style) where TI0 : unmanaged, IComVtbl<IMFTimedTextStyle>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetSubformatting(index, firstChar, ref charLength, (IMFTimedTextStyle**) style.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetSubformatting<TI0>(uint index, ref uint firstChar, uint* charLength, ref ComPtr<TI0> style) where TI0 : unmanaged, IComVtbl<IMFTimedTextStyle>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetSubformatting(index, ref firstChar, charLength, (IMFTimedTextStyle**) style.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetSubformatting<TI0>(uint index, ref uint firstChar, ref uint charLength, ref ComPtr<TI0> style) where TI0 : unmanaged, IComVtbl<IMFTimedTextStyle>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetSubformatting(index, ref firstChar, ref charLength, (IMFTimedTextStyle**) style.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextFormattedText*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextNotify.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextNotify.gen.cs
@@ -1,0 +1,199 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("df6b87b6-ce12-45db-aba7-432fe054e57d")]
+    [NativeName("Name", "IMFTimedTextNotify")]
+    public unsafe partial struct IMFTimedTextNotify : IComVtbl<IMFTimedTextNotify>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("df6b87b6-ce12-45db-aba7-432fe054e57d");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFTimedTextNotify val)
+            => Unsafe.As<IMFTimedTextNotify, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFTimedTextNotify
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void TrackAdded(uint trackId)
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, uint, void>)@this->LpVtbl[3])(@this, trackId);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void TrackRemoved(uint trackId)
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, uint, void>)@this->LpVtbl[4])(@this, trackId);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void TrackSelected(uint trackId, Silk.NET.Core.Bool32 selected)
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, uint, Silk.NET.Core.Bool32, void>)@this->LpVtbl[5])(@this, trackId, selected);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void TrackReadyStateChanged(uint trackId)
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, uint, void>)@this->LpVtbl[6])(@this, trackId);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void Error(TimedTextErrorCode errorCode, int extendedErrorCode, uint sourceTrackId)
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, TimedTextErrorCode, int, uint, void>)@this->LpVtbl[7])(@this, errorCode, extendedErrorCode, sourceTrackId);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe void Cue(TimedTextCueEvent cueEvent, double currentTime, IMFTimedTextCue* cue)
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, TimedTextCueEvent, double, IMFTimedTextCue*, void>)@this->LpVtbl[8])(@this, cueEvent, currentTime, cue);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void Cue(TimedTextCueEvent cueEvent, double currentTime, ref IMFTimedTextCue cue)
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            fixed (IMFTimedTextCue* cuePtr = &cue)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, TimedTextCueEvent, double, IMFTimedTextCue*, void>)@this->LpVtbl[8])(@this, cueEvent, currentTime, cuePtr);
+            }
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void Reset()
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, void>)@this->LpVtbl[9])(@this);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly void Cue<TI0>(TimedTextCueEvent cueEvent, double currentTime, ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            @this->Cue(cueEvent, currentTime, (IMFTimedTextCue*) cue.Handle);
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextNotify*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextRegion.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextRegion.gen.cs
@@ -1,0 +1,1104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("c8d22afc-bc47-4bdf-9b04-787e49ce3f58")]
+    [NativeName("Name", "IMFTimedTextRegion")]
+    public unsafe partial struct IMFTimedTextRegion : IComVtbl<IMFTimedTextRegion>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("c8d22afc-bc47-4bdf-9b04-787e49ce3f58");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFTimedTextRegion val)
+            => Unsafe.As<IMFTimedTextRegion, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFTimedTextRegion
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetName(char** name)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, char**, int>)@this->LpVtbl[3])(@this, name);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetName(ref char* name)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** namePtr = &name)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, char**, int>)@this->LpVtbl[3])(@this, namePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPosition(double* pX, double* pY, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pX, pY, unitType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPosition(double* pX, double* pY, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pX, pY, unitTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPosition(double* pX, ref double pY, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pYPtr = &pY)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pX, pYPtr, unitType);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPosition(double* pX, ref double pY, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pYPtr = &pY)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pX, pYPtr, unitTypePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPosition(ref double pX, double* pY, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pXPtr = &pX)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pXPtr, pY, unitType);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPosition(ref double pX, double* pY, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pXPtr = &pX)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pXPtr, pY, unitTypePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPosition(ref double pX, ref double pY, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pXPtr = &pX)
+            {
+                fixed (double* pYPtr = &pY)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pXPtr, pYPtr, unitType);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetPosition(ref double pX, ref double pY, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pXPtr = &pX)
+            {
+                fixed (double* pYPtr = &pY)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pXPtr, pYPtr, unitTypePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetExtent(double* pWidth, double* pHeight, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidth, pHeight, unitType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetExtent(double* pWidth, double* pHeight, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidth, pHeight, unitTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetExtent(double* pWidth, ref double pHeight, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pHeightPtr = &pHeight)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidth, pHeightPtr, unitType);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetExtent(double* pWidth, ref double pHeight, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pHeightPtr = &pHeight)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidth, pHeightPtr, unitTypePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetExtent(ref double pWidth, double* pHeight, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pWidthPtr = &pWidth)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidthPtr, pHeight, unitType);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetExtent(ref double pWidth, double* pHeight, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pWidthPtr = &pWidth)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidthPtr, pHeight, unitTypePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetExtent(ref double pWidth, ref double pHeight, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pWidthPtr = &pWidth)
+            {
+                fixed (double* pHeightPtr = &pHeight)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidthPtr, pHeightPtr, unitType);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetExtent(ref double pWidth, ref double pHeight, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pWidthPtr = &pWidth)
+            {
+                fixed (double* pHeightPtr = &pHeight)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidthPtr, pHeightPtr, unitTypePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetBackgroundColor(_MFARGB* bgColor)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, _MFARGB*, int>)@this->LpVtbl[6])(@this, bgColor);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetBackgroundColor(ref _MFARGB bgColor)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* bgColorPtr = &bgColor)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, _MFARGB*, int>)@this->LpVtbl[6])(@this, bgColorPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetWritingMode(TimedTextWritingMode* writingMode)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, TimedTextWritingMode*, int>)@this->LpVtbl[7])(@this, writingMode);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetWritingMode(ref TimedTextWritingMode writingMode)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextWritingMode* writingModePtr = &writingMode)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, TimedTextWritingMode*, int>)@this->LpVtbl[7])(@this, writingModePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetDisplayAlignment(TimedTextDisplayAlignment* displayAlign)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, TimedTextDisplayAlignment*, int>)@this->LpVtbl[8])(@this, displayAlign);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetDisplayAlignment(ref TimedTextDisplayAlignment displayAlign)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextDisplayAlignment* displayAlignPtr = &displayAlign)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, TimedTextDisplayAlignment*, int>)@this->LpVtbl[8])(@this, displayAlignPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetLineHeight(double* pLineHeight, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, TimedTextUnitType*, int>)@this->LpVtbl[9])(@this, pLineHeight, unitType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetLineHeight(double* pLineHeight, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, TimedTextUnitType*, int>)@this->LpVtbl[9])(@this, pLineHeight, unitTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetLineHeight(ref double pLineHeight, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pLineHeightPtr = &pLineHeight)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, TimedTextUnitType*, int>)@this->LpVtbl[9])(@this, pLineHeightPtr, unitType);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetLineHeight(ref double pLineHeight, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* pLineHeightPtr = &pLineHeight)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, TimedTextUnitType*, int>)@this->LpVtbl[9])(@this, pLineHeightPtr, unitTypePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetClipOverflow(int* clipOverflow)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, int*, int>)@this->LpVtbl[10])(@this, clipOverflow);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetClipOverflow(ref int clipOverflow)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* clipOverflowPtr = &clipOverflow)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, int*, int>)@this->LpVtbl[10])(@this, clipOverflowPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, double* start, double* after, double* end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, after, end, unitType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, double* start, double* after, double* end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, after, end, unitTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, double* start, double* after, ref double end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* endPtr = &end)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, after, endPtr, unitType);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, double* start, double* after, ref double end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* endPtr = &end)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, after, endPtr, unitTypePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, double* start, ref double after, double* end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* afterPtr = &after)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, afterPtr, end, unitType);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, double* start, ref double after, double* end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* afterPtr = &after)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, afterPtr, end, unitTypePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, double* start, ref double after, ref double end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* afterPtr = &after)
+            {
+                fixed (double* endPtr = &end)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, afterPtr, endPtr, unitType);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, double* start, ref double after, ref double end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* afterPtr = &after)
+            {
+                fixed (double* endPtr = &end)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, afterPtr, endPtr, unitTypePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, ref double start, double* after, double* end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* startPtr = &start)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, after, end, unitType);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, ref double start, double* after, double* end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* startPtr = &start)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, after, end, unitTypePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, ref double start, double* after, ref double end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* startPtr = &start)
+            {
+                fixed (double* endPtr = &end)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, after, endPtr, unitType);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, ref double start, double* after, ref double end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* startPtr = &start)
+            {
+                fixed (double* endPtr = &end)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, after, endPtr, unitTypePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, ref double start, ref double after, double* end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* startPtr = &start)
+            {
+                fixed (double* afterPtr = &after)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, afterPtr, end, unitType);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, ref double start, ref double after, double* end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* startPtr = &start)
+            {
+                fixed (double* afterPtr = &after)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, afterPtr, end, unitTypePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, ref double start, ref double after, ref double end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* startPtr = &start)
+            {
+                fixed (double* afterPtr = &after)
+                {
+                    fixed (double* endPtr = &end)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, afterPtr, endPtr, unitType);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(double* before, ref double start, ref double after, ref double end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* startPtr = &start)
+            {
+                fixed (double* afterPtr = &after)
+                {
+                    fixed (double* endPtr = &end)
+                    {
+                        fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, afterPtr, endPtr, unitTypePtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, double* start, double* after, double* end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, after, end, unitType);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, double* start, double* after, double* end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, after, end, unitTypePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, double* start, double* after, ref double end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (double* endPtr = &end)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, after, endPtr, unitType);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, double* start, double* after, ref double end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (double* endPtr = &end)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, after, endPtr, unitTypePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, double* start, ref double after, double* end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (double* afterPtr = &after)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, afterPtr, end, unitType);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, double* start, ref double after, double* end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (double* afterPtr = &after)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, afterPtr, end, unitTypePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, double* start, ref double after, ref double end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (double* afterPtr = &after)
+                {
+                    fixed (double* endPtr = &end)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, afterPtr, endPtr, unitType);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, double* start, ref double after, ref double end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (double* afterPtr = &after)
+                {
+                    fixed (double* endPtr = &end)
+                    {
+                        fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, afterPtr, endPtr, unitTypePtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, ref double start, double* after, double* end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (double* startPtr = &start)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, after, end, unitType);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, ref double start, double* after, double* end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (double* startPtr = &start)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, after, end, unitTypePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, ref double start, double* after, ref double end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (double* startPtr = &start)
+                {
+                    fixed (double* endPtr = &end)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, after, endPtr, unitType);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, ref double start, double* after, ref double end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (double* startPtr = &start)
+                {
+                    fixed (double* endPtr = &end)
+                    {
+                        fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, after, endPtr, unitTypePtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, ref double start, ref double after, double* end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (double* startPtr = &start)
+                {
+                    fixed (double* afterPtr = &after)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, afterPtr, end, unitType);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, ref double start, ref double after, double* end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (double* startPtr = &start)
+                {
+                    fixed (double* afterPtr = &after)
+                    {
+                        fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, afterPtr, end, unitTypePtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetPadding(ref double before, ref double start, ref double after, ref double end, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (double* startPtr = &start)
+                {
+                    fixed (double* afterPtr = &after)
+                    {
+                        fixed (double* endPtr = &end)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, afterPtr, endPtr, unitType);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetPadding(ref double before, ref double start, ref double after, ref double end, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* beforePtr = &before)
+            {
+                fixed (double* startPtr = &start)
+                {
+                    fixed (double* afterPtr = &after)
+                    {
+                        fixed (double* endPtr = &end)
+                        {
+                            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                            {
+                                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, afterPtr, endPtr, unitTypePtr);
+                            }
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetWrap(int* wrap)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, int*, int>)@this->LpVtbl[12])(@this, wrap);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetWrap(ref int wrap)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* wrapPtr = &wrap)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, int*, int>)@this->LpVtbl[12])(@this, wrapPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetZIndex(int* zIndex)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, int*, int>)@this->LpVtbl[13])(@this, zIndex);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetZIndex(ref int zIndex)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* zIndexPtr = &zIndex)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, int*, int>)@this->LpVtbl[13])(@this, zIndexPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetScrollMode(TimedTextScrollMode* scrollMode)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, TimedTextScrollMode*, int>)@this->LpVtbl[14])(@this, scrollMode);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetScrollMode(ref TimedTextScrollMode scrollMode)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextScrollMode* scrollModePtr = &scrollMode)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, TimedTextScrollMode*, int>)@this->LpVtbl[14])(@this, scrollModePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetName(string[] nameSa)
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var name = (char**) SilkMarshal.StringArrayToPtr(nameSa);
+            var ret = @this->GetName(name);
+            SilkMarshal.CopyPtrToStringArray((nint) name, nameSa);
+            SilkMarshal.Free((nint) name);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextRegion*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextRuby.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextRuby.gen.cs
@@ -1,0 +1,228 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("76c6a6f5-4955-4de5-b27b-14b734cc14b4")]
+    [NativeName("Name", "IMFTimedTextRuby")]
+    public unsafe partial struct IMFTimedTextRuby : IComVtbl<IMFTimedTextRuby>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("76c6a6f5-4955-4de5-b27b-14b734cc14b4");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFTimedTextRuby val)
+            => Unsafe.As<IMFTimedTextRuby, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFTimedTextRuby
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetRubyText(char** rubyText)
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, char**, int>)@this->LpVtbl[3])(@this, rubyText);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetRubyText(ref char* rubyText)
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** rubyTextPtr = &rubyText)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, char**, int>)@this->LpVtbl[3])(@this, rubyTextPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetRubyPosition(TimedTextRubyPosition* value)
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, TimedTextRubyPosition*, int>)@this->LpVtbl[4])(@this, value);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetRubyPosition(ref TimedTextRubyPosition value)
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextRubyPosition* valuePtr = &value)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, TimedTextRubyPosition*, int>)@this->LpVtbl[4])(@this, valuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetRubyAlign(TimedTextRubyAlign* value)
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, TimedTextRubyAlign*, int>)@this->LpVtbl[5])(@this, value);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetRubyAlign(ref TimedTextRubyAlign value)
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextRubyAlign* valuePtr = &value)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, TimedTextRubyAlign*, int>)@this->LpVtbl[5])(@this, valuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetRubyReserve(TimedTextRubyReserve* value)
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, TimedTextRubyReserve*, int>)@this->LpVtbl[6])(@this, value);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetRubyReserve(ref TimedTextRubyReserve value)
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextRubyReserve* valuePtr = &value)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, TimedTextRubyReserve*, int>)@this->LpVtbl[6])(@this, valuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetRubyText(string[] rubyTextSa)
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var rubyText = (char**) SilkMarshal.StringArrayToPtr(rubyTextSa);
+            var ret = @this->GetRubyText(rubyText);
+            SilkMarshal.CopyPtrToStringArray((nint) rubyText, rubyTextSa);
+            SilkMarshal.Free((nint) rubyText);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextRuby*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextStyle.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextStyle.gen.cs
@@ -1,0 +1,663 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("09b2455d-b834-4f01-a347-9052e21c450e")]
+    [NativeName("Name", "IMFTimedTextStyle")]
+    public unsafe partial struct IMFTimedTextStyle : IComVtbl<IMFTimedTextStyle>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("09b2455d-b834-4f01-a347-9052e21c450e");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFTimedTextStyle val)
+            => Unsafe.As<IMFTimedTextStyle, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFTimedTextStyle
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetName(char** name)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, char**, int>)@this->LpVtbl[3])(@this, name);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetName(ref char* name)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** namePtr = &name)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, char**, int>)@this->LpVtbl[3])(@this, namePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 IsExternal()
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, Silk.NET.Core.Bool32>)@this->LpVtbl[4])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetFontFamily(char** fontFamily)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, char**, int>)@this->LpVtbl[5])(@this, fontFamily);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetFontFamily(ref char* fontFamily)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** fontFamilyPtr = &fontFamily)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, char**, int>)@this->LpVtbl[5])(@this, fontFamilyPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetFontSize(double* fontSize, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, double*, TimedTextUnitType*, int>)@this->LpVtbl[6])(@this, fontSize, unitType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetFontSize(double* fontSize, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, double*, TimedTextUnitType*, int>)@this->LpVtbl[6])(@this, fontSize, unitTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetFontSize(ref double fontSize, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* fontSizePtr = &fontSize)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, double*, TimedTextUnitType*, int>)@this->LpVtbl[6])(@this, fontSizePtr, unitType);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetFontSize(ref double fontSize, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* fontSizePtr = &fontSize)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, double*, TimedTextUnitType*, int>)@this->LpVtbl[6])(@this, fontSizePtr, unitTypePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetColor(_MFARGB* color)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, int>)@this->LpVtbl[7])(@this, color);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetColor(ref _MFARGB color)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* colorPtr = &color)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, int>)@this->LpVtbl[7])(@this, colorPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetBackgroundColor(_MFARGB* bgColor)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, int>)@this->LpVtbl[8])(@this, bgColor);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetBackgroundColor(ref _MFARGB bgColor)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* bgColorPtr = &bgColor)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, int>)@this->LpVtbl[8])(@this, bgColorPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetShowBackgroundAlways(int* showBackgroundAlways)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, int*, int>)@this->LpVtbl[9])(@this, showBackgroundAlways);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetShowBackgroundAlways(ref int showBackgroundAlways)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* showBackgroundAlwaysPtr = &showBackgroundAlways)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, int*, int>)@this->LpVtbl[9])(@this, showBackgroundAlwaysPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetFontStyle(TimedTextFontStyle* fontStyle)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, TimedTextFontStyle*, int>)@this->LpVtbl[10])(@this, fontStyle);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetFontStyle(ref TimedTextFontStyle fontStyle)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextFontStyle* fontStylePtr = &fontStyle)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, TimedTextFontStyle*, int>)@this->LpVtbl[10])(@this, fontStylePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetBold(int* bold)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, int*, int>)@this->LpVtbl[11])(@this, bold);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetBold(ref int bold)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* boldPtr = &bold)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, int*, int>)@this->LpVtbl[11])(@this, boldPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetRightToLeft(int* rightToLeft)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, int*, int>)@this->LpVtbl[12])(@this, rightToLeft);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetRightToLeft(ref int rightToLeft)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* rightToLeftPtr = &rightToLeft)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, int*, int>)@this->LpVtbl[12])(@this, rightToLeftPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextAlignment(TimedTextAlignment* textAlign)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, TimedTextAlignment*, int>)@this->LpVtbl[13])(@this, textAlign);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetTextAlignment(ref TimedTextAlignment textAlign)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextAlignment* textAlignPtr = &textAlign)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, TimedTextAlignment*, int>)@this->LpVtbl[13])(@this, textAlignPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextDecoration(uint* textDecoration)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, uint*, int>)@this->LpVtbl[14])(@this, textDecoration);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetTextDecoration(ref uint textDecoration)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (uint* textDecorationPtr = &textDecoration)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, uint*, int>)@this->LpVtbl[14])(@this, textDecorationPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(_MFARGB* color, double* thickness, double* blurRadius, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thickness, blurRadius, unitType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(_MFARGB* color, double* thickness, double* blurRadius, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thickness, blurRadius, unitTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(_MFARGB* color, double* thickness, ref double blurRadius, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* blurRadiusPtr = &blurRadius)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thickness, blurRadiusPtr, unitType);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(_MFARGB* color, double* thickness, ref double blurRadius, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* blurRadiusPtr = &blurRadius)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thickness, blurRadiusPtr, unitTypePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(_MFARGB* color, ref double thickness, double* blurRadius, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* thicknessPtr = &thickness)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thicknessPtr, blurRadius, unitType);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(_MFARGB* color, ref double thickness, double* blurRadius, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* thicknessPtr = &thickness)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thicknessPtr, blurRadius, unitTypePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(_MFARGB* color, ref double thickness, ref double blurRadius, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* thicknessPtr = &thickness)
+            {
+                fixed (double* blurRadiusPtr = &blurRadius)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thicknessPtr, blurRadiusPtr, unitType);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(_MFARGB* color, ref double thickness, ref double blurRadius, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* thicknessPtr = &thickness)
+            {
+                fixed (double* blurRadiusPtr = &blurRadius)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thicknessPtr, blurRadiusPtr, unitTypePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(ref _MFARGB color, double* thickness, double* blurRadius, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* colorPtr = &color)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thickness, blurRadius, unitType);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(ref _MFARGB color, double* thickness, double* blurRadius, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* colorPtr = &color)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thickness, blurRadius, unitTypePtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(ref _MFARGB color, double* thickness, ref double blurRadius, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* colorPtr = &color)
+            {
+                fixed (double* blurRadiusPtr = &blurRadius)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thickness, blurRadiusPtr, unitType);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(ref _MFARGB color, double* thickness, ref double blurRadius, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* colorPtr = &color)
+            {
+                fixed (double* blurRadiusPtr = &blurRadius)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thickness, blurRadiusPtr, unitTypePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(ref _MFARGB color, ref double thickness, double* blurRadius, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* colorPtr = &color)
+            {
+                fixed (double* thicknessPtr = &thickness)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thicknessPtr, blurRadius, unitType);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(ref _MFARGB color, ref double thickness, double* blurRadius, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* colorPtr = &color)
+            {
+                fixed (double* thicknessPtr = &thickness)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thicknessPtr, blurRadius, unitTypePtr);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTextOutline(ref _MFARGB color, ref double thickness, ref double blurRadius, TimedTextUnitType* unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* colorPtr = &color)
+            {
+                fixed (double* thicknessPtr = &thickness)
+                {
+                    fixed (double* blurRadiusPtr = &blurRadius)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thicknessPtr, blurRadiusPtr, unitType);
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetTextOutline(ref _MFARGB color, ref double thickness, ref double blurRadius, ref TimedTextUnitType unitType)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (_MFARGB* colorPtr = &color)
+            {
+                fixed (double* thicknessPtr = &thickness)
+                {
+                    fixed (double* blurRadiusPtr = &blurRadius)
+                    {
+                        fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thicknessPtr, blurRadiusPtr, unitTypePtr);
+                        }
+                    }
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetName(string[] nameSa)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var name = (char**) SilkMarshal.StringArrayToPtr(nameSa);
+            var ret = @this->GetName(name);
+            SilkMarshal.CopyPtrToStringArray((nint) name, nameSa);
+            SilkMarshal.Free((nint) name);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetFontFamily(string[] fontFamilySa)
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var fontFamily = (char**) SilkMarshal.StringArrayToPtr(fontFamilySa);
+            var ret = @this->GetFontFamily(fontFamily);
+            SilkMarshal.CopyPtrToStringArray((nint) fontFamily, fontFamilySa);
+            SilkMarshal.Free((nint) fontFamily);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextStyle*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextStyle2.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextStyle2.gen.cs
@@ -1,0 +1,232 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("db639199-c809-4c89-bfca-d0bbb9729d6e")]
+    [NativeName("Name", "IMFTimedTextStyle2")]
+    public unsafe partial struct IMFTimedTextStyle2 : IComVtbl<IMFTimedTextStyle2>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("db639199-c809-4c89-bfca-d0bbb9729d6e");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFTimedTextStyle2 val)
+            => Unsafe.As<IMFTimedTextStyle2, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFTimedTextStyle2
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetRuby(IMFTimedTextRuby** ruby)
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, IMFTimedTextRuby**, int>)@this->LpVtbl[3])(@this, ruby);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetRuby(ref IMFTimedTextRuby* ruby)
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextRuby** rubyPtr = &ruby)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, IMFTimedTextRuby**, int>)@this->LpVtbl[3])(@this, rubyPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetBouten(IMFTimedTextBouten** bouten)
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, IMFTimedTextBouten**, int>)@this->LpVtbl[4])(@this, bouten);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetBouten(ref IMFTimedTextBouten* bouten)
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextBouten** boutenPtr = &bouten)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, IMFTimedTextBouten**, int>)@this->LpVtbl[4])(@this, boutenPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int IsTextCombined(int* value)
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, int*, int>)@this->LpVtbl[5])(@this, value);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int IsTextCombined(ref int value)
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (int* valuePtr = &value)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, int*, int>)@this->LpVtbl[5])(@this, valuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetFontAngleInDegrees(double* value)
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, double*, int>)@this->LpVtbl[6])(@this, value);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetFontAngleInDegrees(ref double value)
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (double* valuePtr = &value)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, double*, int>)@this->LpVtbl[6])(@this, valuePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetRuby<TI0>(ref ComPtr<TI0> ruby) where TI0 : unmanaged, IComVtbl<IMFTimedTextRuby>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetRuby((IMFTimedTextRuby**) ruby.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetBouten<TI0>(ref ComPtr<TI0> bouten) where TI0 : unmanaged, IComVtbl<IMFTimedTextBouten>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetBouten((IMFTimedTextBouten**) bouten.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextStyle2*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextTrack.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextTrack.gen.cs
@@ -1,0 +1,376 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("8822c32d-654e-4233-bf21-d7f2e67d30d4")]
+    [NativeName("Name", "IMFTimedTextTrack")]
+    public unsafe partial struct IMFTimedTextTrack : IComVtbl<IMFTimedTextTrack>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("8822c32d-654e-4233-bf21-d7f2e67d30d4");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFTimedTextTrack val)
+            => Unsafe.As<IMFTimedTextTrack, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFTimedTextTrack
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint GetId()
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, uint>)@this->LpVtbl[3])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetLabel(char** label)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char**, int>)@this->LpVtbl[4])(@this, label);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetLabel(ref char* label)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** labelPtr = &label)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char**, int>)@this->LpVtbl[4])(@this, labelPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int SetLabel([Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char*, int>)@this->LpVtbl[5])(@this, label);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetLabel([Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char* labelPtr = &label)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char*, int>)@this->LpVtbl[5])(@this, labelPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int SetLabel([Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, byte*, int>)@this->LpVtbl[5])(@this, labelPtr);
+            SilkMarshal.Free((nint)labelPtr);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetLanguage(char** language)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char**, int>)@this->LpVtbl[6])(@this, language);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetLanguage(ref char* language)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char**, int>)@this->LpVtbl[6])(@this, languagePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly TimedTextTrackKind GetTrackKind()
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            TimedTextTrackKind ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, TimedTextTrackKind>)@this->LpVtbl[7])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 IsInBand()
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Silk.NET.Core.Bool32>)@this->LpVtbl[8])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetInBandMetadataTrackDispatchType(char** dispatchType)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char**, int>)@this->LpVtbl[9])(@this, dispatchType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetInBandMetadataTrackDispatchType(ref char* dispatchType)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (char** dispatchTypePtr = &dispatchType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char**, int>)@this->LpVtbl[9])(@this, dispatchTypePtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly Silk.NET.Core.Bool32 IsActive()
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            Silk.NET.Core.Bool32 ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Silk.NET.Core.Bool32>)@this->LpVtbl[10])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly TimedTextErrorCode GetErrorCode()
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            TimedTextErrorCode ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, TimedTextErrorCode>)@this->LpVtbl[11])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetExtendedErrorCode()
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, int>)@this->LpVtbl[12])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetDataFormat(Guid* format)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Guid*, int>)@this->LpVtbl[13])(@this, format);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetDataFormat(ref Guid format)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* formatPtr = &format)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Guid*, int>)@this->LpVtbl[13])(@this, formatPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly TimedTextTrackReadyState GetReadyState()
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            TimedTextTrackReadyState ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, TimedTextTrackReadyState>)@this->LpVtbl[14])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCueList(IMFTimedTextCueList** cues)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, IMFTimedTextCueList**, int>)@this->LpVtbl[15])(@this, cues);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetCueList(ref IMFTimedTextCueList* cues)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextCueList** cuesPtr = &cues)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, IMFTimedTextCueList**, int>)@this->LpVtbl[15])(@this, cuesPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetLabel(string[] labelSa)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var label = (char**) SilkMarshal.StringArrayToPtr(labelSa);
+            var ret = @this->GetLabel(label);
+            SilkMarshal.CopyPtrToStringArray((nint) label, labelSa);
+            SilkMarshal.Free((nint) label);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetLanguage(string[] languageSa)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var language = (char**) SilkMarshal.StringArrayToPtr(languageSa);
+            var ret = @this->GetLanguage(language);
+            SilkMarshal.CopyPtrToStringArray((nint) language, languageSa);
+            SilkMarshal.Free((nint) language);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetInBandMetadataTrackDispatchType(string[] dispatchTypeSa)
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // StringArrayOverloader
+            var dispatchType = (char**) SilkMarshal.StringArrayToPtr(dispatchTypeSa);
+            var ret = @this->GetInBandMetadataTrackDispatchType(dispatchType);
+            SilkMarshal.CopyPtrToStringArray((nint) dispatchType, dispatchTypeSa);
+            SilkMarshal.Free((nint) dispatchType);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetCueList<TI0>(ref ComPtr<TI0> cues) where TI0 : unmanaged, IComVtbl<IMFTimedTextCueList>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetCueList((IMFTimedTextCueList**) cues.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextTrack*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextTrackList.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/IMFTimedTextTrackList.gen.cs
@@ -1,0 +1,199 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [Guid("23ff334c-442c-445f-bccc-edc438aa11e2")]
+    [NativeName("Name", "IMFTimedTextTrackList")]
+    public unsafe partial struct IMFTimedTextTrackList : IComVtbl<IMFTimedTextTrackList>, IComVtbl<Silk.NET.Core.Native.IUnknown>
+    {
+        public static readonly Guid Guid = new("23ff334c-442c-445f-bccc-edc438aa11e2");
+
+        void*** IComVtbl.AsVtblPtr()
+            => (void***) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+
+        public static implicit operator Silk.NET.Core.Native.IUnknown(IMFTimedTextTrackList val)
+            => Unsafe.As<IMFTimedTextTrackList, Silk.NET.Core.Native.IUnknown>(ref val);
+
+        public IMFTimedTextTrackList
+        (
+            void** lpVtbl = null
+        ) : this()
+        {
+            if (lpVtbl is not null)
+            {
+                LpVtbl = lpVtbl;
+            }
+        }
+
+
+        [NativeName("Type", "")]
+        [NativeName("Type.Name", "")]
+        [NativeName("Name", "lpVtbl")]
+        public void** LpVtbl;
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(Guid* riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, void** ppvObject)
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int QueryInterface(ref Guid riid, ref void* ppvObject)
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+                }
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint AddRef()
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, uint>)@this->LpVtbl[1])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint Release()
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, uint>)@this->LpVtbl[2])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly uint GetLength()
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            uint ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, uint>)@this->LpVtbl[3])(@this);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTrack(uint index, IMFTimedTextTrack** track)
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, uint, IMFTimedTextTrack**, int>)@this->LpVtbl[4])(@this, index, track);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTrack(uint index, ref IMFTimedTextTrack* track)
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextTrack** trackPtr = &track)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, uint, IMFTimedTextTrack**, int>)@this->LpVtbl[4])(@this, index, trackPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTrackById(uint trackId, IMFTimedTextTrack** track)
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, uint, IMFTimedTextTrack**, int>)@this->LpVtbl[5])(@this, trackId, track);
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly unsafe int GetTrackById(uint trackId, ref IMFTimedTextTrack* track)
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            int ret = default;
+            fixed (IMFTimedTextTrack** trackPtr = &track)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, uint, IMFTimedTextTrack**, int>)@this->LpVtbl[5])(@this, trackId, trackPtr);
+            }
+            return ret;
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int QueryInterface<TI0>(out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            ppvObject = default;
+            return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetTrack<TI0>(uint index, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetTrack(index, (IMFTimedTextTrack**) track.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly int GetTrackById<TI0>(uint trackId, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // ComPtrOverloader
+            return @this->GetTrackById(trackId, (IMFTimedTextTrack**) track.GetAddressOf());
+        }
+
+        /// <summary>To be documented.</summary>
+        public readonly ComPtr<TI0> QueryInterface<TI0>() where TI0 : unmanaged, IComVtbl<TI0>
+        {
+            var @this = (IMFTimedTextTrackList*) Unsafe.AsPointer(ref Unsafe.AsRef(in this));
+            // NonKhrReturnTypeOverloader
+            SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+            return silkRet;
+        }
+
+    }
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFBufferListNotifyVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFBufferListNotifyVtblExtensions.gen.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFBufferListNotifyVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFBufferListNotify> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFBufferListNotify> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFBufferListNotify> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFBufferListNotify> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFBufferListNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFBufferListNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void OnAddSourceBuffer(this ComPtr<IMFBufferListNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, void>)@this->LpVtbl[3])(@this);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void OnRemoveSourceBuffer(this ComPtr<IMFBufferListNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFBufferListNotify*, void>)@this->LpVtbl[4])(@this);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFBufferListNotify> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFBufferListNotify> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFBufferListNotify> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFBufferListNotify> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFCdmSuspendNotifyVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFCdmSuspendNotifyVtblExtensions.gen.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFCdmSuspendNotifyVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFCdmSuspendNotify> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFCdmSuspendNotify> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFCdmSuspendNotify> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFCdmSuspendNotify> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFCdmSuspendNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFCdmSuspendNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Begin(this ComPtr<IMFCdmSuspendNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, int>)@this->LpVtbl[3])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int End(this ComPtr<IMFCdmSuspendNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFCdmSuspendNotify*, int>)@this->LpVtbl[4])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFCdmSuspendNotify> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFCdmSuspendNotify> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFCdmSuspendNotify> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFCdmSuspendNotify> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFExtendedDRMTypeSupportVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFExtendedDRMTypeSupportVtblExtensions.gen.cs
@@ -1,0 +1,482 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, char* keySystem, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystem, pAnswer);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, char* keySystem, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystem, pAnswerPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, ref char keySystem, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswer);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, ref char keySystem, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswerPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswer);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswerPtr);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, char* keySystem, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswer);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, char* keySystem, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswerPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, ref char keySystem, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, ref char keySystem, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+        SilkMarshal.Free((nint)keySystemPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+            }
+        SilkMarshal.Free((nint)keySystemPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswer);
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswerPtr);
+        }
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+        }
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+            }
+        }
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, char* keySystem, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupportedEx(type, keySystem, ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, Span<char> keySystem, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupportedEx(type, ref keySystem.GetPinnableReference(), pAnswer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, Span<char> keySystem, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupportedEx(type, ref keySystem.GetPinnableReference(), ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupportedEx(type, keySystem, ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, char* keySystem, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupportedEx(ref type.GetPinnableReference(), keySystem, pAnswer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, char* keySystem, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupportedEx(ref type.GetPinnableReference(), keySystem, ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, Span<char> keySystem, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupportedEx(ref type.GetPinnableReference(), ref keySystem.GetPinnableReference(), pAnswer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, Span<char> keySystem, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupportedEx(ref type.GetPinnableReference(), ref keySystem.GetPinnableReference(), ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupportedEx(ref type.GetPinnableReference(), keySystem, pAnswer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupportedEx(ref type.GetPinnableReference(), keySystem, ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupportedEx(type, keySystem, ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<char> keySystem, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupportedEx(type, ref keySystem.GetPinnableReference(), pAnswer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<char> keySystem, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupportedEx(type, ref keySystem.GetPinnableReference(), ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupportedEx(type, keySystem, ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFExtendedDRMTypeSupportVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFExtendedDRMTypeSupportVtblExtensions.gen.cs
@@ -85,107 +85,107 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, char* keySystem, MediaEngineCanplay* pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, char* keySystem, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
-        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystem, pAnswer);
+        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, type, keySystem, pAnswer);
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, char* keySystem, ref MediaEngineCanplay pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, char* keySystem, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
-        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystem, pAnswerPtr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, type, keySystem, pAnswerPtr);
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, ref char keySystem, MediaEngineCanplay* pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, ref char keySystem, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         fixed (char* keySystemPtr = &keySystem)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswer);
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, ref char keySystem, ref MediaEngineCanplay pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, ref char keySystem, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         fixed (char* keySystemPtr = &keySystem)
         {
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswerPtr);
             }
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanplay* pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
-        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswer);
+        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswer);
         SilkMarshal.Free((nint)keySystemPtr);
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanplay pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
-        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswerPtr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, type, keySystemPtr, pAnswerPtr);
         }
         SilkMarshal.Free((nint)keySystemPtr);
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, char* keySystem, MediaEngineCanplay* pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, char* keySystem, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         fixed (char* typePtr = &type)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswer);
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, char* keySystem, ref MediaEngineCanplay pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, char* keySystem, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         fixed (char* typePtr = &type)
         {
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswerPtr);
             }
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, ref char keySystem, MediaEngineCanplay* pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, ref char keySystem, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
@@ -193,14 +193,14 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
         {
             fixed (char* keySystemPtr = &keySystem)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
             }
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, ref char keySystem, ref MediaEngineCanplay pAnswer)
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, ref char keySystem, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
@@ -208,9 +208,9 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
         {
             fixed (char* keySystemPtr = &keySystem)
             {
-                fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+                fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
                 {
-                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
                 }
             }
         }
@@ -218,30 +218,30 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanplay* pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         fixed (char* typePtr = &type)
         {
         var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
-            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
         SilkMarshal.Free((nint)keySystemPtr);
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanplay pAnswer)
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         fixed (char* typePtr = &type)
         {
         var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, char*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
             }
         SilkMarshal.Free((nint)keySystemPtr);
         }
@@ -249,55 +249,55 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, MediaEngineCanplay* pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
-        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswer);
+        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswer);
         SilkMarshal.Free((nint)typePtr);
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, ref MediaEngineCanplay pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
-        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswerPtr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystem, pAnswerPtr);
         }
         SilkMarshal.Free((nint)typePtr);
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, MediaEngineCanplay* pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
         fixed (char* keySystemPtr = &keySystem)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
         }
         SilkMarshal.Free((nint)typePtr);
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, ref MediaEngineCanplay pAnswer)
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
         fixed (char* keySystemPtr = &keySystem)
         {
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
             }
         }
         SilkMarshal.Free((nint)typePtr);
@@ -305,28 +305,28 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanplay* pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
         var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
-        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
+        ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswer);
         SilkMarshal.Free((nint)keySystemPtr);
         SilkMarshal.Free((nint)typePtr);
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanplay pAnswer)
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
         var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
-        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFExtendedDRMTypeSupport*, byte*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, typePtr, keySystemPtr, pAnswerPtr);
         }
         SilkMarshal.Free((nint)keySystemPtr);
         SilkMarshal.Free((nint)typePtr);
@@ -359,7 +359,7 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, char* keySystem, Span<MediaEngineCanplay> pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, char* keySystem, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -367,7 +367,7 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, Span<char> keySystem, MediaEngineCanplay* pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, Span<char> keySystem, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -375,7 +375,7 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, Span<char> keySystem, Span<MediaEngineCanplay> pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, Span<char> keySystem, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -383,7 +383,7 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<MediaEngineCanplay> pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -391,7 +391,7 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, char* keySystem, MediaEngineCanplay* pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, char* keySystem, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -399,7 +399,7 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, char* keySystem, Span<MediaEngineCanplay> pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, char* keySystem, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -407,7 +407,7 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, Span<char> keySystem, MediaEngineCanplay* pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, Span<char> keySystem, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -415,7 +415,7 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, Span<char> keySystem, Span<MediaEngineCanplay> pAnswer)
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, Span<char> keySystem, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -423,7 +423,7 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanplay* pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -431,7 +431,7 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<MediaEngineCanplay> pAnswer)
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, Span<char> type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -439,7 +439,7 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, Span<MediaEngineCanplay> pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -447,7 +447,7 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<char> keySystem, MediaEngineCanplay* pAnswer)
+    public static unsafe int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<char> keySystem, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -455,7 +455,7 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<char> keySystem, Span<MediaEngineCanplay> pAnswer)
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<char> keySystem, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -463,7 +463,7 @@ public unsafe static class MFExtendedDRMTypeSupportVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<MediaEngineCanplay> pAnswer)
+    public static int IsTypeSupportedEx(this ComPtr<IMFExtendedDRMTypeSupport> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFHDCPStatusVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFHDCPStatusVtblExtensions.gen.cs
@@ -1,0 +1,202 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFHDCPStatusVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFHDCPStatus> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFHDCPStatus> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFHDCPStatus> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFHDCPStatus> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFHDCPStatus> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFHDCPStatus> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int Query(this ComPtr<IMFHDCPStatus> thisVtbl, HdcpStatus* pStatus, int* pfStatus)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, HdcpStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatus, pfStatus);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int Query(this ComPtr<IMFHDCPStatus> thisVtbl, HdcpStatus* pStatus, ref int pfStatus)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* pfStatusPtr = &pfStatus)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, HdcpStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatus, pfStatusPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int Query(this ComPtr<IMFHDCPStatus> thisVtbl, ref HdcpStatus pStatus, int* pfStatus)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (HdcpStatus* pStatusPtr = &pStatus)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, HdcpStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatusPtr, pfStatus);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Query(this ComPtr<IMFHDCPStatus> thisVtbl, ref HdcpStatus pStatus, ref int pfStatus)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (HdcpStatus* pStatusPtr = &pStatus)
+        {
+            fixed (int* pfStatusPtr = &pfStatus)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, HdcpStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatusPtr, pfStatusPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Set(this ComPtr<IMFHDCPStatus> thisVtbl, HdcpStatus status)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFHDCPStatus*, HdcpStatus, int>)@this->LpVtbl[4])(@this, status);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFHDCPStatus> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFHDCPStatus> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFHDCPStatus> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int Query(this ComPtr<IMFHDCPStatus> thisVtbl, HdcpStatus* pStatus, Span<int> pfStatus)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->Query(pStatus, ref pfStatus.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int Query(this ComPtr<IMFHDCPStatus> thisVtbl, Span<HdcpStatus> pStatus, int* pfStatus)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->Query(ref pStatus.GetPinnableReference(), pfStatus);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Query(this ComPtr<IMFHDCPStatus> thisVtbl, Span<HdcpStatus> pStatus, Span<int> pfStatus)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->Query(ref pStatus.GetPinnableReference(), ref pfStatus.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFHDCPStatus> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineAudioEndpointIdVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineAudioEndpointIdVtblExtensions.gen.cs
@@ -1,0 +1,194 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineAudioEndpointIdVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetAudioEndpointId(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* pszEndpointId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, char*, int>)@this->LpVtbl[3])(@this, pszEndpointId);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetAudioEndpointId(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char pszEndpointId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pszEndpointIdPtr = &pszEndpointId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, char*, int>)@this->LpVtbl[3])(@this, pszEndpointIdPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetAudioEndpointId(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string pszEndpointId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pszEndpointIdPtr = (byte*) SilkMarshal.StringToPtr(pszEndpointId, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, byte*, int>)@this->LpVtbl[3])(@this, pszEndpointIdPtr);
+        SilkMarshal.Free((nint)pszEndpointIdPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetAudioEndpointId(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl, char** ppszEndpointId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, char**, int>)@this->LpVtbl[4])(@this, ppszEndpointId);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetAudioEndpointId(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl, ref char* ppszEndpointId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** ppszEndpointIdPtr = &ppszEndpointId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineAudioEndpointId*, char**, int>)@this->LpVtbl[4])(@this, ppszEndpointIdPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetAudioEndpointId(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> pszEndpointId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->SetAudioEndpointId(in pszEndpointId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetAudioEndpointId(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl, string[] ppszEndpointIdSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var ppszEndpointId = (char**) SilkMarshal.StringArrayToPtr(ppszEndpointIdSa);
+        var ret = @this->GetAudioEndpointId(ppszEndpointId);
+        SilkMarshal.CopyPtrToStringArray((nint) ppszEndpointId, ppszEndpointIdSa);
+        SilkMarshal.Free((nint) ppszEndpointId);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineAudioEndpointId> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineClassFactory2VtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineClassFactory2VtblExtensions.gen.cs
@@ -1,0 +1,1478 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineClassFactory2VtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePath, inprivateCdmStorePath, ppKeys);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePath, inprivateCdmStorePath, ppKeysPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeys);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+        {
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeysPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeys);
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeysPtr);
+        }
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeys);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+        {
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeysPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+        {
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+        {
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+        {
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+        {
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+            }
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeys);
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeysPtr);
+        }
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+        fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+        }
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+        fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+        {
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+            }
+        }
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystem, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+        }
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePath, ppKeys);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePath, ppKeysPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeys);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeysPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeys);
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeysPtr);
+            }
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeys);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeysPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+                fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+                fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+                {
+                    fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+            {
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                }
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeys);
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeysPtr);
+            }
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+            }
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                }
+            }
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, char*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+            }
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePath, ppKeys);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePath, ppKeysPtr);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeys);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+        {
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeysPtr);
+            }
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeys);
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePath, inprivateCdmStorePathPtr, ppKeysPtr);
+        }
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeys);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+        {
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeysPtr);
+            }
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+        {
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+            }
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+        {
+            fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+        {
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (char* defaultCdmStorePathPtr = &defaultCdmStorePath)
+        {
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+            }
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeys);
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePath, ppKeysPtr);
+        }
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+        fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+        }
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+        fixed (char* inprivateCdmStorePathPtr = &inprivateCdmStorePath)
+        {
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+            }
+        }
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeys);
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        var defaultCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(defaultCdmStorePath, NativeStringEncoding.BStr);
+        var inprivateCdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(inprivateCdmStorePath, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory2*, byte*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keySystemPtr, defaultCdmStorePathPtr, inprivateCdmStorePathPtr, ppKeysPtr);
+        }
+        SilkMarshal.Free((nint)inprivateCdmStorePathPtr);
+        SilkMarshal.Free((nint)defaultCdmStorePathPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, char* defaultCdmStorePath, Span<char> inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath.GetPinnableReference(), ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, char* defaultCdmStorePath, Span<char> inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath.GetPinnableReference(), ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, Span<char> defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath.GetPinnableReference(), inprivateCdmStorePath, ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, Span<char> defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath.GetPinnableReference(), inprivateCdmStorePath, ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, Span<char> defaultCdmStorePath, Span<char> inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath.GetPinnableReference(), ref inprivateCdmStorePath.GetPinnableReference(), ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, Span<char> defaultCdmStorePath, Span<char> inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath.GetPinnableReference(), ref inprivateCdmStorePath.GetPinnableReference(), ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, Span<char> defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath.GetPinnableReference(), inprivateCdmStorePath, ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, Span<char> defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath.GetPinnableReference(), inprivateCdmStorePath, ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, Span<char> inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath.GetPinnableReference(), ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, Span<char> inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath.GetPinnableReference(), ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), defaultCdmStorePath, inprivateCdmStorePath, ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(ref keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), defaultCdmStorePath, inprivateCdmStorePath, ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, char* defaultCdmStorePath, Span<char> inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), defaultCdmStorePath, ref inprivateCdmStorePath.GetPinnableReference(), ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(ref keySystem, defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, char* defaultCdmStorePath, Span<char> inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), defaultCdmStorePath, ref inprivateCdmStorePath.GetPinnableReference(), ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), defaultCdmStorePath, inprivateCdmStorePath, ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(ref keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), defaultCdmStorePath, inprivateCdmStorePath, ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, Span<char> defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), ref defaultCdmStorePath.GetPinnableReference(), inprivateCdmStorePath, ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(ref keySystem, ref defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, Span<char> defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), ref defaultCdmStorePath.GetPinnableReference(), inprivateCdmStorePath, ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, Span<char> defaultCdmStorePath, Span<char> inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), ref defaultCdmStorePath.GetPinnableReference(), ref inprivateCdmStorePath.GetPinnableReference(), ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(ref keySystem, ref defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, Span<char> defaultCdmStorePath, Span<char> inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), ref defaultCdmStorePath.GetPinnableReference(), ref inprivateCdmStorePath.GetPinnableReference(), ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, Span<char> defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), ref defaultCdmStorePath.GetPinnableReference(), inprivateCdmStorePath, ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(ref keySystem, ref defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, Span<char> defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), ref defaultCdmStorePath.GetPinnableReference(), inprivateCdmStorePath, ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), defaultCdmStorePath, inprivateCdmStorePath, ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(ref keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), defaultCdmStorePath, inprivateCdmStorePath, ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, Span<char> inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), defaultCdmStorePath, ref inprivateCdmStorePath.GetPinnableReference(), ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(ref keySystem, defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, Span<char> inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), defaultCdmStorePath, ref inprivateCdmStorePath.GetPinnableReference(), ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), defaultCdmStorePath, inprivateCdmStorePath, ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(ref keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, Span<char> keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(ref keySystem.GetPinnableReference(), defaultCdmStorePath, inprivateCdmStorePath, ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, Span<char> inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath.GetPinnableReference(), ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, Span<char> inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath.GetPinnableReference(), ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<char> defaultCdmStorePath, char* inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath.GetPinnableReference(), inprivateCdmStorePath, ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<char> defaultCdmStorePath, char* inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath.GetPinnableReference(), inprivateCdmStorePath, ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<char> defaultCdmStorePath, Span<char> inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath.GetPinnableReference(), ref inprivateCdmStorePath.GetPinnableReference(), ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<char> defaultCdmStorePath, Span<char> inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath.GetPinnableReference(), ref inprivateCdmStorePath.GetPinnableReference(), ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<char> defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath.GetPinnableReference(), inprivateCdmStorePath, ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<char> defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, ref defaultCdmStorePath.GetPinnableReference(), inprivateCdmStorePath, ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, char* inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, Span<char> inprivateCdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath.GetPinnableReference(), ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, ref char inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys2(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, Span<char> inprivateCdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, ref inprivateCdmStorePath.GetPinnableReference(), ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateMediaKeys2<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string defaultCdmStorePath, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string inprivateCdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys2(keySystem, defaultCdmStorePath, inprivateCdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineClassFactory2> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineClassFactory3VtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineClassFactory3VtblExtensions.gen.cs
@@ -1,0 +1,365 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineClassFactory3VtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, char* keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, IMFMediaKeySystemAccess** ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystem, ppSupportedConfigurationsArray, uSize, ppKeyAccess);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, char* keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, ref IMFMediaKeySystemAccess* ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeySystemAccess** ppKeyAccessPtr = &ppKeyAccess)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystem, ppSupportedConfigurationsArray, uSize, ppKeyAccessPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, char* keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, IMFMediaKeySystemAccess** ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IPropertyStore** ppSupportedConfigurationsArrayPtr = &ppSupportedConfigurationsArray)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystem, ppSupportedConfigurationsArrayPtr, uSize, ppKeyAccess);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, char* keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, ref IMFMediaKeySystemAccess* ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IPropertyStore** ppSupportedConfigurationsArrayPtr = &ppSupportedConfigurationsArray)
+        {
+            fixed (IMFMediaKeySystemAccess** ppKeyAccessPtr = &ppKeyAccess)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystem, ppSupportedConfigurationsArrayPtr, uSize, ppKeyAccessPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, ref char keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, IMFMediaKeySystemAccess** ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArray, uSize, ppKeyAccess);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, ref char keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, ref IMFMediaKeySystemAccess* ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (IMFMediaKeySystemAccess** ppKeyAccessPtr = &ppKeyAccess)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArray, uSize, ppKeyAccessPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, ref char keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, IMFMediaKeySystemAccess** ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (IPropertyStore** ppSupportedConfigurationsArrayPtr = &ppSupportedConfigurationsArray)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArrayPtr, uSize, ppKeyAccess);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, ref char keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, ref IMFMediaKeySystemAccess* ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (IPropertyStore** ppSupportedConfigurationsArrayPtr = &ppSupportedConfigurationsArray)
+            {
+                fixed (IMFMediaKeySystemAccess** ppKeyAccessPtr = &ppKeyAccess)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, char*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArrayPtr, uSize, ppKeyAccessPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, IMFMediaKeySystemAccess** ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, byte*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArray, uSize, ppKeyAccess);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, ref IMFMediaKeySystemAccess* ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeySystemAccess** ppKeyAccessPtr = &ppKeyAccess)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, byte*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArray, uSize, ppKeyAccessPtr);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, IMFMediaKeySystemAccess** ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (IPropertyStore** ppSupportedConfigurationsArrayPtr = &ppSupportedConfigurationsArray)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, byte*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArrayPtr, uSize, ppKeyAccess);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, ref IMFMediaKeySystemAccess* ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (IPropertyStore** ppSupportedConfigurationsArrayPtr = &ppSupportedConfigurationsArray)
+        {
+            fixed (IMFMediaKeySystemAccess** ppKeyAccessPtr = &ppKeyAccess)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory3*, byte*, IPropertyStore**, uint, IMFMediaKeySystemAccess**, int>)@this->LpVtbl[3])(@this, keySystemPtr, ppSupportedConfigurationsArrayPtr, uSize, ppKeyAccessPtr);
+            }
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess<TI0>(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, char* keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, ref ComPtr<TI0> ppKeyAccess) where TI0 : unmanaged, IComVtbl<IMFMediaKeySystemAccess>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeySystemAccess(keySystem, ppSupportedConfigurationsArray, uSize, (IMFMediaKeySystemAccess**) ppKeyAccess.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess<TI0>(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, char* keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, ref ComPtr<TI0> ppKeyAccess) where TI0 : unmanaged, IComVtbl<IMFMediaKeySystemAccess>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeySystemAccess(keySystem, ref ppSupportedConfigurationsArray, uSize, (IMFMediaKeySystemAccess**) ppKeyAccess.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, Span<char> keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, IMFMediaKeySystemAccess** ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeySystemAccess(ref keySystem.GetPinnableReference(), ppSupportedConfigurationsArray, uSize, ppKeyAccess);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess<TI0>(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, ref char keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, ref ComPtr<TI0> ppKeyAccess) where TI0 : unmanaged, IComVtbl<IMFMediaKeySystemAccess>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeySystemAccess(ref keySystem, ppSupportedConfigurationsArray, uSize, (IMFMediaKeySystemAccess**) ppKeyAccess.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, Span<char> keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, ref IMFMediaKeySystemAccess* ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeySystemAccess(ref keySystem.GetPinnableReference(), ppSupportedConfigurationsArray, uSize, ref ppKeyAccess);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, Span<char> keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, IMFMediaKeySystemAccess** ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeySystemAccess(ref keySystem.GetPinnableReference(), ref ppSupportedConfigurationsArray, uSize, ppKeyAccess);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess<TI0>(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, ref char keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, ref ComPtr<TI0> ppKeyAccess) where TI0 : unmanaged, IComVtbl<IMFMediaKeySystemAccess>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeySystemAccess(ref keySystem, ref ppSupportedConfigurationsArray, uSize, (IMFMediaKeySystemAccess**) ppKeyAccess.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, Span<char> keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, ref IMFMediaKeySystemAccess* ppKeyAccess)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeySystemAccess(ref keySystem.GetPinnableReference(), ref ppSupportedConfigurationsArray, uSize, ref ppKeyAccess);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess<TI0>(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, IPropertyStore** ppSupportedConfigurationsArray, uint uSize, ref ComPtr<TI0> ppKeyAccess) where TI0 : unmanaged, IComVtbl<IMFMediaKeySystemAccess>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeySystemAccess(keySystem, ppSupportedConfigurationsArray, uSize, (IMFMediaKeySystemAccess**) ppKeyAccess.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeySystemAccess<TI0>(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref IPropertyStore* ppSupportedConfigurationsArray, uint uSize, ref ComPtr<TI0> ppKeyAccess) where TI0 : unmanaged, IComVtbl<IMFMediaKeySystemAccess>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeySystemAccess(keySystem, ref ppSupportedConfigurationsArray, uSize, (IMFMediaKeySystemAccess**) ppKeyAccess.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineClassFactory3> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineClassFactory4VtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineClassFactory4VtblExtensions.gen.cs
@@ -1,0 +1,403 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineClassFactory4VtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* keySystem, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystem, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* keySystem, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystem, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* keySystem, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystem, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* keySystem, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystem, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char keySystem, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riid, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char keySystem, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riid, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char keySystem, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (Guid* riidPtr = &riid)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riidPtr, ppvObject);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char keySystem, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (Guid* riidPtr = &riid)
+            {
+                fixed (void** ppvObjectPtr = &ppvObject)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, char*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riidPtr, ppvObjectPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string keySystem, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, byte*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riid, ppvObject);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string keySystem, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.LPWStr);
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, byte*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riid, ppvObjectPtr);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string keySystem, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.LPWStr);
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, byte*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riidPtr, ppvObject);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string keySystem, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.LPWStr);
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory4*, byte*, Guid*, void**, int>)@this->LpVtbl[3])(@this, keySystemPtr, riidPtr, ppvObjectPtr);
+            }
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory<TI0>(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* keySystem, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->CreateContentDecryptionModuleFactory(keySystem, SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* keySystem, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateContentDecryptionModuleFactory(keySystem, ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* keySystem, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateContentDecryptionModuleFactory(keySystem, ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> keySystem, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateContentDecryptionModuleFactory(in keySystem.GetPinnableReference(), riid, ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateContentDecryptionModuleFactory<TI0>(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char keySystem, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->CreateContentDecryptionModuleFactory(in keySystem, SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> keySystem, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateContentDecryptionModuleFactory(in keySystem.GetPinnableReference(), riid, ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> keySystem, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateContentDecryptionModuleFactory(in keySystem.GetPinnableReference(), ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> keySystem, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateContentDecryptionModuleFactory(in keySystem.GetPinnableReference(), ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateContentDecryptionModuleFactory<TI0>(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string keySystem, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->CreateContentDecryptionModuleFactory(keySystem, SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string keySystem, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateContentDecryptionModuleFactory(keySystem, ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateContentDecryptionModuleFactory(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string keySystem, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateContentDecryptionModuleFactory(keySystem, ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe ComPtr<TI0> CreateContentDecryptionModuleFactory<TI0>(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* keySystem) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->CreateContentDecryptionModuleFactory(keySystem, out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> CreateContentDecryptionModuleFactory<TI0>(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char keySystem) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->CreateContentDecryptionModuleFactory(in keySystem, out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> CreateContentDecryptionModuleFactory<TI0>(this ComPtr<IMFMediaEngineClassFactory4> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string keySystem) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->CreateContentDecryptionModuleFactory(keySystem, out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineClassFactoryExVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineClassFactoryExVtblExtensions.gen.cs
@@ -1,0 +1,1101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineClassFactoryExVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateInstance(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, IMFAttributes* pAttr, IMFMediaEngine** ppPlayer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttr, ppPlayer);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateInstance(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, IMFAttributes* pAttr, ref IMFMediaEngine* ppPlayer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaEngine** ppPlayerPtr = &ppPlayer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttr, ppPlayerPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateInstance(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, ref IMFAttributes pAttr, IMFMediaEngine** ppPlayer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFAttributes* pAttrPtr = &pAttr)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttrPtr, ppPlayer);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateInstance(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, ref IMFAttributes pAttr, ref IMFMediaEngine* ppPlayer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFAttributes* pAttrPtr = &pAttr)
+        {
+            fixed (IMFMediaEngine** ppPlayerPtr = &ppPlayer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttrPtr, ppPlayerPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateTimeRange(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, IMFMediaTimeRange** ppTimeRange)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[4])(@this, ppTimeRange);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateTimeRange(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref IMFMediaTimeRange* ppTimeRange)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaTimeRange** ppTimeRangePtr = &ppTimeRange)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[4])(@this, ppTimeRangePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateError(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, IMFMediaError** ppError)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, IMFMediaError**, int>)@this->LpVtbl[5])(@this, ppError);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateError(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref IMFMediaError* ppError)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaError** ppErrorPtr = &ppError)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, IMFMediaError**, int>)@this->LpVtbl[5])(@this, ppErrorPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaSourceExtension(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, IMFAttributes* pAttr, IMFMediaSourceExtension** ppMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaSourceExtension**, int>)@this->LpVtbl[6])(@this, dwFlags, pAttr, ppMSE);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaSourceExtension(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, IMFAttributes* pAttr, ref IMFMediaSourceExtension* ppMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaSourceExtension** ppMSEPtr = &ppMSE)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaSourceExtension**, int>)@this->LpVtbl[6])(@this, dwFlags, pAttr, ppMSEPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaSourceExtension(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, ref IMFAttributes pAttr, IMFMediaSourceExtension** ppMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFAttributes* pAttrPtr = &pAttr)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaSourceExtension**, int>)@this->LpVtbl[6])(@this, dwFlags, pAttrPtr, ppMSE);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaSourceExtension(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, ref IMFAttributes pAttr, ref IMFMediaSourceExtension* ppMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFAttributes* pAttrPtr = &pAttr)
+        {
+            fixed (IMFMediaSourceExtension** ppMSEPtr = &ppMSE)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, uint, IMFAttributes*, IMFMediaSourceExtension**, int>)@this->LpVtbl[6])(@this, dwFlags, pAttrPtr, ppMSEPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* keySystem, char* cdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystem, cdmStorePath, ppKeys);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* keySystem, char* cdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystem, cdmStorePath, ppKeysPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* keySystem, ref char cdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* cdmStorePathPtr = &cdmStorePath)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystem, cdmStorePathPtr, ppKeys);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* keySystem, ref char cdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* cdmStorePathPtr = &cdmStorePath)
+        {
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystem, cdmStorePathPtr, ppKeysPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var cdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(cdmStorePath, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystem, cdmStorePathPtr, ppKeys);
+        SilkMarshal.Free((nint)cdmStorePathPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var cdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(cdmStorePath, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystem, cdmStorePathPtr, ppKeysPtr);
+        }
+        SilkMarshal.Free((nint)cdmStorePathPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char keySystem, char* cdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePath, ppKeys);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char keySystem, char* cdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePath, ppKeysPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char keySystem, ref char cdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (char* cdmStorePathPtr = &cdmStorePath)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeys);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char keySystem, ref char cdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (char* cdmStorePathPtr = &cdmStorePath)
+            {
+                fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeysPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+        var cdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(cdmStorePath, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeys);
+        SilkMarshal.Free((nint)cdmStorePathPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+        var cdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(cdmStorePath, NativeStringEncoding.BStr);
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeysPtr);
+            }
+        SilkMarshal.Free((nint)cdmStorePathPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* cdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePath, ppKeys);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* cdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePath, ppKeysPtr);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char cdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (char* cdmStorePathPtr = &cdmStorePath)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeys);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char cdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (char* cdmStorePathPtr = &cdmStorePath)
+        {
+            fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeysPtr);
+            }
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        var cdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(cdmStorePath, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeys);
+        SilkMarshal.Free((nint)cdmStorePathPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        var cdmStorePathPtr = (byte*) SilkMarshal.StringToPtr(cdmStorePath, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeys** ppKeysPtr = &ppKeys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, byte*, IMFMediaKeys**, int>)@this->LpVtbl[7])(@this, keySystemPtr, cdmStorePathPtr, ppKeysPtr);
+        }
+        SilkMarshal.Free((nint)cdmStorePathPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* type, char* keySystem, int* isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, type, keySystem, isSupported);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* type, char* keySystem, ref int isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* isSupportedPtr = &isSupported)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, type, keySystem, isSupportedPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* type, ref char keySystem, int* isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, type, keySystemPtr, isSupported);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* type, ref char keySystem, ref int isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (int* isSupportedPtr = &isSupported)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, type, keySystemPtr, isSupportedPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, int* isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, int*, int>)@this->LpVtbl[8])(@this, type, keySystemPtr, isSupported);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref int isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (int* isSupportedPtr = &isSupported)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, int*, int>)@this->LpVtbl[8])(@this, type, keySystemPtr, isSupportedPtr);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char type, char* keySystem, int* isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystem, isSupported);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char type, char* keySystem, ref int isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            fixed (int* isSupportedPtr = &isSupported)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystem, isSupportedPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char type, ref char keySystem, int* isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupported);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char type, ref char keySystem, ref int isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                fixed (int* isSupportedPtr = &isSupported)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupportedPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, int* isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupported);
+        SilkMarshal.Free((nint)keySystemPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref int isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            fixed (int* isSupportedPtr = &isSupported)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, char*, byte*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupportedPtr);
+            }
+        SilkMarshal.Free((nint)keySystemPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, int* isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystem, isSupported);
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, ref int isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        fixed (int* isSupportedPtr = &isSupported)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystem, isSupportedPtr);
+        }
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, int* isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupported);
+        }
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref char keySystem, ref int isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            fixed (int* isSupportedPtr = &isSupported)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, char*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupportedPtr);
+            }
+        }
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, int* isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, byte*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupported);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref int isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        fixed (int* isSupportedPtr = &isSupported)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactoryEx*, byte*, byte*, int*, int>)@this->LpVtbl[8])(@this, typePtr, keySystemPtr, isSupportedPtr);
+        }
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateInstance<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, IMFAttributes* pAttr, ref ComPtr<TI0> ppPlayer) where TI0 : unmanaged, IComVtbl<IMFMediaEngine>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateInstance(dwFlags, pAttr, (IMFMediaEngine**) ppPlayer.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateInstance(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, Span<IMFAttributes> pAttr, IMFMediaEngine** ppPlayer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateInstance(dwFlags, ref pAttr.GetPinnableReference(), ppPlayer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateInstance<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, ref IMFAttributes pAttr, ref ComPtr<TI0> ppPlayer) where TI0 : unmanaged, IComVtbl<IMFMediaEngine>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateInstance(dwFlags, ref pAttr, (IMFMediaEngine**) ppPlayer.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateInstance(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, Span<IMFAttributes> pAttr, ref IMFMediaEngine* ppPlayer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateInstance(dwFlags, ref pAttr.GetPinnableReference(), ref ppPlayer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateTimeRange<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref ComPtr<TI0> ppTimeRange) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateTimeRange((IMFMediaTimeRange**) ppTimeRange.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateError<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref ComPtr<TI0> ppError) where TI0 : unmanaged, IComVtbl<IMFMediaError>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateError((IMFMediaError**) ppError.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaSourceExtension<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, IMFAttributes* pAttr, ref ComPtr<TI0> ppMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaSourceExtension(dwFlags, pAttr, (IMFMediaSourceExtension**) ppMSE.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaSourceExtension(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, Span<IMFAttributes> pAttr, IMFMediaSourceExtension** ppMSE)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaSourceExtension(dwFlags, ref pAttr.GetPinnableReference(), ppMSE);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateMediaSourceExtension<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, ref IMFAttributes pAttr, ref ComPtr<TI0> ppMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaSourceExtension(dwFlags, ref pAttr, (IMFMediaSourceExtension**) ppMSE.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaSourceExtension(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, uint dwFlags, Span<IMFAttributes> pAttr, ref IMFMediaSourceExtension* ppMSE)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaSourceExtension(dwFlags, ref pAttr.GetPinnableReference(), ref ppMSE);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* keySystem, char* cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys(keySystem, cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* keySystem, Span<char> cdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys(keySystem, ref cdmStorePath.GetPinnableReference(), ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* keySystem, ref char cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys(keySystem, ref cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* keySystem, Span<char> cdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys(keySystem, ref cdmStorePath.GetPinnableReference(), ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys(keySystem, cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Span<char> keySystem, char* cdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys(ref keySystem.GetPinnableReference(), cdmStorePath, ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char keySystem, char* cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys(ref keySystem, cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Span<char> keySystem, char* cdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys(ref keySystem.GetPinnableReference(), cdmStorePath, ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Span<char> keySystem, Span<char> cdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys(ref keySystem.GetPinnableReference(), ref cdmStorePath.GetPinnableReference(), ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateMediaKeys<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char keySystem, ref char cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys(ref keySystem, ref cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Span<char> keySystem, Span<char> cdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys(ref keySystem.GetPinnableReference(), ref cdmStorePath.GetPinnableReference(), ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Span<char> keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys(ref keySystem.GetPinnableReference(), cdmStorePath, ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateMediaKeys<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, ref char keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys(ref keySystem, cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Span<char> keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys(ref keySystem.GetPinnableReference(), cdmStorePath, ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, char* cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys(keySystem, cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<char> cdmStorePath, IMFMediaKeys** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys(keySystem, ref cdmStorePath.GetPinnableReference(), ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateMediaKeys<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, ref char cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys(keySystem, ref cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<char> cdmStorePath, ref IMFMediaKeys* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys(keySystem, ref cdmStorePath.GetPinnableReference(), ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateMediaKeys<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string cdmStorePath, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys(keySystem, cdmStorePath, (IMFMediaKeys**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* type, char* keySystem, Span<int> isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(type, keySystem, ref isSupported.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* type, Span<char> keySystem, int* isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(type, ref keySystem.GetPinnableReference(), isSupported);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* type, Span<char> keySystem, Span<int> isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(type, ref keySystem.GetPinnableReference(), ref isSupported.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, char* type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<int> isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(type, keySystem, ref isSupported.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Span<char> type, char* keySystem, int* isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(ref type.GetPinnableReference(), keySystem, isSupported);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Span<char> type, char* keySystem, Span<int> isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(ref type.GetPinnableReference(), keySystem, ref isSupported.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Span<char> type, Span<char> keySystem, int* isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(ref type.GetPinnableReference(), ref keySystem.GetPinnableReference(), isSupported);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Span<char> type, Span<char> keySystem, Span<int> isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(ref type.GetPinnableReference(), ref keySystem.GetPinnableReference(), ref isSupported.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Span<char> type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, int* isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(ref type.GetPinnableReference(), keySystem, isSupported);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, Span<char> type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<int> isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(ref type.GetPinnableReference(), keySystem, ref isSupported.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, char* keySystem, Span<int> isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(type, keySystem, ref isSupported.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<char> keySystem, int* isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(type, ref keySystem.GetPinnableReference(), isSupported);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<char> keySystem, Span<int> isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(type, ref keySystem.GetPinnableReference(), ref isSupported.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTypeSupported(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem, Span<int> isSupported)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(type, keySystem, ref isSupported.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineClassFactoryEx> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineClassFactoryVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineClassFactoryVtblExtensions.gen.cs
@@ -1,0 +1,259 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineClassFactoryVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineClassFactory> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineClassFactory> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateInstance(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, uint dwFlags, IMFAttributes* pAttr, IMFMediaEngine** ppPlayer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttr, ppPlayer);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateInstance(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, uint dwFlags, IMFAttributes* pAttr, ref IMFMediaEngine* ppPlayer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaEngine** ppPlayerPtr = &ppPlayer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttr, ppPlayerPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateInstance(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, uint dwFlags, ref IMFAttributes pAttr, IMFMediaEngine** ppPlayer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFAttributes* pAttrPtr = &pAttr)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttrPtr, ppPlayer);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateInstance(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, uint dwFlags, ref IMFAttributes pAttr, ref IMFMediaEngine* ppPlayer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFAttributes* pAttrPtr = &pAttr)
+        {
+            fixed (IMFMediaEngine** ppPlayerPtr = &ppPlayer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, uint, IMFAttributes*, IMFMediaEngine**, int>)@this->LpVtbl[3])(@this, dwFlags, pAttrPtr, ppPlayerPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateTimeRange(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, IMFMediaTimeRange** ppTimeRange)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, IMFMediaTimeRange**, int>)@this->LpVtbl[4])(@this, ppTimeRange);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateTimeRange(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, ref IMFMediaTimeRange* ppTimeRange)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaTimeRange** ppTimeRangePtr = &ppTimeRange)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, IMFMediaTimeRange**, int>)@this->LpVtbl[4])(@this, ppTimeRangePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateError(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, IMFMediaError** ppError)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, IMFMediaError**, int>)@this->LpVtbl[5])(@this, ppError);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateError(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, ref IMFMediaError* ppError)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaError** ppErrorPtr = &ppError)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineClassFactory*, IMFMediaError**, int>)@this->LpVtbl[5])(@this, ppErrorPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateInstance<TI0>(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, uint dwFlags, IMFAttributes* pAttr, ref ComPtr<TI0> ppPlayer) where TI0 : unmanaged, IComVtbl<IMFMediaEngine>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateInstance(dwFlags, pAttr, (IMFMediaEngine**) ppPlayer.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateInstance(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, uint dwFlags, Span<IMFAttributes> pAttr, IMFMediaEngine** ppPlayer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateInstance(dwFlags, ref pAttr.GetPinnableReference(), ppPlayer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateInstance<TI0>(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, uint dwFlags, ref IMFAttributes pAttr, ref ComPtr<TI0> ppPlayer) where TI0 : unmanaged, IComVtbl<IMFMediaEngine>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateInstance(dwFlags, ref pAttr, (IMFMediaEngine**) ppPlayer.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateInstance(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, uint dwFlags, Span<IMFAttributes> pAttr, ref IMFMediaEngine* ppPlayer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateInstance(dwFlags, ref pAttr.GetPinnableReference(), ref ppPlayer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateTimeRange<TI0>(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, ref ComPtr<TI0> ppTimeRange) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateTimeRange((IMFMediaTimeRange**) ppTimeRange.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateError<TI0>(this ComPtr<IMFMediaEngineClassFactory> thisVtbl, ref ComPtr<TI0> ppError) where TI0 : unmanaged, IComVtbl<IMFMediaError>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateError((IMFMediaError**) ppError.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineClassFactory> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineEMENotifyVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineEMENotifyVtblExtensions.gen.cs
@@ -1,0 +1,261 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineEMENotifyVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineEMENotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineEMENotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void Encrypted(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbInitData, uint cb, char* bstrInitDataType)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, char*, void>)@this->LpVtbl[3])(@this, pbInitData, cb, bstrInitDataType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void Encrypted(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbInitData, uint cb, ref char bstrInitDataType)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (char* bstrInitDataTypePtr = &bstrInitDataType)
+        {
+            ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, char*, void>)@this->LpVtbl[3])(@this, pbInitData, cb, bstrInitDataTypePtr);
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void Encrypted(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbInitData, uint cb, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrInitDataType)
+    {
+        var @this = thisVtbl.Handle;
+        var bstrInitDataTypePtr = (byte*) SilkMarshal.StringToPtr(bstrInitDataType, NativeStringEncoding.BStr);
+        ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, byte*, void>)@this->LpVtbl[3])(@this, pbInitData, cb, bstrInitDataTypePtr);
+        SilkMarshal.Free((nint)bstrInitDataTypePtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void Encrypted(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbInitData, uint cb, char* bstrInitDataType)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (byte* pbInitDataPtr = &pbInitData)
+        {
+            ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, char*, void>)@this->LpVtbl[3])(@this, pbInitDataPtr, cb, bstrInitDataType);
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void Encrypted(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbInitData, uint cb, ref char bstrInitDataType)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (byte* pbInitDataPtr = &pbInitData)
+        {
+            fixed (char* bstrInitDataTypePtr = &bstrInitDataType)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, char*, void>)@this->LpVtbl[3])(@this, pbInitDataPtr, cb, bstrInitDataTypePtr);
+            }
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void Encrypted(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbInitData, uint cb, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrInitDataType)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (byte* pbInitDataPtr = &pbInitData)
+        {
+        var bstrInitDataTypePtr = (byte*) SilkMarshal.StringToPtr(bstrInitDataType, NativeStringEncoding.BStr);
+            ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, byte*, void>)@this->LpVtbl[3])(@this, pbInitDataPtr, cb, bstrInitDataTypePtr);
+        SilkMarshal.Free((nint)bstrInitDataTypePtr);
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void Encrypted(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbInitData, uint cb, char* bstrInitDataType)
+    {
+        var @this = thisVtbl.Handle;
+        var pbInitDataPtr = (byte*) SilkMarshal.StringToPtr(pbInitData, NativeStringEncoding.UTF8);
+        ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, char*, void>)@this->LpVtbl[3])(@this, pbInitDataPtr, cb, bstrInitDataType);
+        SilkMarshal.Free((nint)pbInitDataPtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void Encrypted(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbInitData, uint cb, ref char bstrInitDataType)
+    {
+        var @this = thisVtbl.Handle;
+        var pbInitDataPtr = (byte*) SilkMarshal.StringToPtr(pbInitData, NativeStringEncoding.UTF8);
+        fixed (char* bstrInitDataTypePtr = &bstrInitDataType)
+        {
+            ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, char*, void>)@this->LpVtbl[3])(@this, pbInitDataPtr, cb, bstrInitDataTypePtr);
+        }
+        SilkMarshal.Free((nint)pbInitDataPtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void Encrypted(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbInitData, uint cb, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrInitDataType)
+    {
+        var @this = thisVtbl.Handle;
+        var pbInitDataPtr = (byte*) SilkMarshal.StringToPtr(pbInitData, NativeStringEncoding.UTF8);
+        var bstrInitDataTypePtr = (byte*) SilkMarshal.StringToPtr(bstrInitDataType, NativeStringEncoding.BStr);
+        ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, byte*, uint, byte*, void>)@this->LpVtbl[3])(@this, pbInitDataPtr, cb, bstrInitDataTypePtr);
+        SilkMarshal.Free((nint)bstrInitDataTypePtr);
+        SilkMarshal.Free((nint)pbInitDataPtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void WaitingForKey(this ComPtr<IMFMediaEngineEMENotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFMediaEngineEMENotify*, void>)@this->LpVtbl[4])(@this);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void Encrypted(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbInitData, uint cb, Span<char> bstrInitDataType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->Encrypted(pbInitData, cb, ref bstrInitDataType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void Encrypted(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> pbInitData, uint cb, char* bstrInitDataType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->Encrypted(in pbInitData.GetPinnableReference(), cb, bstrInitDataType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void Encrypted(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> pbInitData, uint cb, Span<char> bstrInitDataType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->Encrypted(in pbInitData.GetPinnableReference(), cb, ref bstrInitDataType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void Encrypted(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> pbInitData, uint cb, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrInitDataType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->Encrypted(in pbInitData.GetPinnableReference(), cb, bstrInitDataType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void Encrypted(this ComPtr<IMFMediaEngineEMENotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbInitData, uint cb, Span<char> bstrInitDataType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->Encrypted(pbInitData, cb, ref bstrInitDataType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineEMENotify> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineEMEVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineEMEVtblExtensions.gen.cs
@@ -1,0 +1,187 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineEMEVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEME> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEME> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEME> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEME> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineEME> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineEME> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeys(this ComPtr<IMFMediaEngineEME> thisVtbl, IMFMediaKeys** keys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keys);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeys(this ComPtr<IMFMediaEngineEME> thisVtbl, ref IMFMediaKeys* keys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeys** keysPtr = &keys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, IMFMediaKeys**, int>)@this->LpVtbl[3])(@this, keysPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetMediaKeys(this ComPtr<IMFMediaEngineEME> thisVtbl, IMFMediaKeys* keys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, IMFMediaKeys*, int>)@this->LpVtbl[4])(@this, keys);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetMediaKeys(this ComPtr<IMFMediaEngineEME> thisVtbl, ref IMFMediaKeys keys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeys* keysPtr = &keys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEME*, IMFMediaKeys*, int>)@this->LpVtbl[4])(@this, keysPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineEME> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEME> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEME> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetKeys<TI0>(this ComPtr<IMFMediaEngineEME> thisVtbl, ref ComPtr<TI0> keys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetKeys((IMFMediaKeys**) keys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetMediaKeys<TI0>(this ComPtr<IMFMediaEngineEME> thisVtbl, ComPtr<TI0> keys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->SetMediaKeys((IMFMediaKeys*) keys.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetMediaKeys(this ComPtr<IMFMediaEngineEME> thisVtbl, Span<IMFMediaKeys> keys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->SetMediaKeys(ref keys.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineEME> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineExVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineExVtblExtensions.gen.cs
@@ -106,11 +106,11 @@ public unsafe static class MFMediaEngineExVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static int SetErrorCode(this ComPtr<IMFMediaEngineEx> thisVtbl, MediaEngineErr error)
+    public static int SetErrorCode(this ComPtr<IMFMediaEngineEx> thisVtbl, MediaEngineError error)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
-        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineErr, int>)@this->LpVtbl[4])(@this, error);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineError, int>)@this->LpVtbl[4])(@this, error);
         return ret;
     }
 
@@ -246,73 +246,73 @@ public unsafe static class MFMediaEngineExVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, char* type, MediaEngineCanplay* pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, char* type, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
-        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswer);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, type, pAnswer);
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, char* type, ref MediaEngineCanplay pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, char* type, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
-        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswerPtr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, type, pAnswerPtr);
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, ref char type, MediaEngineCanplay* pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, ref char type, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         fixed (char* typePtr = &type)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, ref char type, ref MediaEngineCanplay pAnswer)
+    public static int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, ref char type, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         fixed (char* typePtr = &type)
         {
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
             }
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, MediaEngineCanplay* pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
-        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
         SilkMarshal.Free((nint)typePtr);
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref MediaEngineCanplay pAnswer)
+    public static int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
-        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
         }
         SilkMarshal.Free((nint)typePtr);
         return ret;
@@ -1762,7 +1762,7 @@ public unsafe static class MFMediaEngineExVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, char* type, Span<MediaEngineCanplay> pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, char* type, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -1770,7 +1770,7 @@ public unsafe static class MFMediaEngineExVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<char> type, MediaEngineCanplay* pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<char> type, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -1778,7 +1778,7 @@ public unsafe static class MFMediaEngineExVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<char> type, Span<MediaEngineCanplay> pAnswer)
+    public static int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<char> type, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -1786,7 +1786,7 @@ public unsafe static class MFMediaEngineExVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<MediaEngineCanplay> pAnswer)
+    public static int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineExVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineExVtblExtensions.gen.cs
@@ -1,0 +1,2317 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineExVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEx> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEx> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEx> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEx> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetError(this ComPtr<IMFMediaEngineEx> thisVtbl, IMFMediaError** ppError)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaError**, int>)@this->LpVtbl[3])(@this, ppError);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetError(this ComPtr<IMFMediaEngineEx> thisVtbl, ref IMFMediaError* ppError)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaError** ppErrorPtr = &ppError)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaError**, int>)@this->LpVtbl[3])(@this, ppErrorPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetErrorCode(this ComPtr<IMFMediaEngineEx> thisVtbl, MediaEngineErr error)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineErr, int>)@this->LpVtbl[4])(@this, error);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetSourceElements(this ComPtr<IMFMediaEngineEx> thisVtbl, IMFMediaEngineSrcElements* pSrcElements)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaEngineSrcElements*, int>)@this->LpVtbl[5])(@this, pSrcElements);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSourceElements(this ComPtr<IMFMediaEngineEx> thisVtbl, ref IMFMediaEngineSrcElements pSrcElements)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaEngineSrcElements* pSrcElementsPtr = &pSrcElements)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaEngineSrcElements*, int>)@this->LpVtbl[5])(@this, pSrcElementsPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetSource(this ComPtr<IMFMediaEngineEx> thisVtbl, char* pUrl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, int>)@this->LpVtbl[6])(@this, pUrl);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSource(this ComPtr<IMFMediaEngineEx> thisVtbl, ref char pUrl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pUrlPtr = &pUrl)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, int>)@this->LpVtbl[6])(@this, pUrlPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSource(this ComPtr<IMFMediaEngineEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pUrl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pUrlPtr = (byte*) SilkMarshal.StringToPtr(pUrl, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, byte*, int>)@this->LpVtbl[6])(@this, pUrlPtr);
+        SilkMarshal.Free((nint)pUrlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCurrentSource(this ComPtr<IMFMediaEngineEx> thisVtbl, char** ppUrl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char**, int>)@this->LpVtbl[7])(@this, ppUrl);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCurrentSource(this ComPtr<IMFMediaEngineEx> thisVtbl, ref char* ppUrl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** ppUrlPtr = &ppUrl)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char**, int>)@this->LpVtbl[7])(@this, ppUrlPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ushort GetNetworkState(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ushort ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, ushort>)@this->LpVtbl[8])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static MediaEnginePreload GetPreload(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        MediaEnginePreload ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEnginePreload>)@this->LpVtbl[9])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetPreload(this ComPtr<IMFMediaEngineEx> thisVtbl, MediaEnginePreload Preload)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEnginePreload, int>)@this->LpVtbl[10])(@this, Preload);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetBuffered(this ComPtr<IMFMediaEngineEx> thisVtbl, IMFMediaTimeRange** ppBuffered)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[11])(@this, ppBuffered);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetBuffered(this ComPtr<IMFMediaEngineEx> thisVtbl, ref IMFMediaTimeRange* ppBuffered)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaTimeRange** ppBufferedPtr = &ppBuffered)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[11])(@this, ppBufferedPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Load(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int>)@this->LpVtbl[12])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, char* type, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswer);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, char* type, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswerPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, ref char type, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, ref char type, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+        }
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ushort GetReadyState(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ushort ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, ushort>)@this->LpVtbl[14])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsSeeking(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[15])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetCurrentTime(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double>)@this->LpVtbl[16])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetCurrentTime(this ComPtr<IMFMediaEngineEx> thisVtbl, double seekTime)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, int>)@this->LpVtbl[17])(@this, seekTime);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetStartTime(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double>)@this->LpVtbl[18])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetDuration(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double>)@this->LpVtbl[19])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsPaused(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[20])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetDefaultPlaybackRate(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double>)@this->LpVtbl[21])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetDefaultPlaybackRate(this ComPtr<IMFMediaEngineEx> thisVtbl, double Rate)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, int>)@this->LpVtbl[22])(@this, Rate);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetPlaybackRate(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double>)@this->LpVtbl[23])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetPlaybackRate(this ComPtr<IMFMediaEngineEx> thisVtbl, double Rate)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, int>)@this->LpVtbl[24])(@this, Rate);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPlayed(this ComPtr<IMFMediaEngineEx> thisVtbl, IMFMediaTimeRange** ppPlayed)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[25])(@this, ppPlayed);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPlayed(this ComPtr<IMFMediaEngineEx> thisVtbl, ref IMFMediaTimeRange* ppPlayed)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaTimeRange** ppPlayedPtr = &ppPlayed)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[25])(@this, ppPlayedPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSeekable(this ComPtr<IMFMediaEngineEx> thisVtbl, IMFMediaTimeRange** ppSeekable)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[26])(@this, ppSeekable);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSeekable(this ComPtr<IMFMediaEngineEx> thisVtbl, ref IMFMediaTimeRange* ppSeekable)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaTimeRange** ppSeekablePtr = &ppSeekable)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFMediaTimeRange**, int>)@this->LpVtbl[26])(@this, ppSeekablePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsEnded(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[27])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 GetAutoPlay(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[28])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetAutoPlay(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Bool32 AutoPlay)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[29])(@this, AutoPlay);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 GetLoop(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[30])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetLoop(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Bool32 Loop)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[31])(@this, Loop);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Play(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int>)@this->LpVtbl[32])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Pause(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int>)@this->LpVtbl[33])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 GetMuted(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[34])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetMuted(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Bool32 Muted)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[35])(@this, Muted);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetVolume(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double>)@this->LpVtbl[36])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetVolume(this ComPtr<IMFMediaEngineEx> thisVtbl, double Volume)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, int>)@this->LpVtbl[37])(@this, Volume);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 HasVideo(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[38])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 HasAudio(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[39])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetNativeVideoSize(this ComPtr<IMFMediaEngineEx> thisVtbl, uint* cx, uint* cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cx, cy);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetNativeVideoSize(this ComPtr<IMFMediaEngineEx> thisVtbl, uint* cx, ref uint cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* cyPtr = &cy)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cx, cyPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetNativeVideoSize(this ComPtr<IMFMediaEngineEx> thisVtbl, ref uint cx, uint* cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* cxPtr = &cx)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cxPtr, cy);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetNativeVideoSize(this ComPtr<IMFMediaEngineEx> thisVtbl, ref uint cx, ref uint cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* cxPtr = &cx)
+        {
+            fixed (uint* cyPtr = &cy)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cxPtr, cyPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetVideoAspectRatio(this ComPtr<IMFMediaEngineEx> thisVtbl, uint* cx, uint* cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cx, cy);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetVideoAspectRatio(this ComPtr<IMFMediaEngineEx> thisVtbl, uint* cx, ref uint cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* cyPtr = &cy)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cx, cyPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetVideoAspectRatio(this ComPtr<IMFMediaEngineEx> thisVtbl, ref uint cx, uint* cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* cxPtr = &cx)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cxPtr, cy);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetVideoAspectRatio(this ComPtr<IMFMediaEngineEx> thisVtbl, ref uint cx, ref uint cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* cxPtr = &cx)
+        {
+            fixed (uint* cyPtr = &cy)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cxPtr, cyPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Shutdown(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int>)@this->LpVtbl[42])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDst, pBorderClr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDst, pBorderClrPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDstPtr, pBorderClr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+        {
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDstPtr, pBorderClrPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDst, pBorderClr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDst, pBorderClrPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClrPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDst, pBorderClr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDst, pBorderClrPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClrPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClrPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClrPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int OnVideoStreamTick(this ComPtr<IMFMediaEngineEx> thisVtbl, long* pPts)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, long*, int>)@this->LpVtbl[44])(@this, pPts);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int OnVideoStreamTick(this ComPtr<IMFMediaEngineEx> thisVtbl, ref long pPts)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (long* pPtsPtr = &pPts)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, long*, int>)@this->LpVtbl[44])(@this, pPtsPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetSourceFromByteStream(this ComPtr<IMFMediaEngineEx> thisVtbl, IMFByteStream* pByteStream, char* pURL)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFByteStream*, char*, int>)@this->LpVtbl[45])(@this, pByteStream, pURL);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetSourceFromByteStream(this ComPtr<IMFMediaEngineEx> thisVtbl, IMFByteStream* pByteStream, ref char pURL)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFByteStream*, char*, int>)@this->LpVtbl[45])(@this, pByteStream, pURLPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetSourceFromByteStream(this ComPtr<IMFMediaEngineEx> thisVtbl, IMFByteStream* pByteStream, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFByteStream*, byte*, int>)@this->LpVtbl[45])(@this, pByteStream, pURLPtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetSourceFromByteStream(this ComPtr<IMFMediaEngineEx> thisVtbl, ref IMFByteStream pByteStream, char* pURL)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFByteStream*, char*, int>)@this->LpVtbl[45])(@this, pByteStreamPtr, pURL);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSourceFromByteStream(this ComPtr<IMFMediaEngineEx> thisVtbl, ref IMFByteStream pByteStream, ref char pURL)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (char* pURLPtr = &pURL)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFByteStream*, char*, int>)@this->LpVtbl[45])(@this, pByteStreamPtr, pURLPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSourceFromByteStream(this ComPtr<IMFMediaEngineEx> thisVtbl, ref IMFByteStream pByteStream, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, IMFByteStream*, byte*, int>)@this->LpVtbl[45])(@this, pByteStreamPtr, pURLPtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetStatistics(this ComPtr<IMFMediaEngineEx> thisVtbl, MediaEngineStatistic StatisticID, tagPROPVARIANT* pStatistic)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineStatistic, tagPROPVARIANT*, int>)@this->LpVtbl[46])(@this, StatisticID, pStatistic);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetStatistics(this ComPtr<IMFMediaEngineEx> thisVtbl, MediaEngineStatistic StatisticID, ref tagPROPVARIANT pStatistic)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (tagPROPVARIANT* pStatisticPtr = &pStatistic)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineStatistic, tagPROPVARIANT*, int>)@this->LpVtbl[46])(@this, StatisticID, pStatisticPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrc, pDst, pBorderClr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrc, pDst, pBorderClrPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrc, pDstPtr, pBorderClr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+        {
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrc, pDstPtr, pBorderClrPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrcPtr, pDst, pBorderClr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrcPtr, pDst, pBorderClrPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrcPtr, pDstPtr, pBorderClr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[47])(@this, pSrcPtr, pDstPtr, pBorderClrPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetBalance(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double>)@this->LpVtbl[48])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetBalance(this ComPtr<IMFMediaEngineEx> thisVtbl, double balance)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, int>)@this->LpVtbl[49])(@this, balance);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsPlaybackRateSupported(this ComPtr<IMFMediaEngineEx> thisVtbl, double rate)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, Silk.NET.Core.Bool32>)@this->LpVtbl[50])(@this, rate);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int FrameStep(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Bool32 Forward)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[51])(@this, Forward);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetResourceCharacteristics(this ComPtr<IMFMediaEngineEx> thisVtbl, uint* pCharacteristics)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[52])(@this, pCharacteristics);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetResourceCharacteristics(this ComPtr<IMFMediaEngineEx> thisVtbl, ref uint pCharacteristics)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* pCharacteristicsPtr = &pCharacteristics)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[52])(@this, pCharacteristicsPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPresentationAttribute(this ComPtr<IMFMediaEngineEx> thisVtbl, Guid* guidMFAttribute, tagPROPVARIANT* pvValue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[53])(@this, guidMFAttribute, pvValue);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPresentationAttribute(this ComPtr<IMFMediaEngineEx> thisVtbl, Guid* guidMFAttribute, ref tagPROPVARIANT pvValue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (tagPROPVARIANT* pvValuePtr = &pvValue)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[53])(@this, guidMFAttribute, pvValuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPresentationAttribute(this ComPtr<IMFMediaEngineEx> thisVtbl, ref Guid guidMFAttribute, tagPROPVARIANT* pvValue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* guidMFAttributePtr = &guidMFAttribute)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[53])(@this, guidMFAttributePtr, pvValue);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetPresentationAttribute(this ComPtr<IMFMediaEngineEx> thisVtbl, ref Guid guidMFAttribute, ref tagPROPVARIANT pvValue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* guidMFAttributePtr = &guidMFAttribute)
+        {
+            fixed (tagPROPVARIANT* pvValuePtr = &pvValue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[53])(@this, guidMFAttributePtr, pvValuePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetNumberOfStreams(this ComPtr<IMFMediaEngineEx> thisVtbl, uint* pdwStreamCount)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[54])(@this, pdwStreamCount);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetNumberOfStreams(this ComPtr<IMFMediaEngineEx> thisVtbl, ref uint pdwStreamCount)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* pdwStreamCountPtr = &pdwStreamCount)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[54])(@this, pdwStreamCountPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetStreamAttribute(this ComPtr<IMFMediaEngineEx> thisVtbl, uint dwStreamIndex, Guid* guidMFAttribute, tagPROPVARIANT* pvValue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[55])(@this, dwStreamIndex, guidMFAttribute, pvValue);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetStreamAttribute(this ComPtr<IMFMediaEngineEx> thisVtbl, uint dwStreamIndex, Guid* guidMFAttribute, ref tagPROPVARIANT pvValue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (tagPROPVARIANT* pvValuePtr = &pvValue)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[55])(@this, dwStreamIndex, guidMFAttribute, pvValuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetStreamAttribute(this ComPtr<IMFMediaEngineEx> thisVtbl, uint dwStreamIndex, ref Guid guidMFAttribute, tagPROPVARIANT* pvValue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* guidMFAttributePtr = &guidMFAttribute)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[55])(@this, dwStreamIndex, guidMFAttributePtr, pvValue);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetStreamAttribute(this ComPtr<IMFMediaEngineEx> thisVtbl, uint dwStreamIndex, ref Guid guidMFAttribute, ref tagPROPVARIANT pvValue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* guidMFAttributePtr = &guidMFAttribute)
+        {
+            fixed (tagPROPVARIANT* pvValuePtr = &pvValue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, Guid*, tagPROPVARIANT*, int>)@this->LpVtbl[55])(@this, dwStreamIndex, guidMFAttributePtr, pvValuePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetStreamSelection(this ComPtr<IMFMediaEngineEx> thisVtbl, uint dwStreamIndex, int* pEnabled)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, int*, int>)@this->LpVtbl[56])(@this, dwStreamIndex, pEnabled);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetStreamSelection(this ComPtr<IMFMediaEngineEx> thisVtbl, uint dwStreamIndex, ref int pEnabled)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* pEnabledPtr = &pEnabled)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, int*, int>)@this->LpVtbl[56])(@this, dwStreamIndex, pEnabledPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetStreamSelection(this ComPtr<IMFMediaEngineEx> thisVtbl, uint dwStreamIndex, Silk.NET.Core.Bool32 Enabled)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, Silk.NET.Core.Bool32, int>)@this->LpVtbl[57])(@this, dwStreamIndex, Enabled);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int ApplyStreamSelections(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int>)@this->LpVtbl[58])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsProtected(this ComPtr<IMFMediaEngineEx> thisVtbl, int* pProtected)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int*, int>)@this->LpVtbl[59])(@this, pProtected);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsProtected(this ComPtr<IMFMediaEngineEx> thisVtbl, ref int pProtected)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* pProtectedPtr = &pProtected)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int*, int>)@this->LpVtbl[59])(@this, pProtectedPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int InsertVideoEffect(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pEffect, Silk.NET.Core.Bool32 fOptional)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[60])(@this, pEffect, fOptional);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int InsertVideoEffect(this ComPtr<IMFMediaEngineEx> thisVtbl, ref Silk.NET.Core.Native.IUnknown pEffect, Silk.NET.Core.Bool32 fOptional)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pEffectPtr = &pEffect)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[60])(@this, pEffectPtr, fOptional);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int InsertAudioEffect(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pEffect, Silk.NET.Core.Bool32 fOptional)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[61])(@this, pEffect, fOptional);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int InsertAudioEffect(this ComPtr<IMFMediaEngineEx> thisVtbl, ref Silk.NET.Core.Native.IUnknown pEffect, Silk.NET.Core.Bool32 fOptional)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pEffectPtr = &pEffect)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Native.IUnknown*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[61])(@this, pEffectPtr, fOptional);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RemoveAllEffects(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int>)@this->LpVtbl[62])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetTimelineMarkerTimer(this ComPtr<IMFMediaEngineEx> thisVtbl, double timeToFire)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, int>)@this->LpVtbl[63])(@this, timeToFire);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTimelineMarkerTimer(this ComPtr<IMFMediaEngineEx> thisVtbl, double* pTimeToFire)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double*, int>)@this->LpVtbl[64])(@this, pTimeToFire);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetTimelineMarkerTimer(this ComPtr<IMFMediaEngineEx> thisVtbl, ref double pTimeToFire)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pTimeToFirePtr = &pTimeToFire)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double*, int>)@this->LpVtbl[64])(@this, pTimeToFirePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CancelTimelineMarkerTimer(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int>)@this->LpVtbl[65])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsStereo3D(this ComPtr<IMFMediaEngineEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32>)@this->LpVtbl[66])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetStereo3DFramePackingMode(this ComPtr<IMFMediaEngineEx> thisVtbl, MediaEngineS3DPackingMode* packMode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineS3DPackingMode*, int>)@this->LpVtbl[67])(@this, packMode);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetStereo3DFramePackingMode(this ComPtr<IMFMediaEngineEx> thisVtbl, ref MediaEngineS3DPackingMode packMode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (MediaEngineS3DPackingMode* packModePtr = &packMode)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineS3DPackingMode*, int>)@this->LpVtbl[67])(@this, packModePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetStereo3DFramePackingMode(this ComPtr<IMFMediaEngineEx> thisVtbl, MediaEngineS3DPackingMode packMode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, MediaEngineS3DPackingMode, int>)@this->LpVtbl[68])(@this, packMode);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetStereo3DRenderMode(this ComPtr<IMFMediaEngineEx> thisVtbl, _MF3DVideoOutputType* outputType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, _MF3DVideoOutputType*, int>)@this->LpVtbl[69])(@this, outputType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetStereo3DRenderMode(this ComPtr<IMFMediaEngineEx> thisVtbl, ref _MF3DVideoOutputType outputType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MF3DVideoOutputType* outputTypePtr = &outputType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, _MF3DVideoOutputType*, int>)@this->LpVtbl[69])(@this, outputTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetStereo3DRenderMode(this ComPtr<IMFMediaEngineEx> thisVtbl, _MF3DVideoOutputType outputType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, _MF3DVideoOutputType, int>)@this->LpVtbl[70])(@this, outputType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int EnableWindowlessSwapchainMode(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Bool32 fEnable)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[71])(@this, fEnable);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetVideoSwapchainHandle(this ComPtr<IMFMediaEngineEx> thisVtbl, void** phSwapchain)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, void**, int>)@this->LpVtbl[72])(@this, phSwapchain);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetVideoSwapchainHandle(this ComPtr<IMFMediaEngineEx> thisVtbl, ref void* phSwapchain)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** phSwapchainPtr = &phSwapchain)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, void**, int>)@this->LpVtbl[72])(@this, phSwapchainPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int EnableHorizontalMirrorMode(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Bool32 fEnable)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[73])(@this, fEnable);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetAudioStreamCategory(this ComPtr<IMFMediaEngineEx> thisVtbl, uint* pCategory)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[74])(@this, pCategory);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetAudioStreamCategory(this ComPtr<IMFMediaEngineEx> thisVtbl, ref uint pCategory)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* pCategoryPtr = &pCategory)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[74])(@this, pCategoryPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetAudioStreamCategory(this ComPtr<IMFMediaEngineEx> thisVtbl, uint category)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, int>)@this->LpVtbl[75])(@this, category);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetAudioEndpointRole(this ComPtr<IMFMediaEngineEx> thisVtbl, uint* pRole)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[76])(@this, pRole);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetAudioEndpointRole(this ComPtr<IMFMediaEngineEx> thisVtbl, ref uint pRole)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* pRolePtr = &pRole)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint*, int>)@this->LpVtbl[76])(@this, pRolePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetAudioEndpointRole(this ComPtr<IMFMediaEngineEx> thisVtbl, uint role)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, uint, int>)@this->LpVtbl[77])(@this, role);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetRealTimeMode(this ComPtr<IMFMediaEngineEx> thisVtbl, int* pfEnabled)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int*, int>)@this->LpVtbl[78])(@this, pfEnabled);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRealTimeMode(this ComPtr<IMFMediaEngineEx> thisVtbl, ref int pfEnabled)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* pfEnabledPtr = &pfEnabled)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, int*, int>)@this->LpVtbl[78])(@this, pfEnabledPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetRealTimeMode(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Bool32 fEnable)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[79])(@this, fEnable);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetCurrentTimeEx(this ComPtr<IMFMediaEngineEx> thisVtbl, double seekTime, MediaEngineSeekMode seekMode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, double, MediaEngineSeekMode, int>)@this->LpVtbl[80])(@this, seekTime, seekMode);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int EnableTimeUpdateTimer(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Bool32 fEnableTimer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineEx*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[81])(@this, fEnableTimer);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetError<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ref ComPtr<TI0> ppError) where TI0 : unmanaged, IComVtbl<IMFMediaError>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetError((IMFMediaError**) ppError.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSourceElements<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ComPtr<TI0> pSrcElements) where TI0 : unmanaged, IComVtbl<IMFMediaEngineSrcElements>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->SetSourceElements((IMFMediaEngineSrcElements*) pSrcElements.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSourceElements(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<IMFMediaEngineSrcElements> pSrcElements)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->SetSourceElements(ref pSrcElements.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSource(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<char> pUrl)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->SetSource(ref pUrl.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetCurrentSource(this ComPtr<IMFMediaEngineEx> thisVtbl, string[] ppUrlSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var ppUrl = (char**) SilkMarshal.StringArrayToPtr(ppUrlSa);
+        var ret = @this->GetCurrentSource(ppUrl);
+        SilkMarshal.CopyPtrToStringArray((nint) ppUrl, ppUrlSa);
+        SilkMarshal.Free((nint) ppUrl);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBuffered<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ref ComPtr<TI0> ppBuffered) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetBuffered((IMFMediaTimeRange**) ppBuffered.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, char* type, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CanPlayType(type, ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<char> type, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CanPlayType(ref type.GetPinnableReference(), pAnswer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<char> type, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CanPlayType(ref type.GetPinnableReference(), ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CanPlayType(this ComPtr<IMFMediaEngineEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CanPlayType(type, ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetPlayed<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ref ComPtr<TI0> ppPlayed) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetPlayed((IMFMediaTimeRange**) ppPlayed.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetSeekable<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ref ComPtr<TI0> ppSeekable) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetSeekable((IMFMediaTimeRange**) ppSeekable.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetNativeVideoSize(this ComPtr<IMFMediaEngineEx> thisVtbl, uint* cx, Span<uint> cy)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetNativeVideoSize(cx, ref cy.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetNativeVideoSize(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<uint> cx, uint* cy)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetNativeVideoSize(ref cx.GetPinnableReference(), cy);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetNativeVideoSize(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<uint> cx, Span<uint> cy)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetNativeVideoSize(ref cx.GetPinnableReference(), ref cy.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetVideoAspectRatio(this ComPtr<IMFMediaEngineEx> thisVtbl, uint* cx, Span<uint> cy)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetVideoAspectRatio(cx, ref cy.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetVideoAspectRatio(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<uint> cx, uint* cy)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetVideoAspectRatio(ref cx.GetPinnableReference(), cy);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetVideoAspectRatio(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<uint> cx, Span<uint> cy)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetVideoAspectRatio(ref cx.GetPinnableReference(), ref cy.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, pSrc, pDst, in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, in pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, pSrc, in pDst.GetPinnableReference(), pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, pSrc, in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, in pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), pDst, in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, in pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, in pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, pDst, in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, in pDst.GetPinnableReference(), pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), pDst, in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int TransferVideoFrame(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int OnVideoStreamTick(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<long> pPts)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->OnVideoStreamTick(ref pPts.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetSourceFromByteStream(this ComPtr<IMFMediaEngineEx> thisVtbl, IMFByteStream* pByteStream, Span<char> pURL)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->SetSourceFromByteStream(pByteStream, ref pURL.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetSourceFromByteStream(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<IMFByteStream> pByteStream, char* pURL)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->SetSourceFromByteStream(ref pByteStream.GetPinnableReference(), pURL);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSourceFromByteStream(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<IMFByteStream> pByteStream, Span<char> pURL)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->SetSourceFromByteStream(ref pByteStream.GetPinnableReference(), ref pURL.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSourceFromByteStream(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<IMFByteStream> pByteStream, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->SetSourceFromByteStream(ref pByteStream.GetPinnableReference(), pURL);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetStatistics(this ComPtr<IMFMediaEngineEx> thisVtbl, MediaEngineStatistic StatisticID, Span<tagPROPVARIANT> pStatistic)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetStatistics(StatisticID, ref pStatistic.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->UpdateVideoStream(pSrc, pDst, in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->UpdateVideoStream(pSrc, in pDst.GetPinnableReference(), pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->UpdateVideoStream(pSrc, in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->UpdateVideoStream(in pSrc.GetPinnableReference(), pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->UpdateVideoStream(in pSrc.GetPinnableReference(), pDst, in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->UpdateVideoStream(in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int UpdateVideoStream(this ComPtr<IMFMediaEngineEx> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->UpdateVideoStream(in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetResourceCharacteristics(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<uint> pCharacteristics)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetResourceCharacteristics(ref pCharacteristics.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPresentationAttribute(this ComPtr<IMFMediaEngineEx> thisVtbl, Guid* guidMFAttribute, Span<tagPROPVARIANT> pvValue)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPresentationAttribute(guidMFAttribute, ref pvValue.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPresentationAttribute(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<Guid> guidMFAttribute, tagPROPVARIANT* pvValue)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPresentationAttribute(ref guidMFAttribute.GetPinnableReference(), pvValue);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetPresentationAttribute(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<Guid> guidMFAttribute, Span<tagPROPVARIANT> pvValue)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPresentationAttribute(ref guidMFAttribute.GetPinnableReference(), ref pvValue.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetNumberOfStreams(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<uint> pdwStreamCount)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetNumberOfStreams(ref pdwStreamCount.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetStreamAttribute(this ComPtr<IMFMediaEngineEx> thisVtbl, uint dwStreamIndex, Guid* guidMFAttribute, Span<tagPROPVARIANT> pvValue)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetStreamAttribute(dwStreamIndex, guidMFAttribute, ref pvValue.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetStreamAttribute(this ComPtr<IMFMediaEngineEx> thisVtbl, uint dwStreamIndex, Span<Guid> guidMFAttribute, tagPROPVARIANT* pvValue)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetStreamAttribute(dwStreamIndex, ref guidMFAttribute.GetPinnableReference(), pvValue);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetStreamAttribute(this ComPtr<IMFMediaEngineEx> thisVtbl, uint dwStreamIndex, Span<Guid> guidMFAttribute, Span<tagPROPVARIANT> pvValue)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetStreamAttribute(dwStreamIndex, ref guidMFAttribute.GetPinnableReference(), ref pvValue.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetStreamSelection(this ComPtr<IMFMediaEngineEx> thisVtbl, uint dwStreamIndex, Span<int> pEnabled)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetStreamSelection(dwStreamIndex, ref pEnabled.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsProtected(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<int> pProtected)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsProtected(ref pProtected.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int InsertVideoEffect<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ComPtr<TI0> pEffect, Silk.NET.Core.Bool32 fOptional) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->InsertVideoEffect((Silk.NET.Core.Native.IUnknown*) pEffect.Handle, fOptional);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int InsertVideoEffect(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pEffect, Silk.NET.Core.Bool32 fOptional)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->InsertVideoEffect(ref pEffect.GetPinnableReference(), fOptional);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int InsertAudioEffect<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl, ComPtr<TI0> pEffect, Silk.NET.Core.Bool32 fOptional) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->InsertAudioEffect((Silk.NET.Core.Native.IUnknown*) pEffect.Handle, fOptional);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int InsertAudioEffect(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pEffect, Silk.NET.Core.Bool32 fOptional)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->InsertAudioEffect(ref pEffect.GetPinnableReference(), fOptional);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetTimelineMarkerTimer(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<double> pTimeToFire)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTimelineMarkerTimer(ref pTimeToFire.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetStereo3DFramePackingMode(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<MediaEngineS3DPackingMode> packMode)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetStereo3DFramePackingMode(ref packMode.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetStereo3DRenderMode(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<_MF3DVideoOutputType> outputType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetStereo3DRenderMode(ref outputType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetAudioStreamCategory(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<uint> pCategory)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetAudioStreamCategory(ref pCategory.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetAudioEndpointRole(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<uint> pRole)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetAudioEndpointRole(ref pRole.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRealTimeMode(this ComPtr<IMFMediaEngineEx> thisVtbl, Span<int> pfEnabled)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetRealTimeMode(ref pfEnabled.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineEx> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineExtensionVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineExtensionVtblExtensions.gen.cs
@@ -85,73 +85,73 @@ public unsafe static class MFMediaEngineExtensionVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, char* MimeType, MediaEngineCanplay* pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, char* MimeType, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
-        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeType, pAnswer);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeType, pAnswer);
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, char* MimeType, ref MediaEngineCanplay pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, char* MimeType, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
-        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeType, pAnswerPtr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeType, pAnswerPtr);
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, ref char MimeType, MediaEngineCanplay* pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, ref char MimeType, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         fixed (char* MimeTypePtr = &MimeType)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswer);
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, ref char MimeType, ref MediaEngineCanplay pAnswer)
+    public static int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, ref char MimeType, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         fixed (char* MimeTypePtr = &MimeType)
         {
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswerPtr);
             }
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, MediaEngineCanplay* pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         var MimeTypePtr = (byte*) SilkMarshal.StringToPtr(MimeType, NativeStringEncoding.BStr);
-        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswer);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswer);
         SilkMarshal.Free((nint)MimeTypePtr);
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, ref MediaEngineCanplay pAnswer)
+    public static int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         var MimeTypePtr = (byte*) SilkMarshal.StringToPtr(MimeType, NativeStringEncoding.BStr);
-        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswerPtr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswerPtr);
         }
         SilkMarshal.Free((nint)MimeTypePtr);
         return ret;
@@ -1052,7 +1052,7 @@ public unsafe static class MFMediaEngineExtensionVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, char* MimeType, Span<MediaEngineCanplay> pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, char* MimeType, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -1060,7 +1060,7 @@ public unsafe static class MFMediaEngineExtensionVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, Span<char> MimeType, MediaEngineCanplay* pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, Span<char> MimeType, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -1068,7 +1068,7 @@ public unsafe static class MFMediaEngineExtensionVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, Span<char> MimeType, Span<MediaEngineCanplay> pAnswer)
+    public static int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, Span<char> MimeType, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -1076,7 +1076,7 @@ public unsafe static class MFMediaEngineExtensionVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, Span<MediaEngineCanplay> pAnswer)
+    public static int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineExtensionVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineExtensionVtblExtensions.gen.cs
@@ -1,0 +1,1783 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineExtensionVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineExtension> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineExtension> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineExtension> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineExtension> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, char* MimeType, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeType, pAnswer);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, char* MimeType, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeType, pAnswerPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, ref char MimeType, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* MimeTypePtr = &MimeType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswer);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, ref char MimeType, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* MimeTypePtr = &MimeType)
+        {
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, char*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswerPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var MimeTypePtr = (byte*) SilkMarshal.StringToPtr(MimeType, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswer);
+        SilkMarshal.Free((nint)MimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var MimeTypePtr = (byte*) SilkMarshal.StringToPtr(MimeType, NativeStringEncoding.BStr);
+        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Bool32, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[3])(@this, AudioOnly, MimeTypePtr, pAnswerPtr);
+        }
+        SilkMarshal.Free((nint)MimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookie, pCallback, punkState);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookie, pCallback, punkStatePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookie, pCallbackPtr, punkState);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookie, pCallbackPtr, punkStatePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookiePtr, pCallback, punkState);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookiePtr, pCallback, punkStatePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+        {
+            fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkState);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+        {
+            fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStream, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkStatePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallback, punkState);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallback, punkStatePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallbackPtr, punkState);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallbackPtr, punkStatePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallback, punkState);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallback, punkStatePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkState);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURL, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkStatePtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallback, punkState);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallback, punkStatePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallbackPtr, punkState);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallbackPtr, punkStatePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallback, punkState);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallback, punkStatePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkState);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkStatePtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallback, punkState);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallback, punkStatePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallbackPtr, punkState);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallbackPtr, punkStatePtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallback, punkState);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallback, punkStatePtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkState);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrURLPtr = &bstrURL)
+        {
+            fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+                {
+                    fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                    {
+                        fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, char*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkStatePtr);
+                        }
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallback, punkState);
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallback, punkStatePtr);
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallbackPtr, punkState);
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookie, pCallbackPtr, punkStatePtr);
+            }
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallback, punkState);
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallback, punkStatePtr);
+            }
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+        {
+            fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkState);
+            }
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+        {
+            fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStream, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkStatePtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallback, punkState);
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallback, punkStatePtr);
+            }
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallbackPtr, punkState);
+            }
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookie, pCallbackPtr, punkStatePtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallback, punkState);
+            }
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallback, punkStatePtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkState);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrURLPtr = (byte*) SilkMarshal.StringToPtr(bstrURL, NativeStringEncoding.BStr);
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookiePtr = &ppIUnknownCancelCookie)
+            {
+                fixed (IMFAsyncCallback* pCallbackPtr = &pCallback)
+                {
+                    fixed (Silk.NET.Core.Native.IUnknown* punkStatePtr = &punkState)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, byte*, IMFByteStream*, MF_OBJECT_TYPE, Silk.NET.Core.Native.IUnknown**, IMFAsyncCallback*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[4])(@this, bstrURLPtr, pByteStreamPtr, type, ppIUnknownCancelCookiePtr, pCallbackPtr, punkStatePtr);
+                    }
+                }
+            }
+        }
+        SilkMarshal.Free((nint)bstrURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CancelObjectCreation(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Native.IUnknown* pIUnknownCancelCookie)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[5])(@this, pIUnknownCancelCookie);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CancelObjectCreation(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref Silk.NET.Core.Native.IUnknown pIUnknownCancelCookie)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pIUnknownCancelCookiePtr = &pIUnknownCancelCookie)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[5])(@this, pIUnknownCancelCookiePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int EndCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, IMFAsyncResult* pResult, Silk.NET.Core.Native.IUnknown** ppObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, IMFAsyncResult*, Silk.NET.Core.Native.IUnknown**, int>)@this->LpVtbl[6])(@this, pResult, ppObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int EndCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, IMFAsyncResult* pResult, ref Silk.NET.Core.Native.IUnknown* ppObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown** ppObjectPtr = &ppObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, IMFAsyncResult*, Silk.NET.Core.Native.IUnknown**, int>)@this->LpVtbl[6])(@this, pResult, ppObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int EndCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref IMFAsyncResult pResult, Silk.NET.Core.Native.IUnknown** ppObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFAsyncResult* pResultPtr = &pResult)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, IMFAsyncResult*, Silk.NET.Core.Native.IUnknown**, int>)@this->LpVtbl[6])(@this, pResultPtr, ppObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int EndCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref IMFAsyncResult pResult, ref Silk.NET.Core.Native.IUnknown* ppObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFAsyncResult* pResultPtr = &pResult)
+        {
+            fixed (Silk.NET.Core.Native.IUnknown** ppObjectPtr = &ppObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineExtension*, IMFAsyncResult*, Silk.NET.Core.Native.IUnknown**, int>)@this->LpVtbl[6])(@this, pResultPtr, ppObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, char* MimeType, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CanPlayType(AudioOnly, MimeType, ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, Span<char> MimeType, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CanPlayType(AudioOnly, ref MimeType.GetPinnableReference(), pAnswer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, Span<char> MimeType, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CanPlayType(AudioOnly, ref MimeType.GetPinnableReference(), ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CanPlayType(this ComPtr<IMFMediaEngineExtension> thisVtbl, Silk.NET.Core.Bool32 AudioOnly, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string MimeType, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CanPlayType(AudioOnly, MimeType, ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0, TI1>(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ppIUnknownCancelCookie, pCallback, ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, ref punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0, TI1>(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, ref punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, pCallback, ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ppIUnknownCancelCookie, pCallback, punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0, TI1>(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ppIUnknownCancelCookie, pCallback, ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, ref punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0, TI1>(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, ref punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ref ppIUnknownCancelCookie, pCallback, punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream, type, ref ppIUnknownCancelCookie, pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ref ppIUnknownCancelCookie, pCallback, ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ref ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, char* bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ref ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), pByteStream, type, ppIUnknownCancelCookie, pCallback, punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0, TI1>(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(ref bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), pByteStream, type, ppIUnknownCancelCookie, pCallback, ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(ref bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, ref punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), pByteStream, type, ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0, TI1>(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(ref bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), pByteStream, type, ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(ref bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, ref punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), pByteStream, type, ref ppIUnknownCancelCookie, pCallback, punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(ref bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), pByteStream, type, ref ppIUnknownCancelCookie, pCallback, ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(ref bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), ref pByteStream.GetPinnableReference(), type, ppIUnknownCancelCookie, pCallback, punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0, TI1>(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(ref bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), ref pByteStream.GetPinnableReference(), type, ppIUnknownCancelCookie, pCallback, ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(ref bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, ref punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), ref pByteStream.GetPinnableReference(), type, ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int BeginCreateObject<TI0, TI1>(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(ref bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), ref pByteStream.GetPinnableReference(), type, ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(ref bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, ref punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), ref pByteStream.GetPinnableReference(), type, ref ppIUnknownCancelCookie, pCallback, punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(ref bstrURL, ref pByteStream, type, ref ppIUnknownCancelCookie, pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), ref pByteStream.GetPinnableReference(), type, ref ppIUnknownCancelCookie, pCallback, ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), ref pByteStream.GetPinnableReference(), type, ref ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref char bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(ref bstrURL, ref pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<char> bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(ref bstrURL.GetPinnableReference(), ref pByteStream.GetPinnableReference(), type, ref ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0, TI1>(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ppIUnknownCancelCookie, pCallback, ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, ref punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0, TI1>(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, ref punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, pCallback, ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, IMFByteStream* pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ppIUnknownCancelCookie, pCallback, punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0, TI1>(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ppIUnknownCancelCookie, pCallback, ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), pCallback, ref punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int BeginCreateObject<TI0, TI1>(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI1> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, Silk.NET.Core.Native.IUnknown** ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref ComPtr<TI0> ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ref Silk.NET.Core.Native.IUnknown punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream, type, (Silk.NET.Core.Native.IUnknown**) ppIUnknownCancelCookie.GetAddressOf(), ref pCallback, ref punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ref ppIUnknownCancelCookie, pCallback, punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream, type, ref ppIUnknownCancelCookie, pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, IMFAsyncCallback* pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ref ppIUnknownCancelCookie, pCallback, ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Silk.NET.Core.Native.IUnknown* punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ref ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), punkState);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, ref IMFByteStream pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, ref IMFAsyncCallback pCallback, ComPtr<TI0> punkState) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream, type, ref ppIUnknownCancelCookie, ref pCallback, (Silk.NET.Core.Native.IUnknown*) punkState.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int BeginCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrURL, Span<IMFByteStream> pByteStream, MF_OBJECT_TYPE type, ref Silk.NET.Core.Native.IUnknown* ppIUnknownCancelCookie, Span<IMFAsyncCallback> pCallback, Span<Silk.NET.Core.Native.IUnknown> punkState)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->BeginCreateObject(bstrURL, ref pByteStream.GetPinnableReference(), type, ref ppIUnknownCancelCookie, ref pCallback.GetPinnableReference(), ref punkState.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CancelObjectCreation<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, ComPtr<TI0> pIUnknownCancelCookie) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CancelObjectCreation((Silk.NET.Core.Native.IUnknown*) pIUnknownCancelCookie.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CancelObjectCreation(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pIUnknownCancelCookie)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CancelObjectCreation(ref pIUnknownCancelCookie.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int EndCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, IMFAsyncResult* pResult, ref ComPtr<TI0> ppObject) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->EndCreateObject(pResult, (Silk.NET.Core.Native.IUnknown**) ppObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int EndCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<IMFAsyncResult> pResult, Silk.NET.Core.Native.IUnknown** ppObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->EndCreateObject(ref pResult.GetPinnableReference(), ppObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int EndCreateObject<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl, ref IMFAsyncResult pResult, ref ComPtr<TI0> ppObject) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->EndCreateObject(ref pResult, (Silk.NET.Core.Native.IUnknown**) ppObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int EndCreateObject(this ComPtr<IMFMediaEngineExtension> thisVtbl, Span<IMFAsyncResult> pResult, ref Silk.NET.Core.Native.IUnknown* ppObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->EndCreateObject(ref pResult.GetPinnableReference(), ref ppObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineExtension> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineNeedKeyNotifyVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineNeedKeyNotifyVtblExtensions.gen.cs
@@ -1,0 +1,155 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineNeedKeyNotifyVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineNeedKeyNotify> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineNeedKeyNotify> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineNeedKeyNotify> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineNeedKeyNotify> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineNeedKeyNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineNeedKeyNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void NeedKey(this ComPtr<IMFMediaEngineNeedKeyNotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, byte*, uint, void>)@this->LpVtbl[3])(@this, initData, cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void NeedKey(this ComPtr<IMFMediaEngineNeedKeyNotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (byte* initDataPtr = &initData)
+        {
+            ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, byte*, uint, void>)@this->LpVtbl[3])(@this, initDataPtr, cb);
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void NeedKey(this ComPtr<IMFMediaEngineNeedKeyNotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        ((delegate* unmanaged[Stdcall]<IMFMediaEngineNeedKeyNotify*, byte*, uint, void>)@this->LpVtbl[3])(@this, initDataPtr, cb);
+        SilkMarshal.Free((nint)initDataPtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineNeedKeyNotify> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineNeedKeyNotify> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineNeedKeyNotify> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void NeedKey(this ComPtr<IMFMediaEngineNeedKeyNotify> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->NeedKey(in initData.GetPinnableReference(), cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineNeedKeyNotify> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineNotifyVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineNotifyVtblExtensions.gen.cs
@@ -1,0 +1,130 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineNotifyVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineNotify> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineNotify> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineNotify> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineNotify> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNotify*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNotify*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int EventNotify(this ComPtr<IMFMediaEngineNotify> thisVtbl, uint @event, nuint param1, uint param2)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineNotify*, uint, nuint, uint, int>)@this->LpVtbl[3])(@this, @event, param1, param2);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineNotify> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineNotify> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineNotify> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineNotify> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineOPMInfoVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineOPMInfoVtblExtensions.gen.cs
@@ -1,0 +1,193 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineOPMInfoVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetOPMInfo(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl, MediaEngineOpmStatus* pStatus, int* pConstricted)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, MediaEngineOpmStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatus, pConstricted);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetOPMInfo(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl, MediaEngineOpmStatus* pStatus, ref int pConstricted)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* pConstrictedPtr = &pConstricted)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, MediaEngineOpmStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatus, pConstrictedPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetOPMInfo(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl, ref MediaEngineOpmStatus pStatus, int* pConstricted)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (MediaEngineOpmStatus* pStatusPtr = &pStatus)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, MediaEngineOpmStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatusPtr, pConstricted);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetOPMInfo(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl, ref MediaEngineOpmStatus pStatus, ref int pConstricted)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (MediaEngineOpmStatus* pStatusPtr = &pStatus)
+        {
+            fixed (int* pConstrictedPtr = &pConstricted)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineOPMInfo*, MediaEngineOpmStatus*, int*, int>)@this->LpVtbl[3])(@this, pStatusPtr, pConstrictedPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetOPMInfo(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl, MediaEngineOpmStatus* pStatus, Span<int> pConstricted)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetOPMInfo(pStatus, ref pConstricted.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetOPMInfo(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl, Span<MediaEngineOpmStatus> pStatus, int* pConstricted)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetOPMInfo(ref pStatus.GetPinnableReference(), pConstricted);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetOPMInfo(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl, Span<MediaEngineOpmStatus> pStatus, Span<int> pConstricted)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetOPMInfo(ref pStatus.GetPinnableReference(), ref pConstricted.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineOPMInfo> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineProtectedContentVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineProtectedContentVtblExtensions.gen.cs
@@ -1,0 +1,1169 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineProtectedContentVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int ShareResources(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pUnkDeviceContext)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[3])(@this, pUnkDeviceContext);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int ShareResources(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pUnkDeviceContext)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pUnkDeviceContextPtr = &pUnkDeviceContext)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, int>)@this->LpVtbl[3])(@this, pUnkDeviceContextPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetRequiredProtections(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, uint*, int>)@this->LpVtbl[4])(@this, pFrameProtectionFlags);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRequiredProtections(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, uint*, int>)@this->LpVtbl[4])(@this, pFrameProtectionFlagsPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetOPMWindow(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, nint hwnd)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, nint, int>)@this->LpVtbl[5])(@this, hwnd);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDst, pBorderClr, pFrameProtectionFlags);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDst, pBorderClr, pFrameProtectionFlagsPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDst, pBorderClrPtr, pFrameProtectionFlags);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+        {
+            fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDst, pBorderClrPtr, pFrameProtectionFlagsPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDstPtr, pBorderClr, pFrameProtectionFlags);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+        {
+            fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDstPtr, pBorderClr, pFrameProtectionFlagsPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+        {
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDstPtr, pBorderClrPtr, pFrameProtectionFlags);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+        {
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrc, pDstPtr, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDst, pBorderClr, pFrameProtectionFlags);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDst, pBorderClr, pFrameProtectionFlagsPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDst, pBorderClrPtr, pFrameProtectionFlags);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDst, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClr, pFrameProtectionFlags);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClr, pFrameProtectionFlagsPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClrPtr, pFrameProtectionFlags);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDst, pBorderClr, pFrameProtectionFlags);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDst, pBorderClr, pFrameProtectionFlagsPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDst, pBorderClrPtr, pFrameProtectionFlags);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDst, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClr, pFrameProtectionFlags);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClr, pFrameProtectionFlagsPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClrPtr, pFrameProtectionFlags);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClr, pFrameProtectionFlags);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClr, pFrameProtectionFlagsPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClrPtr, pFrameProtectionFlags);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClr, pFrameProtectionFlags);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClr, pFrameProtectionFlagsPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClrPtr, pFrameProtectionFlags);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        fixed (uint* pFrameProtectionFlagsPtr = &pFrameProtectionFlags)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, uint*, int>)@this->LpVtbl[6])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClrPtr, pFrameProtectionFlagsPtr);
+                        }
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetContentProtectionManager(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, IMFContentProtectionManager* pCPM)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, IMFContentProtectionManager*, int>)@this->LpVtbl[7])(@this, pCPM);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetContentProtectionManager(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ref IMFContentProtectionManager pCPM)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFContentProtectionManager* pCPMPtr = &pCPM)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, IMFContentProtectionManager*, int>)@this->LpVtbl[7])(@this, pCPMPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetApplicationCertificate(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbBlob, uint cbBlob)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, byte*, uint, int>)@this->LpVtbl[8])(@this, pbBlob, cbBlob);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetApplicationCertificate(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbBlob, uint cbBlob)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* pbBlobPtr = &pbBlob)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, byte*, uint, int>)@this->LpVtbl[8])(@this, pbBlobPtr, cbBlob);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetApplicationCertificate(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbBlob, uint cbBlob)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pbBlobPtr = (byte*) SilkMarshal.StringToPtr(pbBlob, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineProtectedContent*, byte*, uint, int>)@this->LpVtbl[8])(@this, pbBlobPtr, cbBlob);
+        SilkMarshal.Free((nint)pbBlobPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int ShareResources<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pUnkDeviceContext) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->ShareResources((Silk.NET.Core.Native.IUnknown*) pUnkDeviceContext.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int ShareResources(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pUnkDeviceContext)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->ShareResources(ref pUnkDeviceContext.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRequiredProtections(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetRequiredProtections(ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, pSrc, pDst, pBorderClr, ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, pBorderClr, ref pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, pSrc, pDst, in pBorderClr.GetPinnableReference(), pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, in pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, pSrc, pDst, in pBorderClr.GetPinnableReference(), ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, in pBorderClr, ref pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, pSrc, in pDst.GetPinnableReference(), pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, pSrc, in pDst.GetPinnableReference(), pBorderClr, ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, pBorderClr, ref pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, pSrc, in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference(), pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, in pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, pSrc, in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference(), ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, in pBorderClr, ref pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), pDst, pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), pDst, pBorderClr, ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, pBorderClr, ref pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), pDst, in pBorderClr.GetPinnableReference(), pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, in pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), pDst, in pBorderClr.GetPinnableReference(), ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, in pBorderClr, ref pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), pBorderClr, ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, pBorderClr, ref pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference(), pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, uint* pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, in pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference(), ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr, ref uint pFrameProtectionFlags) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, in pBorderClr, ref pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, pDst, pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, pDst, pBorderClr, ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, pDst, in pBorderClr.GetPinnableReference(), pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, pDst, in pBorderClr.GetPinnableReference(), ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, in pDst.GetPinnableReference(), pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, in pDst.GetPinnableReference(), pBorderClr, ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference(), pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference(), ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), pDst, pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), pDst, pBorderClr, ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), pDst, in pBorderClr.GetPinnableReference(), pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), pDst, in pBorderClr.GetPinnableReference(), ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), pBorderClr, pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), pBorderClr, ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, uint* pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference(), pFrameProtectionFlags);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int TransferVideoFrame(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr, Span<uint> pFrameProtectionFlags)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference(), ref pFrameProtectionFlags.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetContentProtectionManager(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, Span<IMFContentProtectionManager> pCPM)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->SetContentProtectionManager(ref pCPM.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetApplicationCertificate(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> pbBlob, uint cbBlob)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->SetApplicationCertificate(in pbBlob.GetPinnableReference(), cbBlob);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineProtectedContent> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineSrcElementsExVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineSrcElementsExVtblExtensions.gen.cs
@@ -1,0 +1,2590 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineSrcElementsExVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint GetLength(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint>)@this->LpVtbl[3])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetURL(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, uint index, char** pURL)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[4])(@this, index, pURL);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetURL(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, uint index, ref char* pURL)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** pURLPtr = &pURL)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[4])(@this, index, pURLPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetType(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, uint index, char** pType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[5])(@this, index, pType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetType(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, uint index, ref char* pType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** pTypePtr = &pType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[5])(@this, index, pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetMedia(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, uint index, char** pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[6])(@this, index, pMedia);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetMedia(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, uint index, ref char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** pMediaPtr = &pMedia)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[6])(@this, index, pMediaPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pType, pMedia);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pType, pMediaPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURL, pType, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, ref char pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMedia);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, ref char pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMedia);
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+        }
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, char* pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMedia);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, char* pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, ref char pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, ref char pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+            }
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMedia);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+            }
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+        }
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RemoveAllElements(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, int>)@this->LpVtbl[8])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, char* pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMedia, keySystem);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, char* pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMedia, keySystemPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMedia, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, ref char pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMediaPtr, keySystem);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, ref char pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMediaPtr, keySystemPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pMediaPtr = &pMedia)
+        {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMediaPtr, keySystem);
+        SilkMarshal.Free((nint)pMediaPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMediaPtr, keySystemPtr);
+        }
+        SilkMarshal.Free((nint)pMediaPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pType, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, ref char pType, char* pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMedia, keySystem);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, ref char pType, char* pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMedia, keySystemPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, ref char pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMedia, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, ref char pType, ref char pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystem);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, ref char pType, ref char pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, ref char pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystem);
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+            }
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMedia, keySystem);
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMedia, keySystemPtr);
+        }
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMedia, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystem);
+        }
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+            }
+        }
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        }
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystem);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+        }
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURL, pTypePtr, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, char* pType, char* pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMedia, keySystem);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, char* pType, char* pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMedia, keySystemPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, char* pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMedia, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, char* pType, ref char pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystem);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, char* pType, ref char pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, char* pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystem);
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+            }
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, ref char pType, char* pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystem);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, ref char pType, char* pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, ref char pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, ref char pType, ref char pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, ref char pType, ref char pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    fixed (char* keySystemPtr = &keySystem)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, ref char pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+        SilkMarshal.Free((nint)pMediaPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+                }
+        SilkMarshal.Free((nint)pMediaPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, char*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystem);
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+            }
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+            }
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+                }
+            }
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+            }
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+            }
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, char*, byte*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, char* pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMedia, keySystem);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, char* pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMedia, keySystemPtr);
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMedia, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, ref char pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystem);
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, ref char pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+            }
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystem);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+        }
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pType, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, char* pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystem);
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, char* pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+            }
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, ref char pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+            }
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, ref char pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                fixed (char* keySystemPtr = &keySystem)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+            }
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+            }
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, char*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystem);
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+        }
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMedia, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+        }
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            fixed (char* keySystemPtr = &keySystem)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+            }
+        }
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, char*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        }
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystem);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, ref char keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        fixed (char* keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, byte*, char*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+        }
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        var keySystemPtr = (byte*) SilkMarshal.StringToPtr(keySystem, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, byte*, byte*, byte*, byte*, int>)@this->LpVtbl[9])(@this, pURLPtr, pTypePtr, pMediaPtr, keySystemPtr);
+        SilkMarshal.Free((nint)keySystemPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeySystem(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, uint index, char** pType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[10])(@this, index, pType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeySystem(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, uint index, ref char* pType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** pTypePtr = &pType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElementsEx*, uint, char**, int>)@this->LpVtbl[10])(@this, index, pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetURL(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, uint index, string[] pURLSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var pURL = (char**) SilkMarshal.StringArrayToPtr(pURLSa);
+        var ret = @this->GetURL(index, pURL);
+        SilkMarshal.CopyPtrToStringArray((nint) pURL, pURLSa);
+        SilkMarshal.Free((nint) pURL);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetType(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, uint index, string[] pTypeSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var pType = (char**) SilkMarshal.StringArrayToPtr(pTypeSa);
+        var ret = @this->GetType(index, pType);
+        SilkMarshal.CopyPtrToStringArray((nint) pType, pTypeSa);
+        SilkMarshal.Free((nint) pType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetMedia(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, uint index, string[] pMediaSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var pMedia = (char**) SilkMarshal.StringArrayToPtr(pMediaSa);
+        var ret = @this->GetMedia(index, pMedia);
+        SilkMarshal.CopyPtrToStringArray((nint) pMedia, pMediaSa);
+        SilkMarshal.Free((nint) pMedia);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, pType, ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, Span<char> pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, ref pType.GetPinnableReference(), pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, Span<char> pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, ref pType.GetPinnableReference(), pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, pType, ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, char* pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), pType, pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, char* pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), pType, ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), pType, pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, Span<char> pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, Span<char> pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), pType, pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), pType, ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), pType, pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, pType, ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, ref pType.GetPinnableReference(), pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, ref pType.GetPinnableReference(), pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, pType, ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, char* pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, Span<char> pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, Span<char> pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, ref pMedia.GetPinnableReference(), ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, Span<char> pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, Span<char> pType, char* pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, Span<char> pType, char* pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, Span<char> pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, Span<char> pType, Span<char> pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, Span<char> pType, Span<char> pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference(), ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, Span<char> pType, Span<char> pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, ref pMedia.GetPinnableReference(), ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, char* pType, char* pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, char* pType, char* pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, char* pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, char* pType, Span<char> pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, char* pType, Span<char> pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, ref pMedia.GetPinnableReference(), ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, char* pType, Span<char> pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, Span<char> pType, char* pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, Span<char> pType, char* pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, Span<char> pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, Span<char> pType, Span<char> pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, Span<char> pType, Span<char> pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference(), ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, Span<char> pType, Span<char> pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, ref pMedia.GetPinnableReference(), ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(ref pURL.GetPinnableReference(), pType, pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, char* pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, Span<char> pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, Span<char> pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, ref pMedia.GetPinnableReference(), ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, Span<char> pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, char* pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, char* pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, char* pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, Span<char> pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, Span<char> pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference(), ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, Span<char> pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, ref pType.GetPinnableReference(), pMedia, keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia, char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, ref pMedia.GetPinnableReference(), ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, ref pMedia.GetPinnableReference(), keySystem);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElementEx(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia, Span<char> keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElementEx(pURL, pType, pMedia, ref keySystem.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetKeySystem(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl, uint index, string[] pTypeSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var pType = (char**) SilkMarshal.StringArrayToPtr(pTypeSa);
+        var ret = @this->GetKeySystem(index, pType);
+        SilkMarshal.CopyPtrToStringArray((nint) pType, pTypeSa);
+        SilkMarshal.Free((nint) pType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineSrcElementsEx> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineSrcElementsVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineSrcElementsVtblExtensions.gen.cs
@@ -1,0 +1,768 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineSrcElementsVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineSrcElements> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineSrcElements> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint GetLength(this ComPtr<IMFMediaEngineSrcElements> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint>)@this->LpVtbl[3])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetURL(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, uint index, char** pURL)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint, char**, int>)@this->LpVtbl[4])(@this, index, pURL);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetURL(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, uint index, ref char* pURL)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** pURLPtr = &pURL)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint, char**, int>)@this->LpVtbl[4])(@this, index, pURLPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetType(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, uint index, char** pType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint, char**, int>)@this->LpVtbl[5])(@this, index, pType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetType(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, uint index, ref char* pType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** pTypePtr = &pType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint, char**, int>)@this->LpVtbl[5])(@this, index, pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetMedia(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, uint index, char** pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint, char**, int>)@this->LpVtbl[6])(@this, index, pMedia);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetMedia(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, uint index, ref char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** pMediaPtr = &pMedia)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, uint, char**, int>)@this->LpVtbl[6])(@this, index, pMediaPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, char* pURL, char* pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pType, pMedia);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, char* pURL, char* pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pType, pMediaPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, char* pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURL, pType, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, char* pURL, ref char pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMedia);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, char* pURL, ref char pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, char* pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pTypePtr = &pType)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMedia);
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+        }
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, byte*, byte*, int>)@this->LpVtbl[7])(@this, pURL, pTypePtr, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, ref char pURL, char* pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMedia);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, ref char pURL, char* pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, ref char pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, ref char pURL, ref char pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, ref char pURL, ref char pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+                fixed (char* pMediaPtr = &pMedia)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, ref char pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+            fixed (char* pTypePtr = &pType)
+            {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+            }
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, ref char pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pURLPtr = &pURL)
+        {
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, char*, byte*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMedia);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pType, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+            fixed (char* pMediaPtr = &pMedia)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, char*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+            }
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, ref char pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        fixed (char* pTypePtr = &pType)
+        {
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, char*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        }
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMedia);
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, ref char pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        fixed (char* pMediaPtr = &pMedia)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, byte*, char*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+        }
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pURLPtr = (byte*) SilkMarshal.StringToPtr(pURL, NativeStringEncoding.BStr);
+        var pTypePtr = (byte*) SilkMarshal.StringToPtr(pType, NativeStringEncoding.BStr);
+        var pMediaPtr = (byte*) SilkMarshal.StringToPtr(pMedia, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, byte*, byte*, byte*, int>)@this->LpVtbl[7])(@this, pURLPtr, pTypePtr, pMediaPtr);
+        SilkMarshal.Free((nint)pMediaPtr);
+        SilkMarshal.Free((nint)pTypePtr);
+        SilkMarshal.Free((nint)pURLPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RemoveAllElements(this ComPtr<IMFMediaEngineSrcElements> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSrcElements*, int>)@this->LpVtbl[8])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetURL(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, uint index, string[] pURLSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var pURL = (char**) SilkMarshal.StringArrayToPtr(pURLSa);
+        var ret = @this->GetURL(index, pURL);
+        SilkMarshal.CopyPtrToStringArray((nint) pURL, pURLSa);
+        SilkMarshal.Free((nint) pURL);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetType(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, uint index, string[] pTypeSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var pType = (char**) SilkMarshal.StringArrayToPtr(pTypeSa);
+        var ret = @this->GetType(index, pType);
+        SilkMarshal.CopyPtrToStringArray((nint) pType, pTypeSa);
+        SilkMarshal.Free((nint) pType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetMedia(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, uint index, string[] pMediaSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var pMedia = (char**) SilkMarshal.StringArrayToPtr(pMediaSa);
+        var ret = @this->GetMedia(index, pMedia);
+        SilkMarshal.CopyPtrToStringArray((nint) pMedia, pMediaSa);
+        SilkMarshal.Free((nint) pMedia);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, char* pURL, char* pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, pType, ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, char* pURL, Span<char> pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, ref pType.GetPinnableReference(), pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, char* pURL, Span<char> pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, char* pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, ref pType.GetPinnableReference(), pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, char* pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, pType, ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, Span<char> pURL, char* pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), pType, pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, Span<char> pURL, char* pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), pType, ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, Span<char> pURL, char* pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), pType, pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, Span<char> pURL, Span<char> pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, Span<char> pURL, Span<char> pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, Span<char> pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), ref pType.GetPinnableReference(), pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), pType, pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), pType, ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, Span<char> pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(ref pURL.GetPinnableReference(), pType, pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, char* pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, pType, ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, char* pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, ref pType.GetPinnableReference(), pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, ref pType.GetPinnableReference(), ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, Span<char> pType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, ref pType.GetPinnableReference(), pMedia);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddElement(this ComPtr<IMFMediaEngineSrcElements> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pURL, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pType, Span<char> pMedia)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddElement(pURL, pType, ref pMedia.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineSrcElements> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineSupportsSourceTransferVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineSupportsSourceTransferVtblExtensions.gen.cs
@@ -1,0 +1,486 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineSupportsSourceTransferVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int ShouldTransferSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, int* pfShouldTransfer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, int*, int>)@this->LpVtbl[3])(@this, pfShouldTransfer);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int ShouldTransferSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref int pfShouldTransfer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* pfShouldTransferPtr = &pfShouldTransfer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, int*, int>)@this->LpVtbl[3])(@this, pfShouldTransferPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int DetachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream** ppByteStream, IMFMediaSource** ppMediaSource, IMFMediaSourceExtension** ppMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStream, ppMediaSource, ppMSE);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int DetachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream** ppByteStream, IMFMediaSource** ppMediaSource, ref IMFMediaSourceExtension* ppMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaSourceExtension** ppMSEPtr = &ppMSE)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStream, ppMediaSource, ppMSEPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int DetachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream** ppByteStream, ref IMFMediaSource* ppMediaSource, IMFMediaSourceExtension** ppMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaSource** ppMediaSourcePtr = &ppMediaSource)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStream, ppMediaSourcePtr, ppMSE);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int DetachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream** ppByteStream, ref IMFMediaSource* ppMediaSource, ref IMFMediaSourceExtension* ppMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaSource** ppMediaSourcePtr = &ppMediaSource)
+        {
+            fixed (IMFMediaSourceExtension** ppMSEPtr = &ppMSE)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStream, ppMediaSourcePtr, ppMSEPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int DetachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref IMFByteStream* ppByteStream, IMFMediaSource** ppMediaSource, IMFMediaSourceExtension** ppMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream** ppByteStreamPtr = &ppByteStream)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStreamPtr, ppMediaSource, ppMSE);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int DetachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref IMFByteStream* ppByteStream, IMFMediaSource** ppMediaSource, ref IMFMediaSourceExtension* ppMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream** ppByteStreamPtr = &ppByteStream)
+        {
+            fixed (IMFMediaSourceExtension** ppMSEPtr = &ppMSE)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStreamPtr, ppMediaSource, ppMSEPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int DetachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref IMFByteStream* ppByteStream, ref IMFMediaSource* ppMediaSource, IMFMediaSourceExtension** ppMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream** ppByteStreamPtr = &ppByteStream)
+        {
+            fixed (IMFMediaSource** ppMediaSourcePtr = &ppMediaSource)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStreamPtr, ppMediaSourcePtr, ppMSE);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int DetachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref IMFByteStream* ppByteStream, ref IMFMediaSource* ppMediaSource, ref IMFMediaSourceExtension* ppMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream** ppByteStreamPtr = &ppByteStream)
+        {
+            fixed (IMFMediaSource** ppMediaSourcePtr = &ppMediaSource)
+            {
+                fixed (IMFMediaSourceExtension** ppMSEPtr = &ppMSE)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream**, IMFMediaSource**, IMFMediaSourceExtension**, int>)@this->LpVtbl[4])(@this, ppByteStreamPtr, ppMediaSourcePtr, ppMSEPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream* pByteStream, IMFMediaSource* pMediaSource, IMFMediaSourceExtension* pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStream, pMediaSource, pMSE);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream* pByteStream, IMFMediaSource* pMediaSource, ref IMFMediaSourceExtension pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaSourceExtension* pMSEPtr = &pMSE)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStream, pMediaSource, pMSEPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream* pByteStream, ref IMFMediaSource pMediaSource, IMFMediaSourceExtension* pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaSource* pMediaSourcePtr = &pMediaSource)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStream, pMediaSourcePtr, pMSE);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream* pByteStream, ref IMFMediaSource pMediaSource, ref IMFMediaSourceExtension pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaSource* pMediaSourcePtr = &pMediaSource)
+        {
+            fixed (IMFMediaSourceExtension* pMSEPtr = &pMSE)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStream, pMediaSourcePtr, pMSEPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref IMFByteStream pByteStream, IMFMediaSource* pMediaSource, IMFMediaSourceExtension* pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStreamPtr, pMediaSource, pMSE);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref IMFByteStream pByteStream, IMFMediaSource* pMediaSource, ref IMFMediaSourceExtension pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (IMFMediaSourceExtension* pMSEPtr = &pMSE)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStreamPtr, pMediaSource, pMSEPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref IMFByteStream pByteStream, ref IMFMediaSource pMediaSource, IMFMediaSourceExtension* pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (IMFMediaSource* pMediaSourcePtr = &pMediaSource)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStreamPtr, pMediaSourcePtr, pMSE);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref IMFByteStream pByteStream, ref IMFMediaSource pMediaSource, ref IMFMediaSourceExtension pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pByteStreamPtr = &pByteStream)
+        {
+            fixed (IMFMediaSource* pMediaSourcePtr = &pMediaSource)
+            {
+                fixed (IMFMediaSourceExtension* pMSEPtr = &pMSE)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineSupportsSourceTransfer*, IMFByteStream*, IMFMediaSource*, IMFMediaSourceExtension*, int>)@this->LpVtbl[5])(@this, pByteStreamPtr, pMediaSourcePtr, pMSEPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int ShouldTransferSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, Span<int> pfShouldTransfer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->ShouldTransferSource(ref pfShouldTransfer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int DetachMediaSource<TI0>(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream** ppByteStream, IMFMediaSource** ppMediaSource, ref ComPtr<TI0> ppMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->DetachMediaSource(ppByteStream, ppMediaSource, (IMFMediaSourceExtension**) ppMSE.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int DetachMediaSource<TI0>(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream** ppByteStream, ref IMFMediaSource* ppMediaSource, ref ComPtr<TI0> ppMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->DetachMediaSource(ppByteStream, ref ppMediaSource, (IMFMediaSourceExtension**) ppMSE.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int DetachMediaSource<TI0>(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref IMFByteStream* ppByteStream, IMFMediaSource** ppMediaSource, ref ComPtr<TI0> ppMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->DetachMediaSource(ref ppByteStream, ppMediaSource, (IMFMediaSourceExtension**) ppMSE.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int DetachMediaSource<TI0>(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref IMFByteStream* ppByteStream, ref IMFMediaSource* ppMediaSource, ref ComPtr<TI0> ppMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->DetachMediaSource(ref ppByteStream, ref ppMediaSource, (IMFMediaSourceExtension**) ppMSE.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource<TI0>(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream* pByteStream, IMFMediaSource* pMediaSource, ComPtr<TI0> pMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AttachMediaSource(pByteStream, pMediaSource, (IMFMediaSourceExtension*) pMSE.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream* pByteStream, IMFMediaSource* pMediaSource, Span<IMFMediaSourceExtension> pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AttachMediaSource(pByteStream, pMediaSource, ref pMSE.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream* pByteStream, Span<IMFMediaSource> pMediaSource, IMFMediaSourceExtension* pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AttachMediaSource(pByteStream, ref pMediaSource.GetPinnableReference(), pMSE);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource<TI0>(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream* pByteStream, ref IMFMediaSource pMediaSource, ComPtr<TI0> pMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AttachMediaSource(pByteStream, ref pMediaSource, (IMFMediaSourceExtension*) pMSE.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, IMFByteStream* pByteStream, Span<IMFMediaSource> pMediaSource, Span<IMFMediaSourceExtension> pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AttachMediaSource(pByteStream, ref pMediaSource.GetPinnableReference(), ref pMSE.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, Span<IMFByteStream> pByteStream, IMFMediaSource* pMediaSource, IMFMediaSourceExtension* pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AttachMediaSource(ref pByteStream.GetPinnableReference(), pMediaSource, pMSE);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource<TI0>(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref IMFByteStream pByteStream, IMFMediaSource* pMediaSource, ComPtr<TI0> pMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AttachMediaSource(ref pByteStream, pMediaSource, (IMFMediaSourceExtension*) pMSE.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, Span<IMFByteStream> pByteStream, IMFMediaSource* pMediaSource, Span<IMFMediaSourceExtension> pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AttachMediaSource(ref pByteStream.GetPinnableReference(), pMediaSource, ref pMSE.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, Span<IMFByteStream> pByteStream, Span<IMFMediaSource> pMediaSource, IMFMediaSourceExtension* pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AttachMediaSource(ref pByteStream.GetPinnableReference(), ref pMediaSource.GetPinnableReference(), pMSE);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AttachMediaSource<TI0>(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, ref IMFByteStream pByteStream, ref IMFMediaSource pMediaSource, ComPtr<TI0> pMSE) where TI0 : unmanaged, IComVtbl<IMFMediaSourceExtension>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AttachMediaSource(ref pByteStream, ref pMediaSource, (IMFMediaSourceExtension*) pMSE.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AttachMediaSource(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl, Span<IMFByteStream> pByteStream, Span<IMFMediaSource> pMediaSource, Span<IMFMediaSourceExtension> pMSE)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AttachMediaSource(ref pByteStream.GetPinnableReference(), ref pMediaSource.GetPinnableReference(), ref pMSE.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineSupportsSourceTransfer> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineTransferSourceVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineTransferSourceVtblExtensions.gen.cs
@@ -1,0 +1,158 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineTransferSourceVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineTransferSource> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineTransferSource> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineTransferSource> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineTransferSource> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineTransferSource> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineTransferSource> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferSourceToMediaEngine(this ComPtr<IMFMediaEngineTransferSource> thisVtbl, IMFMediaEngine* destination)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, IMFMediaEngine*, int>)@this->LpVtbl[3])(@this, destination);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int TransferSourceToMediaEngine(this ComPtr<IMFMediaEngineTransferSource> thisVtbl, ref IMFMediaEngine destination)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaEngine* destinationPtr = &destination)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineTransferSource*, IMFMediaEngine*, int>)@this->LpVtbl[3])(@this, destinationPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineTransferSource> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineTransferSource> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineTransferSource> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int TransferSourceToMediaEngine<TI0>(this ComPtr<IMFMediaEngineTransferSource> thisVtbl, ComPtr<TI0> destination) where TI0 : unmanaged, IComVtbl<IMFMediaEngine>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferSourceToMediaEngine((IMFMediaEngine*) destination.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int TransferSourceToMediaEngine(this ComPtr<IMFMediaEngineTransferSource> thisVtbl, Span<IMFMediaEngine> destination)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferSourceToMediaEngine(ref destination.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineTransferSource> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineVtblExtensions.gen.cs
@@ -1,0 +1,1319 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngine> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngine> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngine> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngine> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetError(this ComPtr<IMFMediaEngine> thisVtbl, IMFMediaError** ppError)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaError**, int>)@this->LpVtbl[3])(@this, ppError);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetError(this ComPtr<IMFMediaEngine> thisVtbl, ref IMFMediaError* ppError)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaError** ppErrorPtr = &ppError)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaError**, int>)@this->LpVtbl[3])(@this, ppErrorPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetErrorCode(this ComPtr<IMFMediaEngine> thisVtbl, MediaEngineErr error)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, MediaEngineErr, int>)@this->LpVtbl[4])(@this, error);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetSourceElements(this ComPtr<IMFMediaEngine> thisVtbl, IMFMediaEngineSrcElements* pSrcElements)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaEngineSrcElements*, int>)@this->LpVtbl[5])(@this, pSrcElements);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSourceElements(this ComPtr<IMFMediaEngine> thisVtbl, ref IMFMediaEngineSrcElements pSrcElements)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaEngineSrcElements* pSrcElementsPtr = &pSrcElements)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaEngineSrcElements*, int>)@this->LpVtbl[5])(@this, pSrcElementsPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetSource(this ComPtr<IMFMediaEngine> thisVtbl, char* pUrl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, int>)@this->LpVtbl[6])(@this, pUrl);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSource(this ComPtr<IMFMediaEngine> thisVtbl, ref char pUrl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* pUrlPtr = &pUrl)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, int>)@this->LpVtbl[6])(@this, pUrlPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSource(this ComPtr<IMFMediaEngine> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string pUrl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pUrlPtr = (byte*) SilkMarshal.StringToPtr(pUrl, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, byte*, int>)@this->LpVtbl[6])(@this, pUrlPtr);
+        SilkMarshal.Free((nint)pUrlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCurrentSource(this ComPtr<IMFMediaEngine> thisVtbl, char** ppUrl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char**, int>)@this->LpVtbl[7])(@this, ppUrl);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCurrentSource(this ComPtr<IMFMediaEngine> thisVtbl, ref char* ppUrl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** ppUrlPtr = &ppUrl)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char**, int>)@this->LpVtbl[7])(@this, ppUrlPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ushort GetNetworkState(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ushort ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, ushort>)@this->LpVtbl[8])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static MediaEnginePreload GetPreload(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        MediaEnginePreload ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, MediaEnginePreload>)@this->LpVtbl[9])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetPreload(this ComPtr<IMFMediaEngine> thisVtbl, MediaEnginePreload Preload)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, MediaEnginePreload, int>)@this->LpVtbl[10])(@this, Preload);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetBuffered(this ComPtr<IMFMediaEngine> thisVtbl, IMFMediaTimeRange** ppBuffered)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaTimeRange**, int>)@this->LpVtbl[11])(@this, ppBuffered);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetBuffered(this ComPtr<IMFMediaEngine> thisVtbl, ref IMFMediaTimeRange* ppBuffered)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaTimeRange** ppBufferedPtr = &ppBuffered)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaTimeRange**, int>)@this->LpVtbl[11])(@this, ppBufferedPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Load(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, int>)@this->LpVtbl[12])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, char* type, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswer);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, char* type, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswerPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, ref char type, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, ref char type, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref MediaEngineCanplay pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+        }
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ushort GetReadyState(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ushort ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, ushort>)@this->LpVtbl[14])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsSeeking(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[15])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetCurrentTime(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double>)@this->LpVtbl[16])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetCurrentTime(this ComPtr<IMFMediaEngine> thisVtbl, double seekTime)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double, int>)@this->LpVtbl[17])(@this, seekTime);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetStartTime(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double>)@this->LpVtbl[18])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetDuration(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double>)@this->LpVtbl[19])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsPaused(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[20])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetDefaultPlaybackRate(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double>)@this->LpVtbl[21])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetDefaultPlaybackRate(this ComPtr<IMFMediaEngine> thisVtbl, double Rate)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double, int>)@this->LpVtbl[22])(@this, Rate);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetPlaybackRate(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double>)@this->LpVtbl[23])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetPlaybackRate(this ComPtr<IMFMediaEngine> thisVtbl, double Rate)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double, int>)@this->LpVtbl[24])(@this, Rate);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPlayed(this ComPtr<IMFMediaEngine> thisVtbl, IMFMediaTimeRange** ppPlayed)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaTimeRange**, int>)@this->LpVtbl[25])(@this, ppPlayed);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPlayed(this ComPtr<IMFMediaEngine> thisVtbl, ref IMFMediaTimeRange* ppPlayed)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaTimeRange** ppPlayedPtr = &ppPlayed)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaTimeRange**, int>)@this->LpVtbl[25])(@this, ppPlayedPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSeekable(this ComPtr<IMFMediaEngine> thisVtbl, IMFMediaTimeRange** ppSeekable)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaTimeRange**, int>)@this->LpVtbl[26])(@this, ppSeekable);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSeekable(this ComPtr<IMFMediaEngine> thisVtbl, ref IMFMediaTimeRange* ppSeekable)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaTimeRange** ppSeekablePtr = &ppSeekable)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, IMFMediaTimeRange**, int>)@this->LpVtbl[26])(@this, ppSeekablePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsEnded(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[27])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 GetAutoPlay(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[28])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetAutoPlay(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Bool32 AutoPlay)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[29])(@this, AutoPlay);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 GetLoop(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[30])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetLoop(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Bool32 Loop)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[31])(@this, Loop);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Play(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, int>)@this->LpVtbl[32])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Pause(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, int>)@this->LpVtbl[33])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 GetMuted(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[34])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetMuted(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Bool32 Muted)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[35])(@this, Muted);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetVolume(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double>)@this->LpVtbl[36])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetVolume(this ComPtr<IMFMediaEngine> thisVtbl, double Volume)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, double, int>)@this->LpVtbl[37])(@this, Volume);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 HasVideo(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[38])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 HasAudio(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Bool32>)@this->LpVtbl[39])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetNativeVideoSize(this ComPtr<IMFMediaEngine> thisVtbl, uint* cx, uint* cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cx, cy);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetNativeVideoSize(this ComPtr<IMFMediaEngine> thisVtbl, uint* cx, ref uint cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* cyPtr = &cy)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cx, cyPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetNativeVideoSize(this ComPtr<IMFMediaEngine> thisVtbl, ref uint cx, uint* cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* cxPtr = &cx)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cxPtr, cy);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetNativeVideoSize(this ComPtr<IMFMediaEngine> thisVtbl, ref uint cx, ref uint cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* cxPtr = &cx)
+        {
+            fixed (uint* cyPtr = &cy)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[40])(@this, cxPtr, cyPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetVideoAspectRatio(this ComPtr<IMFMediaEngine> thisVtbl, uint* cx, uint* cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cx, cy);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetVideoAspectRatio(this ComPtr<IMFMediaEngine> thisVtbl, uint* cx, ref uint cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* cyPtr = &cy)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cx, cyPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetVideoAspectRatio(this ComPtr<IMFMediaEngine> thisVtbl, ref uint cx, uint* cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* cxPtr = &cx)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cxPtr, cy);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetVideoAspectRatio(this ComPtr<IMFMediaEngine> thisVtbl, ref uint cx, ref uint cy)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* cxPtr = &cx)
+        {
+            fixed (uint* cyPtr = &cy)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, uint*, uint*, int>)@this->LpVtbl[41])(@this, cxPtr, cyPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Shutdown(this ComPtr<IMFMediaEngine> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, int>)@this->LpVtbl[42])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDst, pBorderClr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDst, pBorderClrPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDstPtr, pBorderClr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+        {
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrc, pDstPtr, pBorderClrPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDst, pBorderClr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDst, pBorderClrPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurf, pSrcPtr, pDstPtr, pBorderClrPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDst, pBorderClr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDst, pBorderClrPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrc, pDstPtr, pBorderClrPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDst, pBorderClrPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, ref Silk.NET.Core.Native.IUnknown pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Silk.NET.Core.Native.IUnknown* pDstSurfPtr = &pDstSurf)
+        {
+            fixed (VideoNormalizedRect* pSrcPtr = &pSrc)
+            {
+                fixed (Silk.NET.Maths.Box2D<int>* pDstPtr = &pDst)
+                {
+                    fixed (_MFARGB* pBorderClrPtr = &pBorderClr)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, Silk.NET.Core.Native.IUnknown*, VideoNormalizedRect*, Silk.NET.Maths.Box2D<int>*, _MFARGB*, int>)@this->LpVtbl[43])(@this, pDstSurfPtr, pSrcPtr, pDstPtr, pBorderClrPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int OnVideoStreamTick(this ComPtr<IMFMediaEngine> thisVtbl, long* pPts)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, long*, int>)@this->LpVtbl[44])(@this, pPts);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int OnVideoStreamTick(this ComPtr<IMFMediaEngine> thisVtbl, ref long pPts)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (long* pPtsPtr = &pPts)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, long*, int>)@this->LpVtbl[44])(@this, pPtsPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngine> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngine> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngine> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetError<TI0>(this ComPtr<IMFMediaEngine> thisVtbl, ref ComPtr<TI0> ppError) where TI0 : unmanaged, IComVtbl<IMFMediaError>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetError((IMFMediaError**) ppError.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSourceElements<TI0>(this ComPtr<IMFMediaEngine> thisVtbl, ComPtr<TI0> pSrcElements) where TI0 : unmanaged, IComVtbl<IMFMediaEngineSrcElements>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->SetSourceElements((IMFMediaEngineSrcElements*) pSrcElements.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSourceElements(this ComPtr<IMFMediaEngine> thisVtbl, Span<IMFMediaEngineSrcElements> pSrcElements)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->SetSourceElements(ref pSrcElements.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetSource(this ComPtr<IMFMediaEngine> thisVtbl, Span<char> pUrl)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->SetSource(ref pUrl.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetCurrentSource(this ComPtr<IMFMediaEngine> thisVtbl, string[] ppUrlSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var ppUrl = (char**) SilkMarshal.StringArrayToPtr(ppUrlSa);
+        var ret = @this->GetCurrentSource(ppUrl);
+        SilkMarshal.CopyPtrToStringArray((nint) ppUrl, ppUrlSa);
+        SilkMarshal.Free((nint) ppUrl);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBuffered<TI0>(this ComPtr<IMFMediaEngine> thisVtbl, ref ComPtr<TI0> ppBuffered) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetBuffered((IMFMediaTimeRange**) ppBuffered.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, char* type, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CanPlayType(type, ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, Span<char> type, MediaEngineCanplay* pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CanPlayType(ref type.GetPinnableReference(), pAnswer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, Span<char> type, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CanPlayType(ref type.GetPinnableReference(), ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<MediaEngineCanplay> pAnswer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CanPlayType(type, ref pAnswer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetPlayed<TI0>(this ComPtr<IMFMediaEngine> thisVtbl, ref ComPtr<TI0> ppPlayed) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetPlayed((IMFMediaTimeRange**) ppPlayed.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetSeekable<TI0>(this ComPtr<IMFMediaEngine> thisVtbl, ref ComPtr<TI0> ppSeekable) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetSeekable((IMFMediaTimeRange**) ppSeekable.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetNativeVideoSize(this ComPtr<IMFMediaEngine> thisVtbl, uint* cx, Span<uint> cy)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetNativeVideoSize(cx, ref cy.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetNativeVideoSize(this ComPtr<IMFMediaEngine> thisVtbl, Span<uint> cx, uint* cy)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetNativeVideoSize(ref cx.GetPinnableReference(), cy);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetNativeVideoSize(this ComPtr<IMFMediaEngine> thisVtbl, Span<uint> cx, Span<uint> cy)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetNativeVideoSize(ref cx.GetPinnableReference(), ref cy.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetVideoAspectRatio(this ComPtr<IMFMediaEngine> thisVtbl, uint* cx, Span<uint> cy)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetVideoAspectRatio(cx, ref cy.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetVideoAspectRatio(this ComPtr<IMFMediaEngine> thisVtbl, Span<uint> cx, uint* cy)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetVideoAspectRatio(ref cx.GetPinnableReference(), cy);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetVideoAspectRatio(this ComPtr<IMFMediaEngine> thisVtbl, Span<uint> cx, Span<uint> cy)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetVideoAspectRatio(ref cx.GetPinnableReference(), ref cy.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngine> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, pSrc, pDst, in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngine> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, pDst, in pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, pSrc, in pDst.GetPinnableReference(), pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngine> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, pSrc, in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngine> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, pSrc, in pDst, in pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngine> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), pDst, in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngine> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, pDst, in pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngine> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Silk.NET.Core.Native.IUnknown* pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(pDstSurf, in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int TransferVideoFrame<TI0>(this ComPtr<IMFMediaEngine> thisVtbl, ComPtr<TI0> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in VideoNormalizedRect pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in Silk.NET.Maths.Box2D<int> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in _MFARGB pBorderClr) where TI0 : unmanaged, IComVtbl<Silk.NET.Core.Native.IUnknown>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->TransferVideoFrame((Silk.NET.Core.Native.IUnknown*) pDstSurf.Handle, in pSrc, in pDst, in pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, pDst, in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, in pDst.GetPinnableReference(), pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] VideoNormalizedRect* pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), pSrc, in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), pDst, pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] Silk.NET.Maths.Box2D<int>* pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), pDst, in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] _MFARGB* pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), pBorderClr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int TransferVideoFrame(this ComPtr<IMFMediaEngine> thisVtbl, Span<Silk.NET.Core.Native.IUnknown> pDstSurf, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<VideoNormalizedRect> pSrc, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<Silk.NET.Maths.Box2D<int>> pDst, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<_MFARGB> pBorderClr)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->TransferVideoFrame(ref pDstSurf.GetPinnableReference(), in pSrc.GetPinnableReference(), in pDst.GetPinnableReference(), in pBorderClr.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int OnVideoStreamTick(this ComPtr<IMFMediaEngine> thisVtbl, Span<long> pPts)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->OnVideoStreamTick(ref pPts.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngine> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineVtblExtensions.gen.cs
@@ -106,11 +106,11 @@ public unsafe static class MFMediaEngineVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static int SetErrorCode(this ComPtr<IMFMediaEngine> thisVtbl, MediaEngineErr error)
+    public static int SetErrorCode(this ComPtr<IMFMediaEngine> thisVtbl, MediaEngineError error)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
-        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, MediaEngineErr, int>)@this->LpVtbl[4])(@this, error);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, MediaEngineError, int>)@this->LpVtbl[4])(@this, error);
         return ret;
     }
 
@@ -246,73 +246,73 @@ public unsafe static class MFMediaEngineVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, char* type, MediaEngineCanplay* pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, char* type, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
-        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswer);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, type, pAnswer);
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, char* type, ref MediaEngineCanplay pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, char* type, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
-        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, type, pAnswerPtr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, type, pAnswerPtr);
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, ref char type, MediaEngineCanplay* pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, ref char type, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         fixed (char* typePtr = &type)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, ref char type, ref MediaEngineCanplay pAnswer)
+    public static int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, ref char type, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         fixed (char* typePtr = &type)
         {
-            fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+            fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
             {
-                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, char*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
             }
         }
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, MediaEngineCanplay* pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
-        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswer);
         SilkMarshal.Free((nint)typePtr);
         return ret;
     }
 
     /// <summary>To be documented.</summary>
-    public static int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref MediaEngineCanplay pAnswer)
+    public static int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref MediaEngineCanPlay pAnswer)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
         var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
-        fixed (MediaEngineCanplay* pAnswerPtr = &pAnswer)
+        fixed (MediaEngineCanPlay* pAnswerPtr = &pAnswer)
         {
-            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, byte*, MediaEngineCanplay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngine*, byte*, MediaEngineCanPlay*, int>)@this->LpVtbl[13])(@this, typePtr, pAnswerPtr);
         }
         SilkMarshal.Free((nint)typePtr);
         return ret;
@@ -1020,7 +1020,7 @@ public unsafe static class MFMediaEngineVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, char* type, Span<MediaEngineCanplay> pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, char* type, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -1028,7 +1028,7 @@ public unsafe static class MFMediaEngineVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, Span<char> type, MediaEngineCanplay* pAnswer)
+    public static unsafe int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, Span<char> type, MediaEngineCanPlay* pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -1036,7 +1036,7 @@ public unsafe static class MFMediaEngineVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, Span<char> type, Span<MediaEngineCanplay> pAnswer)
+    public static int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, Span<char> type, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader
@@ -1044,7 +1044,7 @@ public unsafe static class MFMediaEngineVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<MediaEngineCanplay> pAnswer)
+    public static int CanPlayType(this ComPtr<IMFMediaEngine> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<MediaEngineCanPlay> pAnswer)
     {
         var @this = thisVtbl.Handle;
         // SpanOverloader

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineWebSupportVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaEngineWebSupportVtblExtensions.gen.cs
@@ -1,0 +1,168 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaEngineWebSupportVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineWebSupport> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineWebSupport> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineWebSupport> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineWebSupport> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaEngineWebSupport> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaEngineWebSupport> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 ShouldDelayTheLoadEvent(this ComPtr<IMFMediaEngineWebSupport> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, Silk.NET.Core.Bool32>)@this->LpVtbl[3])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int ConnectWebAudio(this ComPtr<IMFMediaEngineWebSupport> thisVtbl, uint dwSampleRate, IAudioSourceProvider** ppSourceProvider)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, uint, IAudioSourceProvider**, int>)@this->LpVtbl[4])(@this, dwSampleRate, ppSourceProvider);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int ConnectWebAudio(this ComPtr<IMFMediaEngineWebSupport> thisVtbl, uint dwSampleRate, ref IAudioSourceProvider* ppSourceProvider)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IAudioSourceProvider** ppSourceProviderPtr = &ppSourceProvider)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, uint, IAudioSourceProvider**, int>)@this->LpVtbl[4])(@this, dwSampleRate, ppSourceProviderPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int DisconnectWebAudio(this ComPtr<IMFMediaEngineWebSupport> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaEngineWebSupport*, int>)@this->LpVtbl[5])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaEngineWebSupport> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineWebSupport> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaEngineWebSupport> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int ConnectWebAudio<TI0>(this ComPtr<IMFMediaEngineWebSupport> thisVtbl, uint dwSampleRate, ref ComPtr<TI0> ppSourceProvider) where TI0 : unmanaged, IComVtbl<IAudioSourceProvider>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->ConnectWebAudio(dwSampleRate, (IAudioSourceProvider**) ppSourceProvider.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaEngineWebSupport> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaErrorVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaErrorVtblExtensions.gen.cs
@@ -1,0 +1,157 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaErrorVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaError> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaError> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaError> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaError> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaError> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaError> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ushort GetErrorCode(this ComPtr<IMFMediaError> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ushort ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, ushort>)@this->LpVtbl[3])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetExtendedErrorCode(this ComPtr<IMFMediaError> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, int>)@this->LpVtbl[4])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetErrorCode(this ComPtr<IMFMediaError> thisVtbl, MediaEngineErr error)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, MediaEngineErr, int>)@this->LpVtbl[5])(@this, error);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetExtendedErrorCode(this ComPtr<IMFMediaError> thisVtbl, int error)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, int, int>)@this->LpVtbl[6])(@this, error);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaError> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaError> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaError> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaError> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaErrorVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaErrorVtblExtensions.gen.cs
@@ -103,11 +103,11 @@ public unsafe static class MFMediaErrorVtblExtensions
     }
 
     /// <summary>To be documented.</summary>
-    public static int SetErrorCode(this ComPtr<IMFMediaError> thisVtbl, MediaEngineErr error)
+    public static int SetErrorCode(this ComPtr<IMFMediaError> thisVtbl, MediaEngineError error)
     {
         var @this = thisVtbl.Handle;
         int ret = default;
-        ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, MediaEngineErr, int>)@this->LpVtbl[5])(@this, error);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaError*, MediaEngineError, int>)@this->LpVtbl[5])(@this, error);
         return ret;
     }
 

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaKeySession2VtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaKeySession2VtblExtensions.gen.cs
@@ -1,0 +1,675 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaKeySession2VtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySession2> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySession2> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySession2> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySession2> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaKeySession2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaKeySession2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetError(this ComPtr<IMFMediaKeySession2> thisVtbl, ushort* code, uint* systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, code, systemCode);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetError(this ComPtr<IMFMediaKeySession2> thisVtbl, ushort* code, ref uint systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* systemCodePtr = &systemCode)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, code, systemCodePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetError(this ComPtr<IMFMediaKeySession2> thisVtbl, ref ushort code, uint* systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (ushort* codePtr = &code)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, codePtr, systemCode);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetError(this ComPtr<IMFMediaKeySession2> thisVtbl, ref ushort code, ref uint systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (ushort* codePtr = &code)
+        {
+            fixed (uint* systemCodePtr = &systemCode)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, codePtr, systemCodePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeySystem(this ComPtr<IMFMediaKeySession2> thisVtbl, char** keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char**, int>)@this->LpVtbl[4])(@this, keySystem);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeySystem(this ComPtr<IMFMediaKeySession2> thisVtbl, ref char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char**, int>)@this->LpVtbl[4])(@this, keySystemPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSessionId(this ComPtr<IMFMediaKeySession2> thisVtbl, char** sessionId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char**, int>)@this->LpVtbl[5])(@this, sessionId);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSessionId(this ComPtr<IMFMediaKeySession2> thisVtbl, ref char* sessionId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** sessionIdPtr = &sessionId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char**, int>)@this->LpVtbl[5])(@this, sessionIdPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int Update(this ComPtr<IMFMediaKeySession2> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* key, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, uint, int>)@this->LpVtbl[6])(@this, key, cb);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Update(this ComPtr<IMFMediaKeySession2> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte key, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* keyPtr = &key)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, uint, int>)@this->LpVtbl[6])(@this, keyPtr, cb);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Update(this ComPtr<IMFMediaKeySession2> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string key, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keyPtr = (byte*) SilkMarshal.StringToPtr(key, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, uint, int>)@this->LpVtbl[6])(@this, keyPtr, cb);
+        SilkMarshal.Free((nint)keyPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Close(this ComPtr<IMFMediaKeySession2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, int>)@this->LpVtbl[7])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeyStatuses(this ComPtr<IMFMediaKeySession2> thisVtbl, MFMediaKeyStatus** pKeyStatusesArray, uint* puSize)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, MFMediaKeyStatus**, uint*, int>)@this->LpVtbl[8])(@this, pKeyStatusesArray, puSize);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeyStatuses(this ComPtr<IMFMediaKeySession2> thisVtbl, MFMediaKeyStatus** pKeyStatusesArray, ref uint puSize)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* puSizePtr = &puSize)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, MFMediaKeyStatus**, uint*, int>)@this->LpVtbl[8])(@this, pKeyStatusesArray, puSizePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeyStatuses(this ComPtr<IMFMediaKeySession2> thisVtbl, ref MFMediaKeyStatus* pKeyStatusesArray, uint* puSize)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (MFMediaKeyStatus** pKeyStatusesArrayPtr = &pKeyStatusesArray)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, MFMediaKeyStatus**, uint*, int>)@this->LpVtbl[8])(@this, pKeyStatusesArrayPtr, puSize);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeyStatuses(this ComPtr<IMFMediaKeySession2> thisVtbl, ref MFMediaKeyStatus* pKeyStatusesArray, ref uint puSize)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (MFMediaKeyStatus** pKeyStatusesArrayPtr = &pKeyStatusesArray)
+        {
+            fixed (uint* puSizePtr = &puSize)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, MFMediaKeyStatus**, uint*, int>)@this->LpVtbl[8])(@this, pKeyStatusesArrayPtr, puSizePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int Load(this ComPtr<IMFMediaKeySession2> thisVtbl, char* bstrSessionId, int* pfLoaded)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, int*, int>)@this->LpVtbl[9])(@this, bstrSessionId, pfLoaded);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int Load(this ComPtr<IMFMediaKeySession2> thisVtbl, char* bstrSessionId, ref int pfLoaded)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* pfLoadedPtr = &pfLoaded)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, int*, int>)@this->LpVtbl[9])(@this, bstrSessionId, pfLoadedPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int Load(this ComPtr<IMFMediaKeySession2> thisVtbl, ref char bstrSessionId, int* pfLoaded)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrSessionIdPtr = &bstrSessionId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, int*, int>)@this->LpVtbl[9])(@this, bstrSessionIdPtr, pfLoaded);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Load(this ComPtr<IMFMediaKeySession2> thisVtbl, ref char bstrSessionId, ref int pfLoaded)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* bstrSessionIdPtr = &bstrSessionId)
+        {
+            fixed (int* pfLoadedPtr = &pfLoaded)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, int*, int>)@this->LpVtbl[9])(@this, bstrSessionIdPtr, pfLoadedPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int Load(this ComPtr<IMFMediaKeySession2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrSessionId, int* pfLoaded)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrSessionIdPtr = (byte*) SilkMarshal.StringToPtr(bstrSessionId, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, int*, int>)@this->LpVtbl[9])(@this, bstrSessionIdPtr, pfLoaded);
+        SilkMarshal.Free((nint)bstrSessionIdPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Load(this ComPtr<IMFMediaKeySession2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrSessionId, ref int pfLoaded)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var bstrSessionIdPtr = (byte*) SilkMarshal.StringToPtr(bstrSessionId, NativeStringEncoding.BStr);
+        fixed (int* pfLoadedPtr = &pfLoaded)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, int*, int>)@this->LpVtbl[9])(@this, bstrSessionIdPtr, pfLoadedPtr);
+        }
+        SilkMarshal.Free((nint)bstrSessionIdPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GenerateRequest(this ComPtr<IMFMediaKeySession2> thisVtbl, char* initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbInitData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataType, pbInitData, cb);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GenerateRequest(this ComPtr<IMFMediaKeySession2> thisVtbl, char* initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbInitData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* pbInitDataPtr = &pbInitData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataType, pbInitDataPtr, cb);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GenerateRequest(this ComPtr<IMFMediaKeySession2> thisVtbl, char* initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbInitData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pbInitDataPtr = (byte*) SilkMarshal.StringToPtr(pbInitData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataType, pbInitDataPtr, cb);
+        SilkMarshal.Free((nint)pbInitDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GenerateRequest(this ComPtr<IMFMediaKeySession2> thisVtbl, ref char initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbInitData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* initDataTypePtr = &initDataType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataTypePtr, pbInitData, cb);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GenerateRequest(this ComPtr<IMFMediaKeySession2> thisVtbl, ref char initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbInitData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* initDataTypePtr = &initDataType)
+        {
+            fixed (byte* pbInitDataPtr = &pbInitData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataTypePtr, pbInitDataPtr, cb);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GenerateRequest(this ComPtr<IMFMediaKeySession2> thisVtbl, ref char initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbInitData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* initDataTypePtr = &initDataType)
+        {
+        var pbInitDataPtr = (byte*) SilkMarshal.StringToPtr(pbInitData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, char*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataTypePtr, pbInitDataPtr, cb);
+        SilkMarshal.Free((nint)pbInitDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GenerateRequest(this ComPtr<IMFMediaKeySession2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbInitData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataTypePtr = (byte*) SilkMarshal.StringToPtr(initDataType, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataTypePtr, pbInitData, cb);
+        SilkMarshal.Free((nint)initDataTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GenerateRequest(this ComPtr<IMFMediaKeySession2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbInitData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataTypePtr = (byte*) SilkMarshal.StringToPtr(initDataType, NativeStringEncoding.BStr);
+        fixed (byte* pbInitDataPtr = &pbInitData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataTypePtr, pbInitDataPtr, cb);
+        }
+        SilkMarshal.Free((nint)initDataTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GenerateRequest(this ComPtr<IMFMediaKeySession2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbInitData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataTypePtr = (byte*) SilkMarshal.StringToPtr(initDataType, NativeStringEncoding.BStr);
+        var pbInitDataPtr = (byte*) SilkMarshal.StringToPtr(pbInitData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, byte*, byte*, uint, int>)@this->LpVtbl[10])(@this, initDataTypePtr, pbInitDataPtr, cb);
+        SilkMarshal.Free((nint)pbInitDataPtr);
+        SilkMarshal.Free((nint)initDataTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetExpiration(this ComPtr<IMFMediaKeySession2> thisVtbl, double* dblExpiration)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, double*, int>)@this->LpVtbl[11])(@this, dblExpiration);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetExpiration(this ComPtr<IMFMediaKeySession2> thisVtbl, ref double dblExpiration)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* dblExpirationPtr = &dblExpiration)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, double*, int>)@this->LpVtbl[11])(@this, dblExpirationPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Remove(this ComPtr<IMFMediaKeySession2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, int>)@this->LpVtbl[12])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Shutdown(this ComPtr<IMFMediaKeySession2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession2*, int>)@this->LpVtbl[13])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaKeySession2> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySession2> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySession2> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetError(this ComPtr<IMFMediaKeySession2> thisVtbl, ushort* code, Span<uint> systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetError(code, ref systemCode.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetError(this ComPtr<IMFMediaKeySession2> thisVtbl, Span<ushort> code, uint* systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetError(ref code.GetPinnableReference(), systemCode);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetError(this ComPtr<IMFMediaKeySession2> thisVtbl, Span<ushort> code, Span<uint> systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetError(ref code.GetPinnableReference(), ref systemCode.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetKeySystem(this ComPtr<IMFMediaKeySession2> thisVtbl, string[] keySystemSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var keySystem = (char**) SilkMarshal.StringArrayToPtr(keySystemSa);
+        var ret = @this->GetKeySystem(keySystem);
+        SilkMarshal.CopyPtrToStringArray((nint) keySystem, keySystemSa);
+        SilkMarshal.Free((nint) keySystem);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetSessionId(this ComPtr<IMFMediaKeySession2> thisVtbl, string[] sessionIdSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var sessionId = (char**) SilkMarshal.StringArrayToPtr(sessionIdSa);
+        var ret = @this->GetSessionId(sessionId);
+        SilkMarshal.CopyPtrToStringArray((nint) sessionId, sessionIdSa);
+        SilkMarshal.Free((nint) sessionId);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Update(this ComPtr<IMFMediaKeySession2> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> key, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->Update(in key.GetPinnableReference(), cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeyStatuses(this ComPtr<IMFMediaKeySession2> thisVtbl, MFMediaKeyStatus** pKeyStatusesArray, Span<uint> puSize)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetKeyStatuses(pKeyStatusesArray, ref puSize.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeyStatuses(this ComPtr<IMFMediaKeySession2> thisVtbl, ref MFMediaKeyStatus* pKeyStatusesArray, Span<uint> puSize)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetKeyStatuses(ref pKeyStatusesArray, ref puSize.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int Load(this ComPtr<IMFMediaKeySession2> thisVtbl, char* bstrSessionId, Span<int> pfLoaded)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->Load(bstrSessionId, ref pfLoaded.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int Load(this ComPtr<IMFMediaKeySession2> thisVtbl, Span<char> bstrSessionId, int* pfLoaded)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->Load(ref bstrSessionId.GetPinnableReference(), pfLoaded);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Load(this ComPtr<IMFMediaKeySession2> thisVtbl, Span<char> bstrSessionId, Span<int> pfLoaded)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->Load(ref bstrSessionId.GetPinnableReference(), ref pfLoaded.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Load(this ComPtr<IMFMediaKeySession2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string bstrSessionId, Span<int> pfLoaded)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->Load(bstrSessionId, ref pfLoaded.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GenerateRequest(this ComPtr<IMFMediaKeySession2> thisVtbl, char* initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> pbInitData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GenerateRequest(initDataType, in pbInitData.GetPinnableReference(), cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GenerateRequest(this ComPtr<IMFMediaKeySession2> thisVtbl, Span<char> initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbInitData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GenerateRequest(ref initDataType.GetPinnableReference(), pbInitData, cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GenerateRequest(this ComPtr<IMFMediaKeySession2> thisVtbl, Span<char> initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> pbInitData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GenerateRequest(ref initDataType.GetPinnableReference(), in pbInitData.GetPinnableReference(), cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GenerateRequest(this ComPtr<IMFMediaKeySession2> thisVtbl, Span<char> initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbInitData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GenerateRequest(ref initDataType.GetPinnableReference(), pbInitData, cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GenerateRequest(this ComPtr<IMFMediaKeySession2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string initDataType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> pbInitData, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GenerateRequest(initDataType, in pbInitData.GetPinnableReference(), cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetExpiration(this ComPtr<IMFMediaKeySession2> thisVtbl, Span<double> dblExpiration)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetExpiration(ref dblExpiration.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaKeySession2> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaKeySessionNotify2VtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaKeySessionNotify2VtblExtensions.gen.cs
@@ -1,0 +1,408 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaKeySessionNotify2VtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURL, message, cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (byte* messagePtr = &message)
+        {
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURL, messagePtr, cb);
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        var messagePtr = (byte*) SilkMarshal.StringToPtr(message, NativeStringEncoding.UTF8);
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURL, messagePtr, cb);
+        SilkMarshal.Free((nint)messagePtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (char* destinationURLPtr = &destinationURL)
+        {
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, message, cb);
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (char* destinationURLPtr = &destinationURL)
+        {
+            fixed (byte* messagePtr = &message)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+            }
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (char* destinationURLPtr = &destinationURL)
+        {
+        var messagePtr = (byte*) SilkMarshal.StringToPtr(message, NativeStringEncoding.UTF8);
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+        SilkMarshal.Free((nint)messagePtr);
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, byte*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, message, cb);
+        SilkMarshal.Free((nint)destinationURLPtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+        fixed (byte* messagePtr = &message)
+        {
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, byte*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+        }
+        SilkMarshal.Free((nint)destinationURLPtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+        var messagePtr = (byte*) SilkMarshal.StringToPtr(message, NativeStringEncoding.UTF8);
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, byte*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+        SilkMarshal.Free((nint)messagePtr);
+        SilkMarshal.Free((nint)destinationURLPtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyAdded(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, void>)@this->LpVtbl[4])(@this);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyError(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, ushort code, uint systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, ushort, uint, void>)@this->LpVtbl[5])(@this, code, systemCode);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage2(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbMessage, uint cbMessage)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, char*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURL, pbMessage, cbMessage);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage2(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbMessage, uint cbMessage)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (byte* pbMessagePtr = &pbMessage)
+        {
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, char*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURL, pbMessagePtr, cbMessage);
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage2(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbMessage, uint cbMessage)
+    {
+        var @this = thisVtbl.Handle;
+        var pbMessagePtr = (byte*) SilkMarshal.StringToPtr(pbMessage, NativeStringEncoding.UTF8);
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, char*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURL, pbMessagePtr, cbMessage);
+        SilkMarshal.Free((nint)pbMessagePtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage2(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbMessage, uint cbMessage)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (char* destinationURLPtr = &destinationURL)
+        {
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, char*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURLPtr, pbMessage, cbMessage);
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage2(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbMessage, uint cbMessage)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (char* destinationURLPtr = &destinationURL)
+        {
+            fixed (byte* pbMessagePtr = &pbMessage)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, char*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURLPtr, pbMessagePtr, cbMessage);
+            }
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage2(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbMessage, uint cbMessage)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (char* destinationURLPtr = &destinationURL)
+        {
+        var pbMessagePtr = (byte*) SilkMarshal.StringToPtr(pbMessage, NativeStringEncoding.UTF8);
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, char*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURLPtr, pbMessagePtr, cbMessage);
+        SilkMarshal.Free((nint)pbMessagePtr);
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage2(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbMessage, uint cbMessage)
+    {
+        var @this = thisVtbl.Handle;
+        var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, byte*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURLPtr, pbMessage, cbMessage);
+        SilkMarshal.Free((nint)destinationURLPtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage2(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbMessage, uint cbMessage)
+    {
+        var @this = thisVtbl.Handle;
+        var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+        fixed (byte* pbMessagePtr = &pbMessage)
+        {
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, byte*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURLPtr, pbMessagePtr, cbMessage);
+        }
+        SilkMarshal.Free((nint)destinationURLPtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage2(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbMessage, uint cbMessage)
+    {
+        var @this = thisVtbl.Handle;
+        var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+        var pbMessagePtr = (byte*) SilkMarshal.StringToPtr(pbMessage, NativeStringEncoding.UTF8);
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, MF_MEDIAKEYSESSION_MESSAGETYPE, byte*, byte*, uint, void>)@this->LpVtbl[6])(@this, eMessageType, destinationURLPtr, pbMessagePtr, cbMessage);
+        SilkMarshal.Free((nint)pbMessagePtr);
+        SilkMarshal.Free((nint)destinationURLPtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyStatusChange(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify2*, void>)@this->LpVtbl[7])(@this);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage(destinationURL, in message.GetPinnableReference(), cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, Span<char> destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage(ref destinationURL.GetPinnableReference(), message, cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, Span<char> destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage(ref destinationURL.GetPinnableReference(), in message.GetPinnableReference(), cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, Span<char> destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage(ref destinationURL.GetPinnableReference(), message, cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage(destinationURL, in message.GetPinnableReference(), cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage2(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> pbMessage, uint cbMessage)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage2(eMessageType, destinationURL, in pbMessage.GetPinnableReference(), cbMessage);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage2(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, Span<char> destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbMessage, uint cbMessage)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage2(eMessageType, ref destinationURL.GetPinnableReference(), pbMessage, cbMessage);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage2(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, Span<char> destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> pbMessage, uint cbMessage)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage2(eMessageType, ref destinationURL.GetPinnableReference(), in pbMessage.GetPinnableReference(), cbMessage);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage2(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, Span<char> destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbMessage, uint cbMessage)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage2(eMessageType, ref destinationURL.GetPinnableReference(), pbMessage, cbMessage);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage2(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl, MF_MEDIAKEYSESSION_MESSAGETYPE eMessageType, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> pbMessage, uint cbMessage)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage2(eMessageType, destinationURL, in pbMessage.GetPinnableReference(), cbMessage);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaKeySessionNotify2> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaKeySessionNotifyVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaKeySessionNotifyVtblExtensions.gen.cs
@@ -1,0 +1,268 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaKeySessionNotifyVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaKeySessionNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaKeySessionNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURL, message, cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (byte* messagePtr = &message)
+        {
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURL, messagePtr, cb);
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        var messagePtr = (byte*) SilkMarshal.StringToPtr(message, NativeStringEncoding.UTF8);
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURL, messagePtr, cb);
+        SilkMarshal.Free((nint)messagePtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (char* destinationURLPtr = &destinationURL)
+        {
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, message, cb);
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (char* destinationURLPtr = &destinationURL)
+        {
+            fixed (byte* messagePtr = &message)
+            {
+                ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+            }
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, ref char destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (char* destinationURLPtr = &destinationURL)
+        {
+        var messagePtr = (byte*) SilkMarshal.StringToPtr(message, NativeStringEncoding.UTF8);
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, char*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+        SilkMarshal.Free((nint)messagePtr);
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, byte*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, message, cb);
+        SilkMarshal.Free((nint)destinationURLPtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+        fixed (byte* messagePtr = &message)
+        {
+            ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, byte*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+        }
+        SilkMarshal.Free((nint)destinationURLPtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        var destinationURLPtr = (byte*) SilkMarshal.StringToPtr(destinationURL, NativeStringEncoding.BStr);
+        var messagePtr = (byte*) SilkMarshal.StringToPtr(message, NativeStringEncoding.UTF8);
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, byte*, byte*, uint, void>)@this->LpVtbl[3])(@this, destinationURLPtr, messagePtr, cb);
+        SilkMarshal.Free((nint)messagePtr);
+        SilkMarshal.Free((nint)destinationURLPtr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyAdded(this ComPtr<IMFMediaKeySessionNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, void>)@this->LpVtbl[4])(@this);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyError(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, ushort code, uint systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFMediaKeySessionNotify*, ushort, uint, void>)@this->LpVtbl[5])(@this, code, systemCode);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, char* destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage(destinationURL, in message.GetPinnableReference(), cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void KeyMessage(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, Span<char> destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage(ref destinationURL.GetPinnableReference(), message, cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, Span<char> destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage(ref destinationURL.GetPinnableReference(), in message.GetPinnableReference(), cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, Span<char> destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage(ref destinationURL.GetPinnableReference(), message, cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void KeyMessage(this ComPtr<IMFMediaKeySessionNotify> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string destinationURL, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> message, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->KeyMessage(destinationURL, in message.GetPinnableReference(), cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaKeySessionNotify> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaKeySessionVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaKeySessionVtblExtensions.gen.cs
@@ -1,0 +1,308 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaKeySessionVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySession> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySession> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySession> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySession> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaKeySession> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaKeySession> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetError(this ComPtr<IMFMediaKeySession> thisVtbl, ushort* code, uint* systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, code, systemCode);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetError(this ComPtr<IMFMediaKeySession> thisVtbl, ushort* code, ref uint systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* systemCodePtr = &systemCode)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, code, systemCodePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetError(this ComPtr<IMFMediaKeySession> thisVtbl, ref ushort code, uint* systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (ushort* codePtr = &code)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, codePtr, systemCode);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetError(this ComPtr<IMFMediaKeySession> thisVtbl, ref ushort code, ref uint systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (ushort* codePtr = &code)
+        {
+            fixed (uint* systemCodePtr = &systemCode)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, ushort*, uint*, int>)@this->LpVtbl[3])(@this, codePtr, systemCodePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeySystem(this ComPtr<IMFMediaKeySession> thisVtbl, char** keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, char**, int>)@this->LpVtbl[4])(@this, keySystem);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeySystem(this ComPtr<IMFMediaKeySession> thisVtbl, ref char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, char**, int>)@this->LpVtbl[4])(@this, keySystemPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSessionId(this ComPtr<IMFMediaKeySession> thisVtbl, char** sessionId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, char**, int>)@this->LpVtbl[5])(@this, sessionId);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSessionId(this ComPtr<IMFMediaKeySession> thisVtbl, ref char* sessionId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** sessionIdPtr = &sessionId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, char**, int>)@this->LpVtbl[5])(@this, sessionIdPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int Update(this ComPtr<IMFMediaKeySession> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* key, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, byte*, uint, int>)@this->LpVtbl[6])(@this, key, cb);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Update(this ComPtr<IMFMediaKeySession> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte key, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* keyPtr = &key)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, byte*, uint, int>)@this->LpVtbl[6])(@this, keyPtr, cb);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Update(this ComPtr<IMFMediaKeySession> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string key, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var keyPtr = (byte*) SilkMarshal.StringToPtr(key, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, byte*, uint, int>)@this->LpVtbl[6])(@this, keyPtr, cb);
+        SilkMarshal.Free((nint)keyPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Close(this ComPtr<IMFMediaKeySession> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySession*, int>)@this->LpVtbl[7])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaKeySession> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySession> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySession> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetError(this ComPtr<IMFMediaKeySession> thisVtbl, ushort* code, Span<uint> systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetError(code, ref systemCode.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetError(this ComPtr<IMFMediaKeySession> thisVtbl, Span<ushort> code, uint* systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetError(ref code.GetPinnableReference(), systemCode);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetError(this ComPtr<IMFMediaKeySession> thisVtbl, Span<ushort> code, Span<uint> systemCode)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetError(ref code.GetPinnableReference(), ref systemCode.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetKeySystem(this ComPtr<IMFMediaKeySession> thisVtbl, string[] keySystemSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var keySystem = (char**) SilkMarshal.StringArrayToPtr(keySystemSa);
+        var ret = @this->GetKeySystem(keySystem);
+        SilkMarshal.CopyPtrToStringArray((nint) keySystem, keySystemSa);
+        SilkMarshal.Free((nint) keySystem);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetSessionId(this ComPtr<IMFMediaKeySession> thisVtbl, string[] sessionIdSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var sessionId = (char**) SilkMarshal.StringArrayToPtr(sessionIdSa);
+        var ret = @this->GetSessionId(sessionId);
+        SilkMarshal.CopyPtrToStringArray((nint) sessionId, sessionIdSa);
+        SilkMarshal.Free((nint) sessionId);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Update(this ComPtr<IMFMediaKeySession> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> key, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->Update(in key.GetPinnableReference(), cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaKeySession> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaKeySystemAccessVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaKeySystemAccessVtblExtensions.gen.cs
@@ -1,0 +1,255 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaKeySystemAccessVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaKeySystemAccess> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaKeySystemAccess> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, IPropertyStore* pCdmCustomConfig, IMFMediaKeys2** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, IPropertyStore*, IMFMediaKeys2**, int>)@this->LpVtbl[3])(@this, pCdmCustomConfig, ppKeys);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, IPropertyStore* pCdmCustomConfig, ref IMFMediaKeys2* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeys2** ppKeysPtr = &ppKeys)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, IPropertyStore*, IMFMediaKeys2**, int>)@this->LpVtbl[3])(@this, pCdmCustomConfig, ppKeysPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, ref IPropertyStore pCdmCustomConfig, IMFMediaKeys2** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IPropertyStore* pCdmCustomConfigPtr = &pCdmCustomConfig)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, IPropertyStore*, IMFMediaKeys2**, int>)@this->LpVtbl[3])(@this, pCdmCustomConfigPtr, ppKeys);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, ref IPropertyStore pCdmCustomConfig, ref IMFMediaKeys2* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IPropertyStore* pCdmCustomConfigPtr = &pCdmCustomConfig)
+        {
+            fixed (IMFMediaKeys2** ppKeysPtr = &ppKeys)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, IPropertyStore*, IMFMediaKeys2**, int>)@this->LpVtbl[3])(@this, pCdmCustomConfigPtr, ppKeysPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSupportedConfiguration(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, IPropertyStore** ppSupportedConfiguration)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, IPropertyStore**, int>)@this->LpVtbl[4])(@this, ppSupportedConfiguration);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSupportedConfiguration(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, ref IPropertyStore* ppSupportedConfiguration)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IPropertyStore** ppSupportedConfigurationPtr = &ppSupportedConfiguration)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, IPropertyStore**, int>)@this->LpVtbl[4])(@this, ppSupportedConfigurationPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeySystem(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, char** pKeySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, char**, int>)@this->LpVtbl[5])(@this, pKeySystem);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeySystem(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, ref char* pKeySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** pKeySystemPtr = &pKeySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeySystemAccess*, char**, int>)@this->LpVtbl[5])(@this, pKeySystemPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys<TI0>(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, IPropertyStore* pCdmCustomConfig, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys2>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys(pCdmCustomConfig, (IMFMediaKeys2**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, Span<IPropertyStore> pCdmCustomConfig, IMFMediaKeys2** ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys(ref pCdmCustomConfig.GetPinnableReference(), ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateMediaKeys<TI0>(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, ref IPropertyStore pCdmCustomConfig, ref ComPtr<TI0> ppKeys) where TI0 : unmanaged, IComVtbl<IMFMediaKeys2>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateMediaKeys(ref pCdmCustomConfig, (IMFMediaKeys2**) ppKeys.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateMediaKeys(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, Span<IPropertyStore> pCdmCustomConfig, ref IMFMediaKeys2* ppKeys)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateMediaKeys(ref pCdmCustomConfig.GetPinnableReference(), ref ppKeys);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetKeySystem(this ComPtr<IMFMediaKeySystemAccess> thisVtbl, string[] pKeySystemSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var pKeySystem = (char**) SilkMarshal.StringArrayToPtr(pKeySystemSa);
+        var ret = @this->GetKeySystem(pKeySystem);
+        SilkMarshal.CopyPtrToStringArray((nint) pKeySystem, pKeySystemSa);
+        SilkMarshal.Free((nint) pKeySystem);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaKeySystemAccess> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaKeys2VtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaKeys2VtblExtensions.gen.cs
@@ -1,0 +1,3569 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaKeys2VtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeys2> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeys2> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeys2> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeys2> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaKeys2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaKeys2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notify, ppSession);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notify, ppSessionPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notifyPtr, ppSession);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* customDataPtr = &customData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSession);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                        }
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+        SilkMarshal.Free((nint)customDataPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+        SilkMarshal.Free((nint)customDataPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+        SilkMarshal.Free((nint)customDataPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSessionPtr);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSession);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* customDataPtr = &customData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeySystem(this ComPtr<IMFMediaKeys2> thisVtbl, char** keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char**, int>)@this->LpVtbl[4])(@this, keySystem);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeySystem(this ComPtr<IMFMediaKeys2> thisVtbl, ref char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, char**, int>)@this->LpVtbl[4])(@this, keySystemPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Shutdown(this ComPtr<IMFMediaKeys2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, int>)@this->LpVtbl[5])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSuspendNotify(this ComPtr<IMFMediaKeys2> thisVtbl, IMFCdmSuspendNotify** notify)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, IMFCdmSuspendNotify**, int>)@this->LpVtbl[6])(@this, notify);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSuspendNotify(this ComPtr<IMFMediaKeys2> thisVtbl, ref IMFCdmSuspendNotify* notify)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFCdmSuspendNotify** notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, IMFCdmSuspendNotify**, int>)@this->LpVtbl[6])(@this, notifyPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession2(this ComPtr<IMFMediaKeys2> thisVtbl, MF_MEDIAKEYSESSION_TYPE eSessionType, IMFMediaKeySessionNotify2* pMFMediaKeySessionNotify2, IMFMediaKeySession2** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, MF_MEDIAKEYSESSION_TYPE, IMFMediaKeySessionNotify2*, IMFMediaKeySession2**, int>)@this->LpVtbl[7])(@this, eSessionType, pMFMediaKeySessionNotify2, ppSession);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession2(this ComPtr<IMFMediaKeys2> thisVtbl, MF_MEDIAKEYSESSION_TYPE eSessionType, IMFMediaKeySessionNotify2* pMFMediaKeySessionNotify2, ref IMFMediaKeySession2* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeySession2** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, MF_MEDIAKEYSESSION_TYPE, IMFMediaKeySessionNotify2*, IMFMediaKeySession2**, int>)@this->LpVtbl[7])(@this, eSessionType, pMFMediaKeySessionNotify2, ppSessionPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession2(this ComPtr<IMFMediaKeys2> thisVtbl, MF_MEDIAKEYSESSION_TYPE eSessionType, ref IMFMediaKeySessionNotify2 pMFMediaKeySessionNotify2, IMFMediaKeySession2** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeySessionNotify2* pMFMediaKeySessionNotify2Ptr = &pMFMediaKeySessionNotify2)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, MF_MEDIAKEYSESSION_TYPE, IMFMediaKeySessionNotify2*, IMFMediaKeySession2**, int>)@this->LpVtbl[7])(@this, eSessionType, pMFMediaKeySessionNotify2Ptr, ppSession);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession2(this ComPtr<IMFMediaKeys2> thisVtbl, MF_MEDIAKEYSESSION_TYPE eSessionType, ref IMFMediaKeySessionNotify2 pMFMediaKeySessionNotify2, ref IMFMediaKeySession2* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeySessionNotify2* pMFMediaKeySessionNotify2Ptr = &pMFMediaKeySessionNotify2)
+        {
+            fixed (IMFMediaKeySession2** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, MF_MEDIAKEYSESSION_TYPE, IMFMediaKeySessionNotify2*, IMFMediaKeySession2**, int>)@this->LpVtbl[7])(@this, eSessionType, pMFMediaKeySessionNotify2Ptr, ppSessionPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetServerCertificate(this ComPtr<IMFMediaKeys2> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pbServerCertificate, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, uint, int>)@this->LpVtbl[8])(@this, pbServerCertificate, cb);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetServerCertificate(this ComPtr<IMFMediaKeys2> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pbServerCertificate, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* pbServerCertificatePtr = &pbServerCertificate)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, uint, int>)@this->LpVtbl[8])(@this, pbServerCertificatePtr, cb);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetServerCertificate(this ComPtr<IMFMediaKeys2> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pbServerCertificate, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pbServerCertificatePtr = (byte*) SilkMarshal.StringToPtr(pbServerCertificate, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, byte*, uint, int>)@this->LpVtbl[8])(@this, pbServerCertificatePtr, cb);
+        SilkMarshal.Free((nint)pbServerCertificatePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetDOMException(this ComPtr<IMFMediaKeys2> thisVtbl, int systemCode, int* code)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, int, int*, int>)@this->LpVtbl[9])(@this, systemCode, code);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetDOMException(this ComPtr<IMFMediaKeys2> thisVtbl, int systemCode, ref int code)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* codePtr = &code)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys2*, int, int*, int>)@this->LpVtbl[9])(@this, systemCode, codePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeys2> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeys2> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys2> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetKeySystem(this ComPtr<IMFMediaKeys2> thisVtbl, string[] keySystemSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var keySystem = (char**) SilkMarshal.StringArrayToPtr(keySystemSa);
+        var ret = @this->GetKeySystem(keySystem);
+        SilkMarshal.CopyPtrToStringArray((nint) keySystem, keySystemSa);
+        SilkMarshal.Free((nint) keySystem);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetSuspendNotify<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, ref ComPtr<TI0> notify) where TI0 : unmanaged, IComVtbl<IMFCdmSuspendNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetSuspendNotify((IMFCdmSuspendNotify**) notify.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession2<TI0, TI1>(this ComPtr<IMFMediaKeys2> thisVtbl, MF_MEDIAKEYSESSION_TYPE eSessionType, ComPtr<TI0> pMFMediaKeySessionNotify2, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify2>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession2>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession2(eSessionType, (IMFMediaKeySessionNotify2*) pMFMediaKeySessionNotify2.Handle, (IMFMediaKeySession2**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession2<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, MF_MEDIAKEYSESSION_TYPE eSessionType, ComPtr<TI0> pMFMediaKeySessionNotify2, ref IMFMediaKeySession2* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify2>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession2(eSessionType, (IMFMediaKeySessionNotify2*) pMFMediaKeySessionNotify2.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession2(this ComPtr<IMFMediaKeys2> thisVtbl, MF_MEDIAKEYSESSION_TYPE eSessionType, Span<IMFMediaKeySessionNotify2> pMFMediaKeySessionNotify2, IMFMediaKeySession2** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession2(eSessionType, ref pMFMediaKeySessionNotify2.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession2<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl, MF_MEDIAKEYSESSION_TYPE eSessionType, ref IMFMediaKeySessionNotify2 pMFMediaKeySessionNotify2, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession2>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession2(eSessionType, ref pMFMediaKeySessionNotify2, (IMFMediaKeySession2**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession2(this ComPtr<IMFMediaKeys2> thisVtbl, MF_MEDIAKEYSESSION_TYPE eSessionType, Span<IMFMediaKeySessionNotify2> pMFMediaKeySessionNotify2, ref IMFMediaKeySession2* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession2(eSessionType, ref pMFMediaKeySessionNotify2.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetServerCertificate(this ComPtr<IMFMediaKeys2> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> pbServerCertificate, uint cb)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->SetServerCertificate(in pbServerCertificate.GetPinnableReference(), cb);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetDOMException(this ComPtr<IMFMediaKeys2> thisVtbl, int systemCode, Span<int> code)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetDOMException(systemCode, ref code.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaKeys2> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaKeysVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaKeysVtblExtensions.gen.cs
@@ -1,0 +1,3412 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaKeysVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeys> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeys> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeys> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeys> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaKeys> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaKeys> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notify, ppSession);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notify, ppSessionPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notifyPtr, ppSession);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* customDataPtr = &customData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeType, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSession);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+                fixed (byte* customDataPtr = &customData)
+                {
+                    fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                    {
+                        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                        }
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+        SilkMarshal.Free((nint)customDataPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+        SilkMarshal.Free((nint)customDataPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+            fixed (byte* initDataPtr = &initData)
+            {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+        SilkMarshal.Free((nint)customDataPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* mimeTypePtr = &mimeType)
+        {
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notify, ppSessionPtr);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSession);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* customDataPtr = &customData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initData, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+            fixed (byte* customDataPtr = &customData)
+            {
+                fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+                {
+                    fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                    }
+                }
+            }
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        fixed (byte* initDataPtr = &initData)
+        {
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        SilkMarshal.Free((nint)customDataPtr);
+        }
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notify, ppSessionPtr);
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSession);
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customData, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        fixed (byte* customDataPtr = &customData)
+        {
+            fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+            {
+                fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSession);
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notify, ppSessionPtr);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSession);
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var mimeTypePtr = (byte*) SilkMarshal.StringToPtr(mimeType, NativeStringEncoding.BStr);
+        var initDataPtr = (byte*) SilkMarshal.StringToPtr(initData, NativeStringEncoding.UTF8);
+        var customDataPtr = (byte*) SilkMarshal.StringToPtr(customData, NativeStringEncoding.UTF8);
+        fixed (IMFMediaKeySessionNotify* notifyPtr = &notify)
+        {
+            fixed (IMFMediaKeySession** ppSessionPtr = &ppSession)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, byte*, byte*, uint, byte*, uint, IMFMediaKeySessionNotify*, IMFMediaKeySession**, int>)@this->LpVtbl[3])(@this, mimeTypePtr, initDataPtr, cb, customDataPtr, cbCustomData, notifyPtr, ppSessionPtr);
+            }
+        }
+        SilkMarshal.Free((nint)customDataPtr);
+        SilkMarshal.Free((nint)initDataPtr);
+        SilkMarshal.Free((nint)mimeTypePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeySystem(this ComPtr<IMFMediaKeys> thisVtbl, char** keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char**, int>)@this->LpVtbl[4])(@this, keySystem);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetKeySystem(this ComPtr<IMFMediaKeys> thisVtbl, ref char* keySystem)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** keySystemPtr = &keySystem)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, char**, int>)@this->LpVtbl[4])(@this, keySystemPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Shutdown(this ComPtr<IMFMediaKeys> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, int>)@this->LpVtbl[5])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSuspendNotify(this ComPtr<IMFMediaKeys> thisVtbl, IMFCdmSuspendNotify** notify)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, IMFCdmSuspendNotify**, int>)@this->LpVtbl[6])(@this, notify);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSuspendNotify(this ComPtr<IMFMediaKeys> thisVtbl, ref IMFCdmSuspendNotify* notify)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFCdmSuspendNotify** notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaKeys*, IMFCdmSuspendNotify**, int>)@this->LpVtbl[6])(@this, notifyPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeys> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaKeys> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, char* mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref char mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(ref mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, Span<char> mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(ref mimeType.GetPinnableReference(), initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, in initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, in initData.GetPinnableReference(), cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, IMFMediaKeySessionNotify* notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, notify, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, in customData.GetPinnableReference(), cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0, TI1>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref ComPtr<TI1> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ComPtr<TI0> notify, ref IMFMediaKeySession* ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySessionNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, (IMFMediaKeySessionNotify*) notify.Handle, ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, IMFMediaKeySession** ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int CreateSession<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, ref IMFMediaKeySessionNotify notify, ref ComPtr<TI0> ppSession) where TI0 : unmanaged, IComVtbl<IMFMediaKeySession>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify, (IMFMediaKeySession**) ppSession.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int CreateSession(this ComPtr<IMFMediaKeys> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string mimeType, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string initData, uint cb, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string customData, uint cbCustomData, Span<IMFMediaKeySessionNotify> notify, ref IMFMediaKeySession* ppSession)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->CreateSession(mimeType, initData, cb, customData, cbCustomData, ref notify.GetPinnableReference(), ref ppSession);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetKeySystem(this ComPtr<IMFMediaKeys> thisVtbl, string[] keySystemSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var keySystem = (char**) SilkMarshal.StringArrayToPtr(keySystemSa);
+        var ret = @this->GetKeySystem(keySystem);
+        SilkMarshal.CopyPtrToStringArray((nint) keySystem, keySystemSa);
+        SilkMarshal.Free((nint) keySystem);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetSuspendNotify<TI0>(this ComPtr<IMFMediaKeys> thisVtbl, ref ComPtr<TI0> notify) where TI0 : unmanaged, IComVtbl<IMFCdmSuspendNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetSuspendNotify((IMFCdmSuspendNotify**) notify.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaKeys> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaSourceExtensionLiveSeekableRangeVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaSourceExtensionLiveSeekableRangeVtblExtensions.gen.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaSourceExtensionLiveSeekableRangeVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtensionLiveSeekableRange> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtensionLiveSeekableRange> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtensionLiveSeekableRange> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtensionLiveSeekableRange> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaSourceExtensionLiveSeekableRange> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaSourceExtensionLiveSeekableRange> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetLiveSeekableRange(this ComPtr<IMFMediaSourceExtensionLiveSeekableRange> thisVtbl, double start, double end)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, double, double, int>)@this->LpVtbl[3])(@this, start, end);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int ClearLiveSeekableRange(this ComPtr<IMFMediaSourceExtensionLiveSeekableRange> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionLiveSeekableRange*, int>)@this->LpVtbl[4])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaSourceExtensionLiveSeekableRange> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtensionLiveSeekableRange> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtensionLiveSeekableRange> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaSourceExtensionLiveSeekableRange> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaSourceExtensionNotifyVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaSourceExtensionNotifyVtblExtensions.gen.cs
@@ -1,0 +1,142 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaSourceExtensionNotifyVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtensionNotify> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtensionNotify> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtensionNotify> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtensionNotify> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaSourceExtensionNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaSourceExtensionNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void OnSourceOpen(this ComPtr<IMFMediaSourceExtensionNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, void>)@this->LpVtbl[3])(@this);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void OnSourceEnded(this ComPtr<IMFMediaSourceExtensionNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, void>)@this->LpVtbl[4])(@this);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void OnSourceClose(this ComPtr<IMFMediaSourceExtensionNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtensionNotify*, void>)@this->LpVtbl[5])(@this);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaSourceExtensionNotify> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtensionNotify> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtensionNotify> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaSourceExtensionNotify> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaSourceExtensionVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaSourceExtensionVtblExtensions.gen.cs
@@ -1,0 +1,561 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaSourceExtensionVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtension> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtension> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtension> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtension> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaSourceExtension> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaSourceExtension> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe IMFSourceBufferList* GetSourceBuffers(this ComPtr<IMFMediaSourceExtension> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        IMFSourceBufferList* ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, IMFSourceBufferList*>)@this->LpVtbl[3])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe IMFSourceBufferList* GetActiveSourceBuffers(this ComPtr<IMFMediaSourceExtension> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        IMFSourceBufferList* ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, IMFSourceBufferList*>)@this->LpVtbl[4])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static MseReady GetReadyState(this ComPtr<IMFMediaSourceExtension> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        MseReady ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, MseReady>)@this->LpVtbl[5])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetDuration(this ComPtr<IMFMediaSourceExtension> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, double>)@this->LpVtbl[6])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetDuration(this ComPtr<IMFMediaSourceExtension> thisVtbl, double duration)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, double, int>)@this->LpVtbl[7])(@this, duration);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, char* type, IMFSourceBufferNotify* pNotify, IMFSourceBuffer** ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, type, pNotify, ppSourceBuffer);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, char* type, IMFSourceBufferNotify* pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFSourceBuffer** ppSourceBufferPtr = &ppSourceBuffer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, type, pNotify, ppSourceBufferPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, char* type, ref IMFSourceBufferNotify pNotify, IMFSourceBuffer** ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFSourceBufferNotify* pNotifyPtr = &pNotify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, type, pNotifyPtr, ppSourceBuffer);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, char* type, ref IMFSourceBufferNotify pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFSourceBufferNotify* pNotifyPtr = &pNotify)
+        {
+            fixed (IMFSourceBuffer** ppSourceBufferPtr = &ppSourceBuffer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, type, pNotifyPtr, ppSourceBufferPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, ref char type, IMFSourceBufferNotify* pNotify, IMFSourceBuffer** ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotify, ppSourceBuffer);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, ref char type, IMFSourceBufferNotify* pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            fixed (IMFSourceBuffer** ppSourceBufferPtr = &ppSourceBuffer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotify, ppSourceBufferPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, ref char type, ref IMFSourceBufferNotify pNotify, IMFSourceBuffer** ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            fixed (IMFSourceBufferNotify* pNotifyPtr = &pNotify)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotifyPtr, ppSourceBuffer);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, ref char type, ref IMFSourceBufferNotify pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* typePtr = &type)
+        {
+            fixed (IMFSourceBufferNotify* pNotifyPtr = &pNotify)
+            {
+                fixed (IMFSourceBuffer** ppSourceBufferPtr = &ppSourceBuffer)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotifyPtr, ppSourceBufferPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, IMFSourceBufferNotify* pNotify, IMFSourceBuffer** ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, byte*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotify, ppSourceBuffer);
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, IMFSourceBufferNotify* pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        fixed (IMFSourceBuffer** ppSourceBufferPtr = &ppSourceBuffer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, byte*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotify, ppSourceBufferPtr);
+        }
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref IMFSourceBufferNotify pNotify, IMFSourceBuffer** ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        fixed (IMFSourceBufferNotify* pNotifyPtr = &pNotify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, byte*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotifyPtr, ppSourceBuffer);
+        }
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref IMFSourceBufferNotify pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        fixed (IMFSourceBufferNotify* pNotifyPtr = &pNotify)
+        {
+            fixed (IMFSourceBuffer** ppSourceBufferPtr = &ppSourceBuffer)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, byte*, IMFSourceBufferNotify*, IMFSourceBuffer**, int>)@this->LpVtbl[8])(@this, typePtr, pNotifyPtr, ppSourceBufferPtr);
+            }
+        }
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int RemoveSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, IMFSourceBuffer* pSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, IMFSourceBuffer*, int>)@this->LpVtbl[9])(@this, pSourceBuffer);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RemoveSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, ref IMFSourceBuffer pSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFSourceBuffer* pSourceBufferPtr = &pSourceBuffer)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, IMFSourceBuffer*, int>)@this->LpVtbl[9])(@this, pSourceBufferPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetEndOfStream(this ComPtr<IMFMediaSourceExtension> thisVtbl, MseError error)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, MseError, int>)@this->LpVtbl[10])(@this, error);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe Silk.NET.Core.Bool32 IsTypeSupported(this ComPtr<IMFMediaSourceExtension> thisVtbl, char* type)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, Silk.NET.Core.Bool32>)@this->LpVtbl[11])(@this, type);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsTypeSupported(this ComPtr<IMFMediaSourceExtension> thisVtbl, ref char type)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        fixed (char* typePtr = &type)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, char*, Silk.NET.Core.Bool32>)@this->LpVtbl[11])(@this, typePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsTypeSupported(this ComPtr<IMFMediaSourceExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        var typePtr = (byte*) SilkMarshal.StringToPtr(type, NativeStringEncoding.BStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, byte*, Silk.NET.Core.Bool32>)@this->LpVtbl[11])(@this, typePtr);
+        SilkMarshal.Free((nint)typePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe IMFSourceBuffer* GetSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, uint dwStreamIndex)
+    {
+        var @this = thisVtbl.Handle;
+        IMFSourceBuffer* ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaSourceExtension*, uint, IMFSourceBuffer*>)@this->LpVtbl[12])(@this, dwStreamIndex);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaSourceExtension> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtension> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaSourceExtension> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer<TI0, TI1>(this ComPtr<IMFMediaSourceExtension> thisVtbl, char* type, ComPtr<TI0> pNotify, ref ComPtr<TI1> ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBufferNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFSourceBuffer>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddSourceBuffer(type, (IMFSourceBufferNotify*) pNotify.Handle, (IMFSourceBuffer**) ppSourceBuffer.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer<TI0>(this ComPtr<IMFMediaSourceExtension> thisVtbl, char* type, ComPtr<TI0> pNotify, ref IMFSourceBuffer* ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBufferNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddSourceBuffer(type, (IMFSourceBufferNotify*) pNotify.Handle, ref ppSourceBuffer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, char* type, Span<IMFSourceBufferNotify> pNotify, IMFSourceBuffer** ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddSourceBuffer(type, ref pNotify.GetPinnableReference(), ppSourceBuffer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer<TI0>(this ComPtr<IMFMediaSourceExtension> thisVtbl, char* type, ref IMFSourceBufferNotify pNotify, ref ComPtr<TI0> ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBuffer>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddSourceBuffer(type, ref pNotify, (IMFSourceBuffer**) ppSourceBuffer.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, char* type, Span<IMFSourceBufferNotify> pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddSourceBuffer(type, ref pNotify.GetPinnableReference(), ref ppSourceBuffer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, Span<char> type, IMFSourceBufferNotify* pNotify, IMFSourceBuffer** ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddSourceBuffer(ref type.GetPinnableReference(), pNotify, ppSourceBuffer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddSourceBuffer<TI0, TI1>(this ComPtr<IMFMediaSourceExtension> thisVtbl, ref char type, ComPtr<TI0> pNotify, ref ComPtr<TI1> ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBufferNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFSourceBuffer>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddSourceBuffer(ref type, (IMFSourceBufferNotify*) pNotify.Handle, (IMFSourceBuffer**) ppSourceBuffer.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, Span<char> type, IMFSourceBufferNotify* pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddSourceBuffer(ref type.GetPinnableReference(), pNotify, ref ppSourceBuffer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer<TI0>(this ComPtr<IMFMediaSourceExtension> thisVtbl, ref char type, ComPtr<TI0> pNotify, ref IMFSourceBuffer* ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBufferNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddSourceBuffer(ref type, (IMFSourceBufferNotify*) pNotify.Handle, ref ppSourceBuffer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, Span<char> type, Span<IMFSourceBufferNotify> pNotify, IMFSourceBuffer** ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddSourceBuffer(ref type.GetPinnableReference(), ref pNotify.GetPinnableReference(), ppSourceBuffer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddSourceBuffer<TI0>(this ComPtr<IMFMediaSourceExtension> thisVtbl, ref char type, ref IMFSourceBufferNotify pNotify, ref ComPtr<TI0> ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBuffer>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddSourceBuffer(ref type, ref pNotify, (IMFSourceBuffer**) ppSourceBuffer.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, Span<char> type, Span<IMFSourceBufferNotify> pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddSourceBuffer(ref type.GetPinnableReference(), ref pNotify.GetPinnableReference(), ref ppSourceBuffer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddSourceBuffer<TI0, TI1>(this ComPtr<IMFMediaSourceExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ComPtr<TI0> pNotify, ref ComPtr<TI1> ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBufferNotify>, IComVtbl<TI0> where TI1 : unmanaged, IComVtbl<IMFSourceBuffer>, IComVtbl<TI1>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddSourceBuffer(type, (IMFSourceBufferNotify*) pNotify.Handle, (IMFSourceBuffer**) ppSourceBuffer.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer<TI0>(this ComPtr<IMFMediaSourceExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ComPtr<TI0> pNotify, ref IMFSourceBuffer* ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBufferNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddSourceBuffer(type, (IMFSourceBufferNotify*) pNotify.Handle, ref ppSourceBuffer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<IMFSourceBufferNotify> pNotify, IMFSourceBuffer** ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddSourceBuffer(type, ref pNotify.GetPinnableReference(), ppSourceBuffer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddSourceBuffer<TI0>(this ComPtr<IMFMediaSourceExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, ref IMFSourceBufferNotify pNotify, ref ComPtr<TI0> ppSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBuffer>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddSourceBuffer(type, ref pNotify, (IMFSourceBuffer**) ppSourceBuffer.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, [UnmanagedType(Silk.NET.Core.Native.UnmanagedType.BStr)] string type, Span<IMFSourceBufferNotify> pNotify, ref IMFSourceBuffer* ppSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddSourceBuffer(type, ref pNotify.GetPinnableReference(), ref ppSourceBuffer);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RemoveSourceBuffer<TI0>(this ComPtr<IMFMediaSourceExtension> thisVtbl, ComPtr<TI0> pSourceBuffer) where TI0 : unmanaged, IComVtbl<IMFSourceBuffer>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->RemoveSourceBuffer((IMFSourceBuffer*) pSourceBuffer.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RemoveSourceBuffer(this ComPtr<IMFMediaSourceExtension> thisVtbl, Span<IMFSourceBuffer> pSourceBuffer)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->RemoveSourceBuffer(ref pSourceBuffer.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsTypeSupported(this ComPtr<IMFMediaSourceExtension> thisVtbl, Span<char> type)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTypeSupported(ref type.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaSourceExtension> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaTimeRangeVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFMediaTimeRangeVtblExtensions.gen.cs
@@ -1,0 +1,215 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFMediaTimeRangeVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaTimeRange> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaTimeRange> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaTimeRange> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaTimeRange> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFMediaTimeRange> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFMediaTimeRange> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint GetLength(this ComPtr<IMFMediaTimeRange> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, uint>)@this->LpVtbl[3])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetStart(this ComPtr<IMFMediaTimeRange> thisVtbl, uint index, double* pStart)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, uint, double*, int>)@this->LpVtbl[4])(@this, index, pStart);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetStart(this ComPtr<IMFMediaTimeRange> thisVtbl, uint index, ref double pStart)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pStartPtr = &pStart)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, uint, double*, int>)@this->LpVtbl[4])(@this, index, pStartPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetEnd(this ComPtr<IMFMediaTimeRange> thisVtbl, uint index, double* pEnd)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, uint, double*, int>)@this->LpVtbl[5])(@this, index, pEnd);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetEnd(this ComPtr<IMFMediaTimeRange> thisVtbl, uint index, ref double pEnd)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pEndPtr = &pEnd)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, uint, double*, int>)@this->LpVtbl[5])(@this, index, pEndPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 ContainsTime(this ComPtr<IMFMediaTimeRange> thisVtbl, double time)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, double, Silk.NET.Core.Bool32>)@this->LpVtbl[6])(@this, time);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddRange(this ComPtr<IMFMediaTimeRange> thisVtbl, double startTime, double endTime)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, double, double, int>)@this->LpVtbl[7])(@this, startTime, endTime);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Clear(this ComPtr<IMFMediaTimeRange> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFMediaTimeRange*, int>)@this->LpVtbl[8])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFMediaTimeRange> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaTimeRange> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFMediaTimeRange> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetStart(this ComPtr<IMFMediaTimeRange> thisVtbl, uint index, Span<double> pStart)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetStart(index, ref pStart.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetEnd(this ComPtr<IMFMediaTimeRange> thisVtbl, uint index, Span<double> pEnd)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetEnd(index, ref pEnd.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFMediaTimeRange> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFSourceBufferAppendModeVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFSourceBufferAppendModeVtblExtensions.gen.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFSourceBufferAppendModeVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferAppendMode> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferAppendMode> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferAppendMode> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferAppendMode> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFSourceBufferAppendMode> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFSourceBufferAppendMode> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static MseAppendMode GetAppendMode(this ComPtr<IMFSourceBufferAppendMode> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        MseAppendMode ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, MseAppendMode>)@this->LpVtbl[3])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetAppendMode(this ComPtr<IMFSourceBufferAppendMode> thisVtbl, MseAppendMode mode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferAppendMode*, MseAppendMode, int>)@this->LpVtbl[4])(@this, mode);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFSourceBufferAppendMode> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferAppendMode> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferAppendMode> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFSourceBufferAppendMode> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFSourceBufferListVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFSourceBufferListVtblExtensions.gen.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFSourceBufferListVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferList> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferList> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferList> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferList> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFSourceBufferList> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFSourceBufferList> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint GetLength(this ComPtr<IMFSourceBufferList> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, uint>)@this->LpVtbl[3])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe IMFSourceBuffer* GetSourceBuffer(this ComPtr<IMFSourceBufferList> thisVtbl, uint index)
+    {
+        var @this = thisVtbl.Handle;
+        IMFSourceBuffer* ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferList*, uint, IMFSourceBuffer*>)@this->LpVtbl[4])(@this, index);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFSourceBufferList> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferList> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferList> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFSourceBufferList> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFSourceBufferNotifyVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFSourceBufferNotifyVtblExtensions.gen.cs
@@ -1,0 +1,156 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFSourceBufferNotifyVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferNotify> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferNotify> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferNotify> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferNotify> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFSourceBufferNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFSourceBufferNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void OnUpdateStart(this ComPtr<IMFSourceBufferNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, void>)@this->LpVtbl[3])(@this);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void OnAbort(this ComPtr<IMFSourceBufferNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, void>)@this->LpVtbl[4])(@this);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void OnError(this ComPtr<IMFSourceBufferNotify> thisVtbl, int hr)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, int, void>)@this->LpVtbl[5])(@this, hr);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void OnUpdate(this ComPtr<IMFSourceBufferNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, void>)@this->LpVtbl[6])(@this);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void OnUpdateEnd(this ComPtr<IMFSourceBufferNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFSourceBufferNotify*, void>)@this->LpVtbl[7])(@this);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFSourceBufferNotify> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferNotify> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBufferNotify> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFSourceBufferNotify> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFSourceBufferVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFSourceBufferVtblExtensions.gen.cs
@@ -1,0 +1,343 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFSourceBufferVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBuffer> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBuffer> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBuffer> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBuffer> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFSourceBuffer> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFSourceBuffer> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 GetUpdating(this ComPtr<IMFSourceBuffer> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, Silk.NET.Core.Bool32>)@this->LpVtbl[3])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetBuffered(this ComPtr<IMFSourceBuffer> thisVtbl, IMFMediaTimeRange** ppBuffered)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, IMFMediaTimeRange**, int>)@this->LpVtbl[4])(@this, ppBuffered);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetBuffered(this ComPtr<IMFSourceBuffer> thisVtbl, ref IMFMediaTimeRange* ppBuffered)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFMediaTimeRange** ppBufferedPtr = &ppBuffered)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, IMFMediaTimeRange**, int>)@this->LpVtbl[4])(@this, ppBufferedPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetTimeStampOffset(this ComPtr<IMFSourceBuffer> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, double>)@this->LpVtbl[5])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetTimeStampOffset(this ComPtr<IMFSourceBuffer> thisVtbl, double offset)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, double, int>)@this->LpVtbl[6])(@this, offset);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetAppendWindowStart(this ComPtr<IMFSourceBuffer> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, double>)@this->LpVtbl[7])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetAppendWindowStart(this ComPtr<IMFSourceBuffer> thisVtbl, double time)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, double, int>)@this->LpVtbl[8])(@this, time);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetAppendWindowEnd(this ComPtr<IMFSourceBuffer> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, double>)@this->LpVtbl[9])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetAppendWindowEnd(this ComPtr<IMFSourceBuffer> thisVtbl, double time)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, double, int>)@this->LpVtbl[10])(@this, time);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int Append(this ComPtr<IMFSourceBuffer> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* pData, uint len)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, byte*, uint, int>)@this->LpVtbl[11])(@this, pData, len);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Append(this ComPtr<IMFSourceBuffer> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte pData, uint len)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* pDataPtr = &pData)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, byte*, uint, int>)@this->LpVtbl[11])(@this, pDataPtr, len);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Append(this ComPtr<IMFSourceBuffer> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string pData, uint len)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var pDataPtr = (byte*) SilkMarshal.StringToPtr(pData, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, byte*, uint, int>)@this->LpVtbl[11])(@this, pDataPtr, len);
+        SilkMarshal.Free((nint)pDataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AppendByteStream(this ComPtr<IMFSourceBuffer> thisVtbl, IMFByteStream* pStream, ulong* pMaxLen)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, IMFByteStream*, ulong*, int>)@this->LpVtbl[12])(@this, pStream, pMaxLen);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AppendByteStream(this ComPtr<IMFSourceBuffer> thisVtbl, IMFByteStream* pStream, ref ulong pMaxLen)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (ulong* pMaxLenPtr = &pMaxLen)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, IMFByteStream*, ulong*, int>)@this->LpVtbl[12])(@this, pStream, pMaxLenPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AppendByteStream(this ComPtr<IMFSourceBuffer> thisVtbl, ref IMFByteStream pStream, ulong* pMaxLen)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pStreamPtr = &pStream)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, IMFByteStream*, ulong*, int>)@this->LpVtbl[12])(@this, pStreamPtr, pMaxLen);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AppendByteStream(this ComPtr<IMFSourceBuffer> thisVtbl, ref IMFByteStream pStream, ref ulong pMaxLen)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* pStreamPtr = &pStream)
+        {
+            fixed (ulong* pMaxLenPtr = &pMaxLen)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, IMFByteStream*, ulong*, int>)@this->LpVtbl[12])(@this, pStreamPtr, pMaxLenPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Abort(this ComPtr<IMFSourceBuffer> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, int>)@this->LpVtbl[13])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Remove(this ComPtr<IMFSourceBuffer> thisVtbl, double start, double end)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFSourceBuffer*, double, double, int>)@this->LpVtbl[14])(@this, start, end);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFSourceBuffer> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBuffer> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFSourceBuffer> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBuffered<TI0>(this ComPtr<IMFSourceBuffer> thisVtbl, ref ComPtr<TI0> ppBuffered) where TI0 : unmanaged, IComVtbl<IMFMediaTimeRange>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetBuffered((IMFMediaTimeRange**) ppBuffered.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int Append(this ComPtr<IMFSourceBuffer> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> pData, uint len)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->Append(in pData.GetPinnableReference(), len);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AppendByteStream(this ComPtr<IMFSourceBuffer> thisVtbl, IMFByteStream* pStream, Span<ulong> pMaxLen)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AppendByteStream(pStream, ref pMaxLen.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AppendByteStream(this ComPtr<IMFSourceBuffer> thisVtbl, Span<IMFByteStream> pStream, ulong* pMaxLen)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AppendByteStream(ref pStream.GetPinnableReference(), pMaxLen);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AppendByteStream(this ComPtr<IMFSourceBuffer> thisVtbl, Span<IMFByteStream> pStream, Span<ulong> pMaxLen)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AppendByteStream(ref pStream.GetPinnableReference(), ref pMaxLen.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFSourceBuffer> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextBinaryVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextBinaryVtblExtensions.gen.cs
@@ -1,0 +1,209 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFTimedTextBinaryVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextBinary> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextBinary> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextBinary> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextBinary> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFTimedTextBinary> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFTimedTextBinary> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetData(this ComPtr<IMFTimedTextBinary> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte** data, uint* length)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, byte**, uint*, int>)@this->LpVtbl[3])(@this, data, length);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetData(this ComPtr<IMFTimedTextBinary> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte** data, ref uint length)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* lengthPtr = &length)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, byte**, uint*, int>)@this->LpVtbl[3])(@this, data, lengthPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetData(this ComPtr<IMFTimedTextBinary> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte* data, uint* length)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte** dataPtr = &data)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, byte**, uint*, int>)@this->LpVtbl[3])(@this, dataPtr, length);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetData(this ComPtr<IMFTimedTextBinary> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte* data, ref uint length)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte** dataPtr = &data)
+        {
+            fixed (uint* lengthPtr = &length)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBinary*, byte**, uint*, int>)@this->LpVtbl[3])(@this, dataPtr, lengthPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFTimedTextBinary> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextBinary> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextBinary> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetData(this ComPtr<IMFTimedTextBinary> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] string[] dataSa, uint* length)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var data = (byte**) SilkMarshal.StringArrayToPtr(dataSa);
+        var ret = @this->GetData(data, length);
+        SilkMarshal.CopyPtrToStringArray((nint) data, dataSa);
+        SilkMarshal.Free((nint) data);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetData(this ComPtr<IMFTimedTextBinary> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] string[] dataSa, ref uint length)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var data = (byte**) SilkMarshal.StringArrayToPtr(dataSa);
+        var ret = @this->GetData(data, ref length);
+        SilkMarshal.CopyPtrToStringArray((nint) data, dataSa);
+        SilkMarshal.Free((nint) data);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetData(this ComPtr<IMFTimedTextBinary> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte** data, Span<uint> length)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetData(data, ref length.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetData(this ComPtr<IMFTimedTextBinary> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte* data, Span<uint> length)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetData(in data, ref length.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFTimedTextBinary> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextBoutenVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextBoutenVtblExtensions.gen.cs
@@ -1,0 +1,208 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFTimedTextBoutenVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextBouten> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextBouten> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextBouten> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextBouten> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFTimedTextBouten> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFTimedTextBouten> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetBoutenType(this ComPtr<IMFTimedTextBouten> thisVtbl, TimedTextBoutenType* value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, TimedTextBoutenType*, int>)@this->LpVtbl[3])(@this, value);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBoutenType(this ComPtr<IMFTimedTextBouten> thisVtbl, ref TimedTextBoutenType value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextBoutenType* valuePtr = &value)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, TimedTextBoutenType*, int>)@this->LpVtbl[3])(@this, valuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetBoutenColor(this ComPtr<IMFTimedTextBouten> thisVtbl, _MFARGB* value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, _MFARGB*, int>)@this->LpVtbl[4])(@this, value);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBoutenColor(this ComPtr<IMFTimedTextBouten> thisVtbl, ref _MFARGB value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* valuePtr = &value)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, _MFARGB*, int>)@this->LpVtbl[4])(@this, valuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetBoutenPosition(this ComPtr<IMFTimedTextBouten> thisVtbl, TimedTextBoutenPosition* value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, TimedTextBoutenPosition*, int>)@this->LpVtbl[5])(@this, value);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBoutenPosition(this ComPtr<IMFTimedTextBouten> thisVtbl, ref TimedTextBoutenPosition value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextBoutenPosition* valuePtr = &value)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextBouten*, TimedTextBoutenPosition*, int>)@this->LpVtbl[5])(@this, valuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFTimedTextBouten> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextBouten> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextBouten> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBoutenType(this ComPtr<IMFTimedTextBouten> thisVtbl, Span<TimedTextBoutenType> value)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetBoutenType(ref value.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBoutenColor(this ComPtr<IMFTimedTextBouten> thisVtbl, Span<_MFARGB> value)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetBoutenColor(ref value.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBoutenPosition(this ComPtr<IMFTimedTextBouten> thisVtbl, Span<TimedTextBoutenPosition> value)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetBoutenPosition(ref value.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFTimedTextBouten> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextCueListVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextCueListVtblExtensions.gen.cs
@@ -1,0 +1,564 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFTimedTextCueListVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextCueList> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextCueList> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextCueList> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextCueList> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFTimedTextCueList> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFTimedTextCueList> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint GetLength(this ComPtr<IMFTimedTextCueList> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, uint>)@this->LpVtbl[3])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueByIndex(this ComPtr<IMFTimedTextCueList> thisVtbl, uint index, IMFTimedTextCue** cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[4])(@this, index, cue);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueByIndex(this ComPtr<IMFTimedTextCueList> thisVtbl, uint index, ref IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextCue** cuePtr = &cue)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[4])(@this, index, cuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueById(this ComPtr<IMFTimedTextCueList> thisVtbl, uint id, IMFTimedTextCue** cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[5])(@this, id, cue);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueById(this ComPtr<IMFTimedTextCueList> thisVtbl, uint id, ref IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextCue** cuePtr = &cue)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[5])(@this, id, cuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueByOriginalId(this ComPtr<IMFTimedTextCueList> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* originalId, IMFTimedTextCue** cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, char*, IMFTimedTextCue**, int>)@this->LpVtbl[6])(@this, originalId, cue);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueByOriginalId(this ComPtr<IMFTimedTextCueList> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* originalId, ref IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextCue** cuePtr = &cue)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, char*, IMFTimedTextCue**, int>)@this->LpVtbl[6])(@this, originalId, cuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueByOriginalId(this ComPtr<IMFTimedTextCueList> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char originalId, IMFTimedTextCue** cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* originalIdPtr = &originalId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, char*, IMFTimedTextCue**, int>)@this->LpVtbl[6])(@this, originalIdPtr, cue);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueByOriginalId(this ComPtr<IMFTimedTextCueList> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char originalId, ref IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* originalIdPtr = &originalId)
+        {
+            fixed (IMFTimedTextCue** cuePtr = &cue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, char*, IMFTimedTextCue**, int>)@this->LpVtbl[6])(@this, originalIdPtr, cuePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueByOriginalId(this ComPtr<IMFTimedTextCueList> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string originalId, IMFTimedTextCue** cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var originalIdPtr = (byte*) SilkMarshal.StringToPtr(originalId, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, byte*, IMFTimedTextCue**, int>)@this->LpVtbl[6])(@this, originalIdPtr, cue);
+        SilkMarshal.Free((nint)originalIdPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueByOriginalId(this ComPtr<IMFTimedTextCueList> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string originalId, ref IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var originalIdPtr = (byte*) SilkMarshal.StringToPtr(originalId, NativeStringEncoding.LPWStr);
+        fixed (IMFTimedTextCue** cuePtr = &cue)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, byte*, IMFTimedTextCue**, int>)@this->LpVtbl[6])(@this, originalIdPtr, cuePtr);
+        }
+        SilkMarshal.Free((nint)originalIdPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTextCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* text, IMFTimedTextCue** cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, char*, IMFTimedTextCue**, int>)@this->LpVtbl[7])(@this, start, duration, text, cue);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTextCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* text, ref IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextCue** cuePtr = &cue)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, char*, IMFTimedTextCue**, int>)@this->LpVtbl[7])(@this, start, duration, text, cuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTextCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char text, IMFTimedTextCue** cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* textPtr = &text)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, char*, IMFTimedTextCue**, int>)@this->LpVtbl[7])(@this, start, duration, textPtr, cue);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTextCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char text, ref IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* textPtr = &text)
+        {
+            fixed (IMFTimedTextCue** cuePtr = &cue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, char*, IMFTimedTextCue**, int>)@this->LpVtbl[7])(@this, start, duration, textPtr, cuePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTextCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string text, IMFTimedTextCue** cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var textPtr = (byte*) SilkMarshal.StringToPtr(text, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, IMFTimedTextCue**, int>)@this->LpVtbl[7])(@this, start, duration, textPtr, cue);
+        SilkMarshal.Free((nint)textPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTextCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string text, ref IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var textPtr = (byte*) SilkMarshal.StringToPtr(text, NativeStringEncoding.LPWStr);
+        fixed (IMFTimedTextCue** cuePtr = &cue)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, IMFTimedTextCue**, int>)@this->LpVtbl[7])(@this, start, duration, textPtr, cuePtr);
+        }
+        SilkMarshal.Free((nint)textPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* data, uint dataSize, IMFTimedTextCue** cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[8])(@this, start, duration, data, dataSize, cue);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* data, uint dataSize, ref IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextCue** cuePtr = &cue)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[8])(@this, start, duration, data, dataSize, cuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte data, uint dataSize, IMFTimedTextCue** cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* dataPtr = &data)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[8])(@this, start, duration, dataPtr, dataSize, cue);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte data, uint dataSize, ref IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (byte* dataPtr = &data)
+        {
+            fixed (IMFTimedTextCue** cuePtr = &cue)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[8])(@this, start, duration, dataPtr, dataSize, cuePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string data, uint dataSize, IMFTimedTextCue** cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var dataPtr = (byte*) SilkMarshal.StringToPtr(data, NativeStringEncoding.UTF8);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[8])(@this, start, duration, dataPtr, dataSize, cue);
+        SilkMarshal.Free((nint)dataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string data, uint dataSize, ref IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var dataPtr = (byte*) SilkMarshal.StringToPtr(data, NativeStringEncoding.UTF8);
+        fixed (IMFTimedTextCue** cuePtr = &cue)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, double, double, byte*, uint, IMFTimedTextCue**, int>)@this->LpVtbl[8])(@this, start, duration, dataPtr, dataSize, cuePtr);
+        }
+        SilkMarshal.Free((nint)dataPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int RemoveCue(this ComPtr<IMFTimedTextCueList> thisVtbl, IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, IMFTimedTextCue*, int>)@this->LpVtbl[9])(@this, cue);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RemoveCue(this ComPtr<IMFTimedTextCueList> thisVtbl, ref IMFTimedTextCue cue)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextCue* cuePtr = &cue)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCueList*, IMFTimedTextCue*, int>)@this->LpVtbl[9])(@this, cuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFTimedTextCueList> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextCueList> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextCueList> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetCueByIndex<TI0>(this ComPtr<IMFTimedTextCueList> thisVtbl, uint index, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetCueByIndex(index, (IMFTimedTextCue**) cue.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetCueById<TI0>(this ComPtr<IMFTimedTextCueList> thisVtbl, uint id, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetCueById(id, (IMFTimedTextCue**) cue.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueByOriginalId<TI0>(this ComPtr<IMFTimedTextCueList> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* originalId, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetCueByOriginalId(originalId, (IMFTimedTextCue**) cue.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueByOriginalId(this ComPtr<IMFTimedTextCueList> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> originalId, IMFTimedTextCue** cue)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetCueByOriginalId(in originalId.GetPinnableReference(), cue);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetCueByOriginalId<TI0>(this ComPtr<IMFTimedTextCueList> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char originalId, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetCueByOriginalId(in originalId, (IMFTimedTextCue**) cue.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueByOriginalId(this ComPtr<IMFTimedTextCueList> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> originalId, ref IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetCueByOriginalId(in originalId.GetPinnableReference(), ref cue);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetCueByOriginalId<TI0>(this ComPtr<IMFTimedTextCueList> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string originalId, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetCueByOriginalId(originalId, (IMFTimedTextCue**) cue.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTextCue<TI0>(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* text, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddTextCue(start, duration, text, (IMFTimedTextCue**) cue.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTextCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> text, IMFTimedTextCue** cue)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddTextCue(start, duration, in text.GetPinnableReference(), cue);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddTextCue<TI0>(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char text, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddTextCue(start, duration, in text, (IMFTimedTextCue**) cue.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTextCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> text, ref IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddTextCue(start, duration, in text.GetPinnableReference(), ref cue);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddTextCue<TI0>(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string text, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddTextCue(start, duration, text, (IMFTimedTextCue**) cue.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataCue<TI0>(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] byte* data, uint dataSize, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddDataCue(start, duration, data, dataSize, (IMFTimedTextCue**) cue.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> data, uint dataSize, IMFTimedTextCue** cue)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataCue(start, duration, in data.GetPinnableReference(), dataSize, cue);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataCue<TI0>(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in byte data, uint dataSize, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddDataCue(start, duration, in data, dataSize, (IMFTimedTextCue**) cue.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataCue(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<byte> data, uint dataSize, ref IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataCue(start, duration, in data.GetPinnableReference(), dataSize, ref cue);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataCue<TI0>(this ComPtr<IMFTimedTextCueList> thisVtbl, double start, double duration, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPUTF8Str)] string data, uint dataSize, ref ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddDataCue(start, duration, data, dataSize, (IMFTimedTextCue**) cue.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RemoveCue<TI0>(this ComPtr<IMFTimedTextCueList> thisVtbl, ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->RemoveCue((IMFTimedTextCue*) cue.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RemoveCue(this ComPtr<IMFTimedTextCueList> thisVtbl, Span<IMFTimedTextCue> cue)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->RemoveCue(ref cue.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFTimedTextCueList> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextCueVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextCueVtblExtensions.gen.cs
@@ -1,0 +1,324 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFTimedTextCueVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextCue> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextCue> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextCue> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextCue> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFTimedTextCue> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFTimedTextCue> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint GetId(this ComPtr<IMFTimedTextCue> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, uint>)@this->LpVtbl[3])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetOriginalId(this ComPtr<IMFTimedTextCue> thisVtbl, char** originalId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, char**, int>)@this->LpVtbl[4])(@this, originalId);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetOriginalId(this ComPtr<IMFTimedTextCue> thisVtbl, ref char* originalId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** originalIdPtr = &originalId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, char**, int>)@this->LpVtbl[4])(@this, originalIdPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static TimedTextTrackKind GetCueKind(this ComPtr<IMFTimedTextCue> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        TimedTextTrackKind ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, TimedTextTrackKind>)@this->LpVtbl[5])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetStartTime(this ComPtr<IMFTimedTextCue> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, double>)@this->LpVtbl[6])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static double GetDuration(this ComPtr<IMFTimedTextCue> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        double ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, double>)@this->LpVtbl[7])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint GetTrackId(this ComPtr<IMFTimedTextCue> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, uint>)@this->LpVtbl[8])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetData(this ComPtr<IMFTimedTextCue> thisVtbl, IMFTimedTextBinary** data)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, IMFTimedTextBinary**, int>)@this->LpVtbl[9])(@this, data);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetData(this ComPtr<IMFTimedTextCue> thisVtbl, ref IMFTimedTextBinary* data)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextBinary** dataPtr = &data)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, IMFTimedTextBinary**, int>)@this->LpVtbl[9])(@this, dataPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetRegion(this ComPtr<IMFTimedTextCue> thisVtbl, IMFTimedTextRegion** region)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, IMFTimedTextRegion**, int>)@this->LpVtbl[10])(@this, region);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetRegion(this ComPtr<IMFTimedTextCue> thisVtbl, ref IMFTimedTextRegion* region)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextRegion** regionPtr = &region)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, IMFTimedTextRegion**, int>)@this->LpVtbl[10])(@this, regionPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetStyle(this ComPtr<IMFTimedTextCue> thisVtbl, IMFTimedTextStyle** style)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, IMFTimedTextStyle**, int>)@this->LpVtbl[11])(@this, style);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetStyle(this ComPtr<IMFTimedTextCue> thisVtbl, ref IMFTimedTextStyle* style)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextStyle** stylePtr = &style)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, IMFTimedTextStyle**, int>)@this->LpVtbl[11])(@this, stylePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint GetLineCount(this ComPtr<IMFTimedTextCue> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, uint>)@this->LpVtbl[12])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetLine(this ComPtr<IMFTimedTextCue> thisVtbl, uint index, IMFTimedTextFormattedText** line)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, uint, IMFTimedTextFormattedText**, int>)@this->LpVtbl[13])(@this, index, line);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetLine(this ComPtr<IMFTimedTextCue> thisVtbl, uint index, ref IMFTimedTextFormattedText* line)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextFormattedText** linePtr = &line)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextCue*, uint, IMFTimedTextFormattedText**, int>)@this->LpVtbl[13])(@this, index, linePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFTimedTextCue> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextCue> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextCue> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetOriginalId(this ComPtr<IMFTimedTextCue> thisVtbl, string[] originalIdSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var originalId = (char**) SilkMarshal.StringArrayToPtr(originalIdSa);
+        var ret = @this->GetOriginalId(originalId);
+        SilkMarshal.CopyPtrToStringArray((nint) originalId, originalIdSa);
+        SilkMarshal.Free((nint) originalId);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetData<TI0>(this ComPtr<IMFTimedTextCue> thisVtbl, ref ComPtr<TI0> data) where TI0 : unmanaged, IComVtbl<IMFTimedTextBinary>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetData((IMFTimedTextBinary**) data.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRegion<TI0>(this ComPtr<IMFTimedTextCue> thisVtbl, ref ComPtr<TI0> region) where TI0 : unmanaged, IComVtbl<IMFTimedTextRegion>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetRegion((IMFTimedTextRegion**) region.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetStyle<TI0>(this ComPtr<IMFTimedTextCue> thisVtbl, ref ComPtr<TI0> style) where TI0 : unmanaged, IComVtbl<IMFTimedTextStyle>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetStyle((IMFTimedTextStyle**) style.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetLine<TI0>(this ComPtr<IMFTimedTextCue> thisVtbl, uint index, ref ComPtr<TI0> line) where TI0 : unmanaged, IComVtbl<IMFTimedTextFormattedText>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetLine(index, (IMFTimedTextFormattedText**) line.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFTimedTextCue> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextFormattedTextVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextFormattedTextVtblExtensions.gen.cs
@@ -1,0 +1,351 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFTimedTextFormattedTextVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextFormattedText> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextFormattedText> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextFormattedText> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextFormattedText> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFTimedTextFormattedText> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFTimedTextFormattedText> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetText(this ComPtr<IMFTimedTextFormattedText> thisVtbl, char** text)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, char**, int>)@this->LpVtbl[3])(@this, text);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetText(this ComPtr<IMFTimedTextFormattedText> thisVtbl, ref char* text)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** textPtr = &text)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, char**, int>)@this->LpVtbl[3])(@this, textPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint GetSubformattingCount(this ComPtr<IMFTimedTextFormattedText> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint>)@this->LpVtbl[4])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, uint* firstChar, uint* charLength, IMFTimedTextStyle** style)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstChar, charLength, style);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, uint* firstChar, uint* charLength, ref IMFTimedTextStyle* style)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextStyle** stylePtr = &style)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstChar, charLength, stylePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, uint* firstChar, ref uint charLength, IMFTimedTextStyle** style)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* charLengthPtr = &charLength)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstChar, charLengthPtr, style);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, uint* firstChar, ref uint charLength, ref IMFTimedTextStyle* style)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* charLengthPtr = &charLength)
+        {
+            fixed (IMFTimedTextStyle** stylePtr = &style)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstChar, charLengthPtr, stylePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, ref uint firstChar, uint* charLength, IMFTimedTextStyle** style)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* firstCharPtr = &firstChar)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstCharPtr, charLength, style);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, ref uint firstChar, uint* charLength, ref IMFTimedTextStyle* style)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* firstCharPtr = &firstChar)
+        {
+            fixed (IMFTimedTextStyle** stylePtr = &style)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstCharPtr, charLength, stylePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, ref uint firstChar, ref uint charLength, IMFTimedTextStyle** style)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* firstCharPtr = &firstChar)
+        {
+            fixed (uint* charLengthPtr = &charLength)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstCharPtr, charLengthPtr, style);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, ref uint firstChar, ref uint charLength, ref IMFTimedTextStyle* style)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* firstCharPtr = &firstChar)
+        {
+            fixed (uint* charLengthPtr = &charLength)
+            {
+                fixed (IMFTimedTextStyle** stylePtr = &style)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextFormattedText*, uint, uint*, uint*, IMFTimedTextStyle**, int>)@this->LpVtbl[5])(@this, index, firstCharPtr, charLengthPtr, stylePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFTimedTextFormattedText> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextFormattedText> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextFormattedText> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetText(this ComPtr<IMFTimedTextFormattedText> thisVtbl, string[] textSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var text = (char**) SilkMarshal.StringArrayToPtr(textSa);
+        var ret = @this->GetText(text);
+        SilkMarshal.CopyPtrToStringArray((nint) text, textSa);
+        SilkMarshal.Free((nint) text);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting<TI0>(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, uint* firstChar, uint* charLength, ref ComPtr<TI0> style) where TI0 : unmanaged, IComVtbl<IMFTimedTextStyle>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetSubformatting(index, firstChar, charLength, (IMFTimedTextStyle**) style.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, uint* firstChar, Span<uint> charLength, IMFTimedTextStyle** style)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetSubformatting(index, firstChar, ref charLength.GetPinnableReference(), style);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting<TI0>(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, uint* firstChar, ref uint charLength, ref ComPtr<TI0> style) where TI0 : unmanaged, IComVtbl<IMFTimedTextStyle>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetSubformatting(index, firstChar, ref charLength, (IMFTimedTextStyle**) style.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, uint* firstChar, Span<uint> charLength, ref IMFTimedTextStyle* style)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetSubformatting(index, firstChar, ref charLength.GetPinnableReference(), ref style);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, Span<uint> firstChar, uint* charLength, IMFTimedTextStyle** style)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetSubformatting(index, ref firstChar.GetPinnableReference(), charLength, style);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting<TI0>(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, ref uint firstChar, uint* charLength, ref ComPtr<TI0> style) where TI0 : unmanaged, IComVtbl<IMFTimedTextStyle>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetSubformatting(index, ref firstChar, charLength, (IMFTimedTextStyle**) style.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, Span<uint> firstChar, uint* charLength, ref IMFTimedTextStyle* style)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetSubformatting(index, ref firstChar.GetPinnableReference(), charLength, ref style);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, Span<uint> firstChar, Span<uint> charLength, IMFTimedTextStyle** style)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetSubformatting(index, ref firstChar.GetPinnableReference(), ref charLength.GetPinnableReference(), style);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetSubformatting<TI0>(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, ref uint firstChar, ref uint charLength, ref ComPtr<TI0> style) where TI0 : unmanaged, IComVtbl<IMFTimedTextStyle>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetSubformatting(index, ref firstChar, ref charLength, (IMFTimedTextStyle**) style.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetSubformatting(this ComPtr<IMFTimedTextFormattedText> thisVtbl, uint index, Span<uint> firstChar, Span<uint> charLength, ref IMFTimedTextStyle* style)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetSubformatting(index, ref firstChar.GetPinnableReference(), ref charLength.GetPinnableReference(), ref style);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFTimedTextFormattedText> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextNotifyVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextNotifyVtblExtensions.gen.cs
@@ -1,0 +1,196 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFTimedTextNotifyVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextNotify> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextNotify> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextNotify> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextNotify> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFTimedTextNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFTimedTextNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void TrackAdded(this ComPtr<IMFTimedTextNotify> thisVtbl, uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, uint, void>)@this->LpVtbl[3])(@this, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void TrackRemoved(this ComPtr<IMFTimedTextNotify> thisVtbl, uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, uint, void>)@this->LpVtbl[4])(@this, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void TrackSelected(this ComPtr<IMFTimedTextNotify> thisVtbl, uint trackId, Silk.NET.Core.Bool32 selected)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, uint, Silk.NET.Core.Bool32, void>)@this->LpVtbl[5])(@this, trackId, selected);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void TrackReadyStateChanged(this ComPtr<IMFTimedTextNotify> thisVtbl, uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, uint, void>)@this->LpVtbl[6])(@this, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void Error(this ComPtr<IMFTimedTextNotify> thisVtbl, TimedTextErrorCode errorCode, int extendedErrorCode, uint sourceTrackId)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, TimedTextErrorCode, int, uint, void>)@this->LpVtbl[7])(@this, errorCode, extendedErrorCode, sourceTrackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe void Cue(this ComPtr<IMFTimedTextNotify> thisVtbl, TimedTextCueEvent cueEvent, double currentTime, IMFTimedTextCue* cue)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, TimedTextCueEvent, double, IMFTimedTextCue*, void>)@this->LpVtbl[8])(@this, cueEvent, currentTime, cue);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void Cue(this ComPtr<IMFTimedTextNotify> thisVtbl, TimedTextCueEvent cueEvent, double currentTime, ref IMFTimedTextCue cue)
+    {
+        var @this = thisVtbl.Handle;
+        fixed (IMFTimedTextCue* cuePtr = &cue)
+        {
+            ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, TimedTextCueEvent, double, IMFTimedTextCue*, void>)@this->LpVtbl[8])(@this, cueEvent, currentTime, cuePtr);
+        }
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void Reset(this ComPtr<IMFTimedTextNotify> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        ((delegate* unmanaged[Stdcall]<IMFTimedTextNotify*, void>)@this->LpVtbl[9])(@this);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFTimedTextNotify> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextNotify> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextNotify> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void Cue<TI0>(this ComPtr<IMFTimedTextNotify> thisVtbl, TimedTextCueEvent cueEvent, double currentTime, ComPtr<TI0> cue) where TI0 : unmanaged, IComVtbl<IMFTimedTextCue>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        @this->Cue(cueEvent, currentTime, (IMFTimedTextCue*) cue.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static void Cue(this ComPtr<IMFTimedTextNotify> thisVtbl, TimedTextCueEvent cueEvent, double currentTime, Span<IMFTimedTextCue> cue)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        @this->Cue(cueEvent, currentTime, ref cue.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFTimedTextNotify> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextRegionVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextRegionVtblExtensions.gen.cs
@@ -1,0 +1,1533 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFTimedTextRegionVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextRegion> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextRegion> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextRegion> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextRegion> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFTimedTextRegion> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFTimedTextRegion> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetName(this ComPtr<IMFTimedTextRegion> thisVtbl, char** name)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, char**, int>)@this->LpVtbl[3])(@this, name);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetName(this ComPtr<IMFTimedTextRegion> thisVtbl, ref char* name)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** namePtr = &name)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, char**, int>)@this->LpVtbl[3])(@this, namePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pX, double* pY, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pX, pY, unitType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pX, double* pY, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextUnitType* unitTypePtr = &unitType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pX, pY, unitTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pX, ref double pY, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pYPtr = &pY)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pX, pYPtr, unitType);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pX, ref double pY, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pYPtr = &pY)
+        {
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pX, pYPtr, unitTypePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double pX, double* pY, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pXPtr = &pX)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pXPtr, pY, unitType);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double pX, double* pY, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pXPtr = &pX)
+        {
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pXPtr, pY, unitTypePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double pX, ref double pY, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pXPtr = &pX)
+        {
+            fixed (double* pYPtr = &pY)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pXPtr, pYPtr, unitType);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double pX, ref double pY, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pXPtr = &pX)
+        {
+            fixed (double* pYPtr = &pY)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[4])(@this, pXPtr, pYPtr, unitTypePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pWidth, double* pHeight, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidth, pHeight, unitType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pWidth, double* pHeight, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextUnitType* unitTypePtr = &unitType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidth, pHeight, unitTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pWidth, ref double pHeight, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pHeightPtr = &pHeight)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidth, pHeightPtr, unitType);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pWidth, ref double pHeight, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pHeightPtr = &pHeight)
+        {
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidth, pHeightPtr, unitTypePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double pWidth, double* pHeight, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pWidthPtr = &pWidth)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidthPtr, pHeight, unitType);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double pWidth, double* pHeight, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pWidthPtr = &pWidth)
+        {
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidthPtr, pHeight, unitTypePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double pWidth, ref double pHeight, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pWidthPtr = &pWidth)
+        {
+            fixed (double* pHeightPtr = &pHeight)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidthPtr, pHeightPtr, unitType);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double pWidth, ref double pHeight, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pWidthPtr = &pWidth)
+        {
+            fixed (double* pHeightPtr = &pHeight)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[5])(@this, pWidthPtr, pHeightPtr, unitTypePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetBackgroundColor(this ComPtr<IMFTimedTextRegion> thisVtbl, _MFARGB* bgColor)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, _MFARGB*, int>)@this->LpVtbl[6])(@this, bgColor);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBackgroundColor(this ComPtr<IMFTimedTextRegion> thisVtbl, ref _MFARGB bgColor)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* bgColorPtr = &bgColor)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, _MFARGB*, int>)@this->LpVtbl[6])(@this, bgColorPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetWritingMode(this ComPtr<IMFTimedTextRegion> thisVtbl, TimedTextWritingMode* writingMode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, TimedTextWritingMode*, int>)@this->LpVtbl[7])(@this, writingMode);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetWritingMode(this ComPtr<IMFTimedTextRegion> thisVtbl, ref TimedTextWritingMode writingMode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextWritingMode* writingModePtr = &writingMode)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, TimedTextWritingMode*, int>)@this->LpVtbl[7])(@this, writingModePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetDisplayAlignment(this ComPtr<IMFTimedTextRegion> thisVtbl, TimedTextDisplayAlignment* displayAlign)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, TimedTextDisplayAlignment*, int>)@this->LpVtbl[8])(@this, displayAlign);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetDisplayAlignment(this ComPtr<IMFTimedTextRegion> thisVtbl, ref TimedTextDisplayAlignment displayAlign)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextDisplayAlignment* displayAlignPtr = &displayAlign)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, TimedTextDisplayAlignment*, int>)@this->LpVtbl[8])(@this, displayAlignPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetLineHeight(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pLineHeight, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, TimedTextUnitType*, int>)@this->LpVtbl[9])(@this, pLineHeight, unitType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetLineHeight(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pLineHeight, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextUnitType* unitTypePtr = &unitType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, TimedTextUnitType*, int>)@this->LpVtbl[9])(@this, pLineHeight, unitTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetLineHeight(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double pLineHeight, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pLineHeightPtr = &pLineHeight)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, TimedTextUnitType*, int>)@this->LpVtbl[9])(@this, pLineHeightPtr, unitType);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetLineHeight(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double pLineHeight, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* pLineHeightPtr = &pLineHeight)
+        {
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, TimedTextUnitType*, int>)@this->LpVtbl[9])(@this, pLineHeightPtr, unitTypePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetClipOverflow(this ComPtr<IMFTimedTextRegion> thisVtbl, int* clipOverflow)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, int*, int>)@this->LpVtbl[10])(@this, clipOverflow);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetClipOverflow(this ComPtr<IMFTimedTextRegion> thisVtbl, ref int clipOverflow)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* clipOverflowPtr = &clipOverflow)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, int*, int>)@this->LpVtbl[10])(@this, clipOverflowPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, double* after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, after, end, unitType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, double* after, double* end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextUnitType* unitTypePtr = &unitType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, after, end, unitTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, double* after, ref double end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* endPtr = &end)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, after, endPtr, unitType);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, double* after, ref double end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* endPtr = &end)
+        {
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, after, endPtr, unitTypePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, ref double after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* afterPtr = &after)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, afterPtr, end, unitType);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, ref double after, double* end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* afterPtr = &after)
+        {
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, afterPtr, end, unitTypePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, ref double after, ref double end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* afterPtr = &after)
+        {
+            fixed (double* endPtr = &end)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, afterPtr, endPtr, unitType);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, ref double after, ref double end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* afterPtr = &after)
+        {
+            fixed (double* endPtr = &end)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, start, afterPtr, endPtr, unitTypePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, ref double start, double* after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* startPtr = &start)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, after, end, unitType);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, ref double start, double* after, double* end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* startPtr = &start)
+        {
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, after, end, unitTypePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, ref double start, double* after, ref double end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* startPtr = &start)
+        {
+            fixed (double* endPtr = &end)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, after, endPtr, unitType);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, ref double start, double* after, ref double end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* startPtr = &start)
+        {
+            fixed (double* endPtr = &end)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, after, endPtr, unitTypePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, ref double start, ref double after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* startPtr = &start)
+        {
+            fixed (double* afterPtr = &after)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, afterPtr, end, unitType);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, ref double start, ref double after, double* end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* startPtr = &start)
+        {
+            fixed (double* afterPtr = &after)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, afterPtr, end, unitTypePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, ref double start, ref double after, ref double end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* startPtr = &start)
+        {
+            fixed (double* afterPtr = &after)
+            {
+                fixed (double* endPtr = &end)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, afterPtr, endPtr, unitType);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, ref double start, ref double after, ref double end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* startPtr = &start)
+        {
+            fixed (double* afterPtr = &after)
+            {
+                fixed (double* endPtr = &end)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, before, startPtr, afterPtr, endPtr, unitTypePtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, double* start, double* after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, after, end, unitType);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, double* start, double* after, double* end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, after, end, unitTypePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, double* start, double* after, ref double end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (double* endPtr = &end)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, after, endPtr, unitType);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, double* start, double* after, ref double end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (double* endPtr = &end)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, after, endPtr, unitTypePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, double* start, ref double after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (double* afterPtr = &after)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, afterPtr, end, unitType);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, double* start, ref double after, double* end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (double* afterPtr = &after)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, afterPtr, end, unitTypePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, double* start, ref double after, ref double end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (double* afterPtr = &after)
+            {
+                fixed (double* endPtr = &end)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, afterPtr, endPtr, unitType);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, double* start, ref double after, ref double end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (double* afterPtr = &after)
+            {
+                fixed (double* endPtr = &end)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, start, afterPtr, endPtr, unitTypePtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, ref double start, double* after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (double* startPtr = &start)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, after, end, unitType);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, ref double start, double* after, double* end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (double* startPtr = &start)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, after, end, unitTypePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, ref double start, double* after, ref double end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (double* startPtr = &start)
+            {
+                fixed (double* endPtr = &end)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, after, endPtr, unitType);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, ref double start, double* after, ref double end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (double* startPtr = &start)
+            {
+                fixed (double* endPtr = &end)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, after, endPtr, unitTypePtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, ref double start, ref double after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (double* startPtr = &start)
+            {
+                fixed (double* afterPtr = &after)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, afterPtr, end, unitType);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, ref double start, ref double after, double* end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (double* startPtr = &start)
+            {
+                fixed (double* afterPtr = &after)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, afterPtr, end, unitTypePtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, ref double start, ref double after, ref double end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (double* startPtr = &start)
+            {
+                fixed (double* afterPtr = &after)
+                {
+                    fixed (double* endPtr = &end)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, afterPtr, endPtr, unitType);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, ref double before, ref double start, ref double after, ref double end, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* beforePtr = &before)
+        {
+            fixed (double* startPtr = &start)
+            {
+                fixed (double* afterPtr = &after)
+                {
+                    fixed (double* endPtr = &end)
+                    {
+                        fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                        {
+                            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, double*, double*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[11])(@this, beforePtr, startPtr, afterPtr, endPtr, unitTypePtr);
+                        }
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetWrap(this ComPtr<IMFTimedTextRegion> thisVtbl, int* wrap)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, int*, int>)@this->LpVtbl[12])(@this, wrap);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetWrap(this ComPtr<IMFTimedTextRegion> thisVtbl, ref int wrap)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* wrapPtr = &wrap)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, int*, int>)@this->LpVtbl[12])(@this, wrapPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetZIndex(this ComPtr<IMFTimedTextRegion> thisVtbl, int* zIndex)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, int*, int>)@this->LpVtbl[13])(@this, zIndex);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetZIndex(this ComPtr<IMFTimedTextRegion> thisVtbl, ref int zIndex)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* zIndexPtr = &zIndex)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, int*, int>)@this->LpVtbl[13])(@this, zIndexPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetScrollMode(this ComPtr<IMFTimedTextRegion> thisVtbl, TimedTextScrollMode* scrollMode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, TimedTextScrollMode*, int>)@this->LpVtbl[14])(@this, scrollMode);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetScrollMode(this ComPtr<IMFTimedTextRegion> thisVtbl, ref TimedTextScrollMode scrollMode)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextScrollMode* scrollModePtr = &scrollMode)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRegion*, TimedTextScrollMode*, int>)@this->LpVtbl[14])(@this, scrollModePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFTimedTextRegion> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetName(this ComPtr<IMFTimedTextRegion> thisVtbl, string[] nameSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var name = (char**) SilkMarshal.StringArrayToPtr(nameSa);
+        var ret = @this->GetName(name);
+        SilkMarshal.CopyPtrToStringArray((nint) name, nameSa);
+        SilkMarshal.Free((nint) name);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pX, double* pY, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPosition(pX, pY, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pX, Span<double> pY, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPosition(pX, ref pY.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pX, Span<double> pY, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPosition(pX, ref pY.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> pX, double* pY, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPosition(ref pX.GetPinnableReference(), pY, unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> pX, double* pY, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPosition(ref pX.GetPinnableReference(), pY, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> pX, Span<double> pY, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPosition(ref pX.GetPinnableReference(), ref pY.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetPosition(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> pX, Span<double> pY, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPosition(ref pX.GetPinnableReference(), ref pY.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pWidth, double* pHeight, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetExtent(pWidth, pHeight, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pWidth, Span<double> pHeight, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetExtent(pWidth, ref pHeight.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pWidth, Span<double> pHeight, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetExtent(pWidth, ref pHeight.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> pWidth, double* pHeight, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetExtent(ref pWidth.GetPinnableReference(), pHeight, unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> pWidth, double* pHeight, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetExtent(ref pWidth.GetPinnableReference(), pHeight, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> pWidth, Span<double> pHeight, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetExtent(ref pWidth.GetPinnableReference(), ref pHeight.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetExtent(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> pWidth, Span<double> pHeight, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetExtent(ref pWidth.GetPinnableReference(), ref pHeight.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBackgroundColor(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<_MFARGB> bgColor)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetBackgroundColor(ref bgColor.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetWritingMode(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<TimedTextWritingMode> writingMode)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetWritingMode(ref writingMode.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetDisplayAlignment(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<TimedTextDisplayAlignment> displayAlign)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetDisplayAlignment(ref displayAlign.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetLineHeight(this ComPtr<IMFTimedTextRegion> thisVtbl, double* pLineHeight, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetLineHeight(pLineHeight, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetLineHeight(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> pLineHeight, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetLineHeight(ref pLineHeight.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetLineHeight(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> pLineHeight, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetLineHeight(ref pLineHeight.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetClipOverflow(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<int> clipOverflow)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetClipOverflow(ref clipOverflow.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, double* after, double* end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, start, after, end, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, double* after, Span<double> end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, start, after, ref end.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, double* after, Span<double> end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, start, after, ref end.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, Span<double> after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, start, ref after.GetPinnableReference(), end, unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, Span<double> after, double* end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, start, ref after.GetPinnableReference(), end, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, Span<double> after, Span<double> end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, start, ref after.GetPinnableReference(), ref end.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, double* start, Span<double> after, Span<double> end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, start, ref after.GetPinnableReference(), ref end.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, Span<double> start, double* after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, ref start.GetPinnableReference(), after, end, unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, Span<double> start, double* after, double* end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, ref start.GetPinnableReference(), after, end, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, Span<double> start, double* after, Span<double> end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, ref start.GetPinnableReference(), after, ref end.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, Span<double> start, double* after, Span<double> end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, ref start.GetPinnableReference(), after, ref end.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, Span<double> start, Span<double> after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, ref start.GetPinnableReference(), ref after.GetPinnableReference(), end, unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, Span<double> start, Span<double> after, double* end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, ref start.GetPinnableReference(), ref after.GetPinnableReference(), end, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, Span<double> start, Span<double> after, Span<double> end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, ref start.GetPinnableReference(), ref after.GetPinnableReference(), ref end.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, double* before, Span<double> start, Span<double> after, Span<double> end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(before, ref start.GetPinnableReference(), ref after.GetPinnableReference(), ref end.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, double* start, double* after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), start, after, end, unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, double* start, double* after, double* end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), start, after, end, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, double* start, double* after, Span<double> end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), start, after, ref end.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, double* start, double* after, Span<double> end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), start, after, ref end.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, double* start, Span<double> after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), start, ref after.GetPinnableReference(), end, unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, double* start, Span<double> after, double* end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), start, ref after.GetPinnableReference(), end, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, double* start, Span<double> after, Span<double> end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), start, ref after.GetPinnableReference(), ref end.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, double* start, Span<double> after, Span<double> end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), start, ref after.GetPinnableReference(), ref end.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, Span<double> start, double* after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), ref start.GetPinnableReference(), after, end, unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, Span<double> start, double* after, double* end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), ref start.GetPinnableReference(), after, end, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, Span<double> start, double* after, Span<double> end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), ref start.GetPinnableReference(), after, ref end.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, Span<double> start, double* after, Span<double> end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), ref start.GetPinnableReference(), after, ref end.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, Span<double> start, Span<double> after, double* end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), ref start.GetPinnableReference(), ref after.GetPinnableReference(), end, unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, Span<double> start, Span<double> after, double* end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), ref start.GetPinnableReference(), ref after.GetPinnableReference(), end, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, Span<double> start, Span<double> after, Span<double> end, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), ref start.GetPinnableReference(), ref after.GetPinnableReference(), ref end.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetPadding(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<double> before, Span<double> start, Span<double> after, Span<double> end, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetPadding(ref before.GetPinnableReference(), ref start.GetPinnableReference(), ref after.GetPinnableReference(), ref end.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetWrap(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<int> wrap)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetWrap(ref wrap.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetZIndex(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<int> zIndex)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetZIndex(ref zIndex.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetScrollMode(this ComPtr<IMFTimedTextRegion> thisVtbl, Span<TimedTextScrollMode> scrollMode)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetScrollMode(ref scrollMode.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFTimedTextRegion> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextRubyVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextRubyVtblExtensions.gen.cs
@@ -1,0 +1,241 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFTimedTextRubyVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextRuby> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextRuby> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextRuby> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextRuby> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFTimedTextRuby> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFTimedTextRuby> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetRubyText(this ComPtr<IMFTimedTextRuby> thisVtbl, char** rubyText)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, char**, int>)@this->LpVtbl[3])(@this, rubyText);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetRubyText(this ComPtr<IMFTimedTextRuby> thisVtbl, ref char* rubyText)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** rubyTextPtr = &rubyText)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, char**, int>)@this->LpVtbl[3])(@this, rubyTextPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetRubyPosition(this ComPtr<IMFTimedTextRuby> thisVtbl, TimedTextRubyPosition* value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, TimedTextRubyPosition*, int>)@this->LpVtbl[4])(@this, value);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRubyPosition(this ComPtr<IMFTimedTextRuby> thisVtbl, ref TimedTextRubyPosition value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextRubyPosition* valuePtr = &value)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, TimedTextRubyPosition*, int>)@this->LpVtbl[4])(@this, valuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetRubyAlign(this ComPtr<IMFTimedTextRuby> thisVtbl, TimedTextRubyAlign* value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, TimedTextRubyAlign*, int>)@this->LpVtbl[5])(@this, value);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRubyAlign(this ComPtr<IMFTimedTextRuby> thisVtbl, ref TimedTextRubyAlign value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextRubyAlign* valuePtr = &value)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, TimedTextRubyAlign*, int>)@this->LpVtbl[5])(@this, valuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetRubyReserve(this ComPtr<IMFTimedTextRuby> thisVtbl, TimedTextRubyReserve* value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, TimedTextRubyReserve*, int>)@this->LpVtbl[6])(@this, value);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRubyReserve(this ComPtr<IMFTimedTextRuby> thisVtbl, ref TimedTextRubyReserve value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextRubyReserve* valuePtr = &value)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextRuby*, TimedTextRubyReserve*, int>)@this->LpVtbl[6])(@this, valuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFTimedTextRuby> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextRuby> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextRuby> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRubyText(this ComPtr<IMFTimedTextRuby> thisVtbl, string[] rubyTextSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var rubyText = (char**) SilkMarshal.StringArrayToPtr(rubyTextSa);
+        var ret = @this->GetRubyText(rubyText);
+        SilkMarshal.CopyPtrToStringArray((nint) rubyText, rubyTextSa);
+        SilkMarshal.Free((nint) rubyText);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRubyPosition(this ComPtr<IMFTimedTextRuby> thisVtbl, Span<TimedTextRubyPosition> value)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetRubyPosition(ref value.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRubyAlign(this ComPtr<IMFTimedTextRuby> thisVtbl, Span<TimedTextRubyAlign> value)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetRubyAlign(ref value.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRubyReserve(this ComPtr<IMFTimedTextRuby> thisVtbl, Span<TimedTextRubyReserve> value)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetRubyReserve(ref value.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFTimedTextRuby> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextStyle2VtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextStyle2VtblExtensions.gen.cs
@@ -1,0 +1,237 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFTimedTextStyle2VtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextStyle2> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextStyle2> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextStyle2> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextStyle2> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFTimedTextStyle2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFTimedTextStyle2> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetRuby(this ComPtr<IMFTimedTextStyle2> thisVtbl, IMFTimedTextRuby** ruby)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, IMFTimedTextRuby**, int>)@this->LpVtbl[3])(@this, ruby);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetRuby(this ComPtr<IMFTimedTextStyle2> thisVtbl, ref IMFTimedTextRuby* ruby)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextRuby** rubyPtr = &ruby)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, IMFTimedTextRuby**, int>)@this->LpVtbl[3])(@this, rubyPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetBouten(this ComPtr<IMFTimedTextStyle2> thisVtbl, IMFTimedTextBouten** bouten)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, IMFTimedTextBouten**, int>)@this->LpVtbl[4])(@this, bouten);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetBouten(this ComPtr<IMFTimedTextStyle2> thisVtbl, ref IMFTimedTextBouten* bouten)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextBouten** boutenPtr = &bouten)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, IMFTimedTextBouten**, int>)@this->LpVtbl[4])(@this, boutenPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int IsTextCombined(this ComPtr<IMFTimedTextStyle2> thisVtbl, int* value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, int*, int>)@this->LpVtbl[5])(@this, value);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTextCombined(this ComPtr<IMFTimedTextStyle2> thisVtbl, ref int value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* valuePtr = &value)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, int*, int>)@this->LpVtbl[5])(@this, valuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetFontAngleInDegrees(this ComPtr<IMFTimedTextStyle2> thisVtbl, double* value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, double*, int>)@this->LpVtbl[6])(@this, value);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetFontAngleInDegrees(this ComPtr<IMFTimedTextStyle2> thisVtbl, ref double value)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* valuePtr = &value)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle2*, double*, int>)@this->LpVtbl[6])(@this, valuePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFTimedTextStyle2> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextStyle2> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextStyle2> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRuby<TI0>(this ComPtr<IMFTimedTextStyle2> thisVtbl, ref ComPtr<TI0> ruby) where TI0 : unmanaged, IComVtbl<IMFTimedTextRuby>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetRuby((IMFTimedTextRuby**) ruby.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBouten<TI0>(this ComPtr<IMFTimedTextStyle2> thisVtbl, ref ComPtr<TI0> bouten) where TI0 : unmanaged, IComVtbl<IMFTimedTextBouten>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetBouten((IMFTimedTextBouten**) bouten.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int IsTextCombined(this ComPtr<IMFTimedTextStyle2> thisVtbl, Span<int> value)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->IsTextCombined(ref value.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetFontAngleInDegrees(this ComPtr<IMFTimedTextStyle2> thisVtbl, Span<double> value)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetFontAngleInDegrees(ref value.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFTimedTextStyle2> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextStyleVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextStyleVtblExtensions.gen.cs
@@ -1,0 +1,860 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFTimedTextStyleVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextStyle> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextStyle> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextStyle> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextStyle> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFTimedTextStyle> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFTimedTextStyle> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetName(this ComPtr<IMFTimedTextStyle> thisVtbl, char** name)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, char**, int>)@this->LpVtbl[3])(@this, name);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetName(this ComPtr<IMFTimedTextStyle> thisVtbl, ref char* name)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** namePtr = &name)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, char**, int>)@this->LpVtbl[3])(@this, namePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsExternal(this ComPtr<IMFTimedTextStyle> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, Silk.NET.Core.Bool32>)@this->LpVtbl[4])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetFontFamily(this ComPtr<IMFTimedTextStyle> thisVtbl, char** fontFamily)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, char**, int>)@this->LpVtbl[5])(@this, fontFamily);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetFontFamily(this ComPtr<IMFTimedTextStyle> thisVtbl, ref char* fontFamily)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** fontFamilyPtr = &fontFamily)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, char**, int>)@this->LpVtbl[5])(@this, fontFamilyPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetFontSize(this ComPtr<IMFTimedTextStyle> thisVtbl, double* fontSize, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, double*, TimedTextUnitType*, int>)@this->LpVtbl[6])(@this, fontSize, unitType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetFontSize(this ComPtr<IMFTimedTextStyle> thisVtbl, double* fontSize, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextUnitType* unitTypePtr = &unitType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, double*, TimedTextUnitType*, int>)@this->LpVtbl[6])(@this, fontSize, unitTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetFontSize(this ComPtr<IMFTimedTextStyle> thisVtbl, ref double fontSize, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* fontSizePtr = &fontSize)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, double*, TimedTextUnitType*, int>)@this->LpVtbl[6])(@this, fontSizePtr, unitType);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetFontSize(this ComPtr<IMFTimedTextStyle> thisVtbl, ref double fontSize, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* fontSizePtr = &fontSize)
+        {
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, double*, TimedTextUnitType*, int>)@this->LpVtbl[6])(@this, fontSizePtr, unitTypePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetColor(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, int>)@this->LpVtbl[7])(@this, color);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetColor(this ComPtr<IMFTimedTextStyle> thisVtbl, ref _MFARGB color)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* colorPtr = &color)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, int>)@this->LpVtbl[7])(@this, colorPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetBackgroundColor(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* bgColor)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, int>)@this->LpVtbl[8])(@this, bgColor);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBackgroundColor(this ComPtr<IMFTimedTextStyle> thisVtbl, ref _MFARGB bgColor)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* bgColorPtr = &bgColor)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, int>)@this->LpVtbl[8])(@this, bgColorPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetShowBackgroundAlways(this ComPtr<IMFTimedTextStyle> thisVtbl, int* showBackgroundAlways)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, int*, int>)@this->LpVtbl[9])(@this, showBackgroundAlways);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetShowBackgroundAlways(this ComPtr<IMFTimedTextStyle> thisVtbl, ref int showBackgroundAlways)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* showBackgroundAlwaysPtr = &showBackgroundAlways)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, int*, int>)@this->LpVtbl[9])(@this, showBackgroundAlwaysPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetFontStyle(this ComPtr<IMFTimedTextStyle> thisVtbl, TimedTextFontStyle* fontStyle)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, TimedTextFontStyle*, int>)@this->LpVtbl[10])(@this, fontStyle);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetFontStyle(this ComPtr<IMFTimedTextStyle> thisVtbl, ref TimedTextFontStyle fontStyle)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextFontStyle* fontStylePtr = &fontStyle)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, TimedTextFontStyle*, int>)@this->LpVtbl[10])(@this, fontStylePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetBold(this ComPtr<IMFTimedTextStyle> thisVtbl, int* bold)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, int*, int>)@this->LpVtbl[11])(@this, bold);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBold(this ComPtr<IMFTimedTextStyle> thisVtbl, ref int bold)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* boldPtr = &bold)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, int*, int>)@this->LpVtbl[11])(@this, boldPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetRightToLeft(this ComPtr<IMFTimedTextStyle> thisVtbl, int* rightToLeft)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, int*, int>)@this->LpVtbl[12])(@this, rightToLeft);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRightToLeft(this ComPtr<IMFTimedTextStyle> thisVtbl, ref int rightToLeft)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (int* rightToLeftPtr = &rightToLeft)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, int*, int>)@this->LpVtbl[12])(@this, rightToLeftPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextAlignment(this ComPtr<IMFTimedTextStyle> thisVtbl, TimedTextAlignment* textAlign)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, TimedTextAlignment*, int>)@this->LpVtbl[13])(@this, textAlign);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetTextAlignment(this ComPtr<IMFTimedTextStyle> thisVtbl, ref TimedTextAlignment textAlign)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextAlignment* textAlignPtr = &textAlign)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, TimedTextAlignment*, int>)@this->LpVtbl[13])(@this, textAlignPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextDecoration(this ComPtr<IMFTimedTextStyle> thisVtbl, uint* textDecoration)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, uint*, int>)@this->LpVtbl[14])(@this, textDecoration);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetTextDecoration(this ComPtr<IMFTimedTextStyle> thisVtbl, ref uint textDecoration)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* textDecorationPtr = &textDecoration)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, uint*, int>)@this->LpVtbl[14])(@this, textDecorationPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, double* thickness, double* blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thickness, blurRadius, unitType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, double* thickness, double* blurRadius, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (TimedTextUnitType* unitTypePtr = &unitType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thickness, blurRadius, unitTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, double* thickness, ref double blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* blurRadiusPtr = &blurRadius)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thickness, blurRadiusPtr, unitType);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, double* thickness, ref double blurRadius, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* blurRadiusPtr = &blurRadius)
+        {
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thickness, blurRadiusPtr, unitTypePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, ref double thickness, double* blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* thicknessPtr = &thickness)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thicknessPtr, blurRadius, unitType);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, ref double thickness, double* blurRadius, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* thicknessPtr = &thickness)
+        {
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thicknessPtr, blurRadius, unitTypePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, ref double thickness, ref double blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* thicknessPtr = &thickness)
+        {
+            fixed (double* blurRadiusPtr = &blurRadius)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thicknessPtr, blurRadiusPtr, unitType);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, ref double thickness, ref double blurRadius, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* thicknessPtr = &thickness)
+        {
+            fixed (double* blurRadiusPtr = &blurRadius)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, color, thicknessPtr, blurRadiusPtr, unitTypePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, ref _MFARGB color, double* thickness, double* blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* colorPtr = &color)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thickness, blurRadius, unitType);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, ref _MFARGB color, double* thickness, double* blurRadius, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* colorPtr = &color)
+        {
+            fixed (TimedTextUnitType* unitTypePtr = &unitType)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thickness, blurRadius, unitTypePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, ref _MFARGB color, double* thickness, ref double blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* colorPtr = &color)
+        {
+            fixed (double* blurRadiusPtr = &blurRadius)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thickness, blurRadiusPtr, unitType);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, ref _MFARGB color, double* thickness, ref double blurRadius, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* colorPtr = &color)
+        {
+            fixed (double* blurRadiusPtr = &blurRadius)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thickness, blurRadiusPtr, unitTypePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, ref _MFARGB color, ref double thickness, double* blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* colorPtr = &color)
+        {
+            fixed (double* thicknessPtr = &thickness)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thicknessPtr, blurRadius, unitType);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, ref _MFARGB color, ref double thickness, double* blurRadius, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* colorPtr = &color)
+        {
+            fixed (double* thicknessPtr = &thickness)
+            {
+                fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thicknessPtr, blurRadius, unitTypePtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, ref _MFARGB color, ref double thickness, ref double blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* colorPtr = &color)
+        {
+            fixed (double* thicknessPtr = &thickness)
+            {
+                fixed (double* blurRadiusPtr = &blurRadius)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thicknessPtr, blurRadiusPtr, unitType);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, ref _MFARGB color, ref double thickness, ref double blurRadius, ref TimedTextUnitType unitType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (_MFARGB* colorPtr = &color)
+        {
+            fixed (double* thicknessPtr = &thickness)
+            {
+                fixed (double* blurRadiusPtr = &blurRadius)
+                {
+                    fixed (TimedTextUnitType* unitTypePtr = &unitType)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextStyle*, _MFARGB*, double*, double*, TimedTextUnitType*, int>)@this->LpVtbl[15])(@this, colorPtr, thicknessPtr, blurRadiusPtr, unitTypePtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFTimedTextStyle> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetName(this ComPtr<IMFTimedTextStyle> thisVtbl, string[] nameSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var name = (char**) SilkMarshal.StringArrayToPtr(nameSa);
+        var ret = @this->GetName(name);
+        SilkMarshal.CopyPtrToStringArray((nint) name, nameSa);
+        SilkMarshal.Free((nint) name);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetFontFamily(this ComPtr<IMFTimedTextStyle> thisVtbl, string[] fontFamilySa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var fontFamily = (char**) SilkMarshal.StringArrayToPtr(fontFamilySa);
+        var ret = @this->GetFontFamily(fontFamily);
+        SilkMarshal.CopyPtrToStringArray((nint) fontFamily, fontFamilySa);
+        SilkMarshal.Free((nint) fontFamily);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetFontSize(this ComPtr<IMFTimedTextStyle> thisVtbl, double* fontSize, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetFontSize(fontSize, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetFontSize(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<double> fontSize, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetFontSize(ref fontSize.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetFontSize(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<double> fontSize, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetFontSize(ref fontSize.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetColor(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<_MFARGB> color)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetColor(ref color.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBackgroundColor(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<_MFARGB> bgColor)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetBackgroundColor(ref bgColor.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetShowBackgroundAlways(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<int> showBackgroundAlways)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetShowBackgroundAlways(ref showBackgroundAlways.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetFontStyle(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<TimedTextFontStyle> fontStyle)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetFontStyle(ref fontStyle.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetBold(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<int> bold)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetBold(ref bold.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetRightToLeft(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<int> rightToLeft)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetRightToLeft(ref rightToLeft.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetTextAlignment(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<TimedTextAlignment> textAlign)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextAlignment(ref textAlign.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetTextDecoration(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<uint> textDecoration)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextDecoration(ref textDecoration.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, double* thickness, double* blurRadius, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(color, thickness, blurRadius, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, double* thickness, Span<double> blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(color, thickness, ref blurRadius.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, double* thickness, Span<double> blurRadius, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(color, thickness, ref blurRadius.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, Span<double> thickness, double* blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(color, ref thickness.GetPinnableReference(), blurRadius, unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, Span<double> thickness, double* blurRadius, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(color, ref thickness.GetPinnableReference(), blurRadius, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, Span<double> thickness, Span<double> blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(color, ref thickness.GetPinnableReference(), ref blurRadius.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, _MFARGB* color, Span<double> thickness, Span<double> blurRadius, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(color, ref thickness.GetPinnableReference(), ref blurRadius.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<_MFARGB> color, double* thickness, double* blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(ref color.GetPinnableReference(), thickness, blurRadius, unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<_MFARGB> color, double* thickness, double* blurRadius, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(ref color.GetPinnableReference(), thickness, blurRadius, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<_MFARGB> color, double* thickness, Span<double> blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(ref color.GetPinnableReference(), thickness, ref blurRadius.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<_MFARGB> color, double* thickness, Span<double> blurRadius, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(ref color.GetPinnableReference(), thickness, ref blurRadius.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<_MFARGB> color, Span<double> thickness, double* blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(ref color.GetPinnableReference(), ref thickness.GetPinnableReference(), blurRadius, unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<_MFARGB> color, Span<double> thickness, double* blurRadius, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(ref color.GetPinnableReference(), ref thickness.GetPinnableReference(), blurRadius, ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<_MFARGB> color, Span<double> thickness, Span<double> blurRadius, TimedTextUnitType* unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(ref color.GetPinnableReference(), ref thickness.GetPinnableReference(), ref blurRadius.GetPinnableReference(), unitType);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetTextOutline(this ComPtr<IMFTimedTextStyle> thisVtbl, Span<_MFARGB> color, Span<double> thickness, Span<double> blurRadius, Span<TimedTextUnitType> unitType)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetTextOutline(ref color.GetPinnableReference(), ref thickness.GetPinnableReference(), ref blurRadius.GetPinnableReference(), ref unitType.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFTimedTextStyle> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextTrackListVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextTrackListVtblExtensions.gen.cs
@@ -1,0 +1,188 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFTimedTextTrackListVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextTrackList> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextTrackList> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextTrackList> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextTrackList> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFTimedTextTrackList> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFTimedTextTrackList> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint GetLength(this ComPtr<IMFTimedTextTrackList> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, uint>)@this->LpVtbl[3])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTrack(this ComPtr<IMFTimedTextTrackList> thisVtbl, uint index, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, uint, IMFTimedTextTrack**, int>)@this->LpVtbl[4])(@this, index, track);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTrack(this ComPtr<IMFTimedTextTrackList> thisVtbl, uint index, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextTrack** trackPtr = &track)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, uint, IMFTimedTextTrack**, int>)@this->LpVtbl[4])(@this, index, trackPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTrackById(this ComPtr<IMFTimedTextTrackList> thisVtbl, uint trackId, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, uint, IMFTimedTextTrack**, int>)@this->LpVtbl[5])(@this, trackId, track);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTrackById(this ComPtr<IMFTimedTextTrackList> thisVtbl, uint trackId, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextTrack** trackPtr = &track)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrackList*, uint, IMFTimedTextTrack**, int>)@this->LpVtbl[5])(@this, trackId, trackPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFTimedTextTrackList> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextTrackList> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextTrackList> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetTrack<TI0>(this ComPtr<IMFTimedTextTrackList> thisVtbl, uint index, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetTrack(index, (IMFTimedTextTrack**) track.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetTrackById<TI0>(this ComPtr<IMFTimedTextTrackList> thisVtbl, uint trackId, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetTrackById(trackId, (IMFTimedTextTrack**) track.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFTimedTextTrackList> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextTrackVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextTrackVtblExtensions.gen.cs
@@ -1,0 +1,381 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFTimedTextTrackVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextTrack> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextTrack> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextTrack> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextTrack> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFTimedTextTrack> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFTimedTextTrack> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint GetId(this ComPtr<IMFTimedTextTrack> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, uint>)@this->LpVtbl[3])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetLabel(this ComPtr<IMFTimedTextTrack> thisVtbl, char** label)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char**, int>)@this->LpVtbl[4])(@this, label);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetLabel(this ComPtr<IMFTimedTextTrack> thisVtbl, ref char* label)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** labelPtr = &label)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char**, int>)@this->LpVtbl[4])(@this, labelPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int SetLabel(this ComPtr<IMFTimedTextTrack> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char*, int>)@this->LpVtbl[5])(@this, label);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetLabel(this ComPtr<IMFTimedTextTrack> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char*, int>)@this->LpVtbl[5])(@this, labelPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetLabel(this ComPtr<IMFTimedTextTrack> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, byte*, int>)@this->LpVtbl[5])(@this, labelPtr);
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetLanguage(this ComPtr<IMFTimedTextTrack> thisVtbl, char** language)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char**, int>)@this->LpVtbl[6])(@this, language);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetLanguage(this ComPtr<IMFTimedTextTrack> thisVtbl, ref char* language)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** languagePtr = &language)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char**, int>)@this->LpVtbl[6])(@this, languagePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static TimedTextTrackKind GetTrackKind(this ComPtr<IMFTimedTextTrack> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        TimedTextTrackKind ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, TimedTextTrackKind>)@this->LpVtbl[7])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsInBand(this ComPtr<IMFTimedTextTrack> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Silk.NET.Core.Bool32>)@this->LpVtbl[8])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetInBandMetadataTrackDispatchType(this ComPtr<IMFTimedTextTrack> thisVtbl, char** dispatchType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char**, int>)@this->LpVtbl[9])(@this, dispatchType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetInBandMetadataTrackDispatchType(this ComPtr<IMFTimedTextTrack> thisVtbl, ref char* dispatchType)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char** dispatchTypePtr = &dispatchType)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, char**, int>)@this->LpVtbl[9])(@this, dispatchTypePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsActive(this ComPtr<IMFTimedTextTrack> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Silk.NET.Core.Bool32>)@this->LpVtbl[10])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static TimedTextErrorCode GetErrorCode(this ComPtr<IMFTimedTextTrack> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        TimedTextErrorCode ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, TimedTextErrorCode>)@this->LpVtbl[11])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetExtendedErrorCode(this ComPtr<IMFTimedTextTrack> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, int>)@this->LpVtbl[12])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetDataFormat(this ComPtr<IMFTimedTextTrack> thisVtbl, Guid* format)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Guid*, int>)@this->LpVtbl[13])(@this, format);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetDataFormat(this ComPtr<IMFTimedTextTrack> thisVtbl, ref Guid format)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* formatPtr = &format)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, Guid*, int>)@this->LpVtbl[13])(@this, formatPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static TimedTextTrackReadyState GetReadyState(this ComPtr<IMFTimedTextTrack> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        TimedTextTrackReadyState ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, TimedTextTrackReadyState>)@this->LpVtbl[14])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueList(this ComPtr<IMFTimedTextTrack> thisVtbl, IMFTimedTextCueList** cues)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, IMFTimedTextCueList**, int>)@this->LpVtbl[15])(@this, cues);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueList(this ComPtr<IMFTimedTextTrack> thisVtbl, ref IMFTimedTextCueList* cues)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextCueList** cuesPtr = &cues)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedTextTrack*, IMFTimedTextCueList**, int>)@this->LpVtbl[15])(@this, cuesPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFTimedTextTrack> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextTrack> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedTextTrack> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetLabel(this ComPtr<IMFTimedTextTrack> thisVtbl, string[] labelSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var label = (char**) SilkMarshal.StringArrayToPtr(labelSa);
+        var ret = @this->GetLabel(label);
+        SilkMarshal.CopyPtrToStringArray((nint) label, labelSa);
+        SilkMarshal.Free((nint) label);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetLabel(this ComPtr<IMFTimedTextTrack> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->SetLabel(in label.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetLanguage(this ComPtr<IMFTimedTextTrack> thisVtbl, string[] languageSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var language = (char**) SilkMarshal.StringArrayToPtr(languageSa);
+        var ret = @this->GetLanguage(language);
+        SilkMarshal.CopyPtrToStringArray((nint) language, languageSa);
+        SilkMarshal.Free((nint) language);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetInBandMetadataTrackDispatchType(this ComPtr<IMFTimedTextTrack> thisVtbl, string[] dispatchTypeSa)
+    {
+        var @this = thisVtbl.Handle;
+        // StringArrayOverloader
+        var dispatchType = (char**) SilkMarshal.StringArrayToPtr(dispatchTypeSa);
+        var ret = @this->GetInBandMetadataTrackDispatchType(dispatchType);
+        SilkMarshal.CopyPtrToStringArray((nint) dispatchType, dispatchTypeSa);
+        SilkMarshal.Free((nint) dispatchType);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetDataFormat(this ComPtr<IMFTimedTextTrack> thisVtbl, Span<Guid> format)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetDataFormat(ref format.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetCueList<TI0>(this ComPtr<IMFTimedTextTrack> thisVtbl, ref ComPtr<TI0> cues) where TI0 : unmanaged, IComVtbl<IMFTimedTextCueList>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetCueList((IMFTimedTextCueList**) cues.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFTimedTextTrack> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextVtblExtensions.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/MFTimedTextVtblExtensions.gen.cs
@@ -1,0 +1,2790 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation;
+
+public unsafe static class MFTimedTextVtblExtensions
+{
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedText> thisVtbl, Guid* riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObject);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedText> thisVtbl, Guid* riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (void** ppvObjectPtr = &ppvObject)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riid, ppvObjectPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedText> thisVtbl, ref Guid riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObject);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedText> thisVtbl, ref Guid riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (Guid* riidPtr = &riid)
+        {
+            fixed (void** ppvObjectPtr = &ppvObject)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, Guid*, void**, int>)@this->LpVtbl[0])(@this, riidPtr, ppvObjectPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint AddRef(this ComPtr<IMFTimedText> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, uint>)@this->LpVtbl[1])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static uint Release(this ComPtr<IMFTimedText> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        uint ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, uint>)@this->LpVtbl[2])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int RegisterNotifications(this ComPtr<IMFTimedText> thisVtbl, IMFTimedTextNotify* notify)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextNotify*, int>)@this->LpVtbl[3])(@this, notify);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RegisterNotifications(this ComPtr<IMFTimedText> thisVtbl, ref IMFTimedTextNotify notify)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextNotify* notifyPtr = &notify)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextNotify*, int>)@this->LpVtbl[3])(@this, notifyPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SelectTrack(this ComPtr<IMFTimedText> thisVtbl, uint trackId, Silk.NET.Core.Bool32 selected)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, uint, Silk.NET.Core.Bool32, int>)@this->LpVtbl[4])(@this, trackId, selected);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, label, language, kind, isDefault, trackId);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* trackIdPtr = &trackId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, label, language, kind, isDefault, trackIdPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* languagePtr = &language)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, label, languagePtr, kind, isDefault, trackId);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* languagePtr = &language)
+        {
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, label, languagePtr, kind, isDefault, trackIdPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, label, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        fixed (uint* trackIdPtr = &trackId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, label, languagePtr, kind, isDefault, trackIdPtr);
+        }
+        SilkMarshal.Free((nint)languagePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, language, kind, isDefault, trackId);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, language, kind, isDefault, trackIdPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackId);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+            fixed (char* languagePtr = &language)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+            }
+        SilkMarshal.Free((nint)languagePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, language, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        fixed (uint* trackIdPtr = &trackId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, language, kind, isDefault, trackIdPtr);
+        }
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        fixed (char* languagePtr = &language)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackId);
+        }
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        fixed (char* languagePtr = &language)
+        {
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+            }
+        }
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        fixed (uint* trackIdPtr = &trackId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStream, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+        }
+        SilkMarshal.Free((nint)languagePtr);
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, label, language, kind, isDefault, trackId);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, label, language, kind, isDefault, trackIdPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, label, languagePtr, kind, isDefault, trackId);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+            fixed (char* languagePtr = &language)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, label, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, label, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, label, languagePtr, kind, isDefault, trackIdPtr);
+            }
+        SilkMarshal.Free((nint)languagePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+            fixed (char* labelPtr = &label)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, language, kind, isDefault, trackId);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+            fixed (char* labelPtr = &label)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, language, kind, isDefault, trackIdPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+            fixed (char* labelPtr = &label)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+            fixed (char* labelPtr = &label)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    fixed (uint* trackIdPtr = &trackId)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+            fixed (char* labelPtr = &label)
+            {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+            fixed (char* labelPtr = &label)
+            {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+        SilkMarshal.Free((nint)languagePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, language, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)labelPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, language, kind, isDefault, trackIdPtr);
+            }
+        SilkMarshal.Free((nint)labelPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+            }
+        SilkMarshal.Free((nint)labelPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (char* languagePtr = &language)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            }
+        SilkMarshal.Free((nint)labelPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+        SilkMarshal.Free((nint)labelPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, ref IMFByteStream byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFByteStream* byteStreamPtr = &byteStream)
+        {
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFByteStream*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[5])(@this, byteStreamPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+            }
+        SilkMarshal.Free((nint)languagePtr);
+        SilkMarshal.Free((nint)labelPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, label, language, kind, isDefault, trackId);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (uint* trackIdPtr = &trackId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, label, language, kind, isDefault, trackIdPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* languagePtr = &language)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, label, languagePtr, kind, isDefault, trackId);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* languagePtr = &language)
+        {
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, label, languagePtr, kind, isDefault, trackIdPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, label, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        fixed (uint* trackIdPtr = &trackId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, label, languagePtr, kind, isDefault, trackIdPtr);
+        }
+        SilkMarshal.Free((nint)languagePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, language, kind, isDefault, trackId);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, language, kind, isDefault, trackIdPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackId);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+            fixed (char* languagePtr = &language)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+            }
+        SilkMarshal.Free((nint)languagePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, language, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        fixed (uint* trackIdPtr = &trackId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, language, kind, isDefault, trackIdPtr);
+        }
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        fixed (char* languagePtr = &language)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackId);
+        }
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        fixed (char* languagePtr = &language)
+        {
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+            }
+        }
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        fixed (uint* trackIdPtr = &trackId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, url, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+        }
+        SilkMarshal.Free((nint)languagePtr);
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, language, kind, isDefault, trackId);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, language, kind, isDefault, trackIdPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackId);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+            fixed (char* languagePtr = &language)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackIdPtr);
+            }
+        SilkMarshal.Free((nint)languagePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+            fixed (char* labelPtr = &label)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackId);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+            fixed (char* labelPtr = &label)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackIdPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+            fixed (char* labelPtr = &label)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+            fixed (char* labelPtr = &label)
+            {
+                fixed (char* languagePtr = &language)
+                {
+                    fixed (uint* trackIdPtr = &trackId)
+                    {
+                        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                    }
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+            fixed (char* labelPtr = &label)
+            {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+            fixed (char* labelPtr = &label)
+            {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+        SilkMarshal.Free((nint)languagePtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)labelPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackIdPtr);
+            }
+        SilkMarshal.Free((nint)labelPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+            }
+        SilkMarshal.Free((nint)labelPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+            fixed (char* languagePtr = &language)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            }
+        SilkMarshal.Free((nint)labelPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+        SilkMarshal.Free((nint)labelPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* urlPtr = &url)
+        {
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+            }
+        SilkMarshal.Free((nint)languagePtr);
+        SilkMarshal.Free((nint)labelPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, language, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        fixed (uint* trackIdPtr = &trackId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, language, kind, isDefault, trackIdPtr);
+        }
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        fixed (char* languagePtr = &language)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackId);
+        }
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        fixed (char* languagePtr = &language)
+        {
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackIdPtr);
+            }
+        }
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        fixed (uint* trackIdPtr = &trackId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, label, languagePtr, kind, isDefault, trackIdPtr);
+        }
+        SilkMarshal.Free((nint)languagePtr);
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        fixed (char* labelPtr = &label)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackId);
+        }
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        fixed (char* labelPtr = &label)
+        {
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackIdPtr);
+            }
+        }
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        fixed (char* labelPtr = &label)
+        {
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+            }
+        }
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        fixed (char* labelPtr = &label)
+        {
+            fixed (char* languagePtr = &language)
+            {
+                fixed (uint* trackIdPtr = &trackId)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+                }
+            }
+        }
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        fixed (char* labelPtr = &label)
+        {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+        }
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        fixed (char* labelPtr = &label)
+        {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+            }
+        SilkMarshal.Free((nint)languagePtr);
+        }
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)labelPtr);
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        fixed (uint* trackIdPtr = &trackId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, language, kind, isDefault, trackIdPtr);
+        }
+        SilkMarshal.Free((nint)labelPtr);
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        fixed (char* languagePtr = &language)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+        }
+        SilkMarshal.Free((nint)labelPtr);
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        fixed (char* languagePtr = &language)
+        {
+            fixed (uint* trackIdPtr = &trackId)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, char*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+            }
+        }
+        SilkMarshal.Free((nint)labelPtr);
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackId);
+        SilkMarshal.Free((nint)languagePtr);
+        SilkMarshal.Free((nint)labelPtr);
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, ref uint trackId)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var urlPtr = (byte*) SilkMarshal.StringToPtr(url, NativeStringEncoding.LPWStr);
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        fixed (uint* trackIdPtr = &trackId)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, byte*, TimedTextTrackKind, Silk.NET.Core.Bool32, uint*, int>)@this->LpVtbl[6])(@this, urlPtr, labelPtr, languagePtr, kind, isDefault, trackIdPtr);
+        }
+        SilkMarshal.Free((nint)languagePtr);
+        SilkMarshal.Free((nint)labelPtr);
+        SilkMarshal.Free((nint)urlPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, label, language, kind, track);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextTrack** trackPtr = &track)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, label, language, kind, trackPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* languagePtr = &language)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, label, languagePtr, kind, track);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* languagePtr = &language)
+        {
+            fixed (IMFTimedTextTrack** trackPtr = &track)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, label, languagePtr, kind, trackPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, label, languagePtr, kind, track);
+        SilkMarshal.Free((nint)languagePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        fixed (IMFTimedTextTrack** trackPtr = &track)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, label, languagePtr, kind, trackPtr);
+        }
+        SilkMarshal.Free((nint)languagePtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, language, kind, track);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+            fixed (IMFTimedTextTrack** trackPtr = &track)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, language, kind, trackPtr);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+            fixed (char* languagePtr = &language)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, track);
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+            fixed (char* languagePtr = &language)
+            {
+                fixed (IMFTimedTextTrack** trackPtr = &track)
+                {
+                    ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, trackPtr);
+                }
+            }
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, track);
+        SilkMarshal.Free((nint)languagePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (char* labelPtr = &label)
+        {
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+            fixed (IMFTimedTextTrack** trackPtr = &track)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, char*, byte*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, trackPtr);
+            }
+        SilkMarshal.Free((nint)languagePtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, language, kind, track);
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        fixed (IMFTimedTextTrack** trackPtr = &track)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, language, kind, trackPtr);
+        }
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        fixed (char* languagePtr = &language)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, track);
+        }
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        fixed (char* languagePtr = &language)
+        {
+            fixed (IMFTimedTextTrack** trackPtr = &track)
+            {
+                ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, char*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, trackPtr);
+            }
+        }
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, track);
+        SilkMarshal.Free((nint)languagePtr);
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        var labelPtr = (byte*) SilkMarshal.StringToPtr(label, NativeStringEncoding.LPWStr);
+        var languagePtr = (byte*) SilkMarshal.StringToPtr(language, NativeStringEncoding.LPWStr);
+        fixed (IMFTimedTextTrack** trackPtr = &track)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, byte*, byte*, TimedTextTrackKind, IMFTimedTextTrack**, int>)@this->LpVtbl[7])(@this, labelPtr, languagePtr, kind, trackPtr);
+        }
+        SilkMarshal.Free((nint)languagePtr);
+        SilkMarshal.Free((nint)labelPtr);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int RemoveTrack(this ComPtr<IMFTimedText> thisVtbl, IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrack*, int>)@this->LpVtbl[8])(@this, track);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RemoveTrack(this ComPtr<IMFTimedText> thisVtbl, ref IMFTimedTextTrack track)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextTrack* trackPtr = &track)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrack*, int>)@this->LpVtbl[8])(@this, trackPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetCueTimeOffset(this ComPtr<IMFTimedText> thisVtbl, double* offset)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, double*, int>)@this->LpVtbl[9])(@this, offset);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetCueTimeOffset(this ComPtr<IMFTimedText> thisVtbl, ref double offset)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (double* offsetPtr = &offset)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, double*, int>)@this->LpVtbl[9])(@this, offsetPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetCueTimeOffset(this ComPtr<IMFTimedText> thisVtbl, double offset)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, double, int>)@this->LpVtbl[10])(@this, offset);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTracks(this ComPtr<IMFTimedText> thisVtbl, IMFTimedTextTrackList** tracks)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[11])(@this, tracks);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTracks(this ComPtr<IMFTimedText> thisVtbl, ref IMFTimedTextTrackList* tracks)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextTrackList** tracksPtr = &tracks)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[11])(@this, tracksPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetActiveTracks(this ComPtr<IMFTimedText> thisVtbl, IMFTimedTextTrackList** activeTracks)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[12])(@this, activeTracks);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetActiveTracks(this ComPtr<IMFTimedText> thisVtbl, ref IMFTimedTextTrackList* activeTracks)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextTrackList** activeTracksPtr = &activeTracks)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[12])(@this, activeTracksPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextTracks(this ComPtr<IMFTimedText> thisVtbl, IMFTimedTextTrackList** textTracks)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[13])(@this, textTracks);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetTextTracks(this ComPtr<IMFTimedText> thisVtbl, ref IMFTimedTextTrackList* textTracks)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextTrackList** textTracksPtr = &textTracks)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[13])(@this, textTracksPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetMetadataTracks(this ComPtr<IMFTimedText> thisVtbl, IMFTimedTextTrackList** metadataTracks)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[14])(@this, metadataTracks);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int GetMetadataTracks(this ComPtr<IMFTimedText> thisVtbl, ref IMFTimedTextTrackList* metadataTracks)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        fixed (IMFTimedTextTrackList** metadataTracksPtr = &metadataTracks)
+        {
+            ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, IMFTimedTextTrackList**, int>)@this->LpVtbl[14])(@this, metadataTracksPtr);
+        }
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int SetInBandEnabled(this ComPtr<IMFTimedText> thisVtbl, Silk.NET.Core.Bool32 enabled)
+    {
+        var @this = thisVtbl.Handle;
+        int ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, Silk.NET.Core.Bool32, int>)@this->LpVtbl[15])(@this, enabled);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static Silk.NET.Core.Bool32 IsInBandEnabled(this ComPtr<IMFTimedText> thisVtbl)
+    {
+        var @this = thisVtbl.Handle;
+        Silk.NET.Core.Bool32 ret = default;
+        ret = ((delegate* unmanaged[Stdcall]<IMFTimedText*, Silk.NET.Core.Bool32>)@this->LpVtbl[16])(@this);
+        return ret;
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int QueryInterface<TI0>(this ComPtr<IMFTimedText> thisVtbl, out ComPtr<TI0> ppvObject) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        ppvObject = default;
+        return @this->QueryInterface(SilkMarshal.GuidPtrOf<TI0>(), (void**) ppvObject.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedText> thisVtbl, Span<Guid> riid, void** ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int QueryInterface(this ComPtr<IMFTimedText> thisVtbl, Span<Guid> riid, ref void* ppvObject)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->QueryInterface(ref riid.GetPinnableReference(), ref ppvObject);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RegisterNotifications<TI0>(this ComPtr<IMFTimedText> thisVtbl, ComPtr<TI0> notify) where TI0 : unmanaged, IComVtbl<IMFTimedTextNotify>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->RegisterNotifications((IMFTimedTextNotify*) notify.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RegisterNotifications(this ComPtr<IMFTimedText> thisVtbl, Span<IMFTimedTextNotify> notify)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->RegisterNotifications(ref notify.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(byteStream, label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(byteStream, label, in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(byteStream, label, in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(byteStream, label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(byteStream, in label.GetPinnableReference(), language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(byteStream, in label.GetPinnableReference(), language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(byteStream, in label.GetPinnableReference(), in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(byteStream, in label.GetPinnableReference(), in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(byteStream, in label.GetPinnableReference(), language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(byteStream, in label.GetPinnableReference(), language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(byteStream, label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(byteStream, label, in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(byteStream, label, in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, IMFByteStream* byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(byteStream, label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), label, language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), label, in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), label, in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), label, language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), in label.GetPinnableReference(), language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), in label.GetPinnableReference(), language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), in label.GetPinnableReference(), in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), in label.GetPinnableReference(), in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), in label.GetPinnableReference(), language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), in label.GetPinnableReference(), language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), label, language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), label, in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), label, in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), label, language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSource(this ComPtr<IMFTimedText> thisVtbl, Span<IMFByteStream> byteStream, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSource(ref byteStream.GetPinnableReference(), label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, in label.GetPinnableReference(), language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, in label.GetPinnableReference(), language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, in label.GetPinnableReference(), in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, in label.GetPinnableReference(), in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, in label.GetPinnableReference(), language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, in label.GetPinnableReference(), language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), label, language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), label, in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), label, in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), label, language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), in label.GetPinnableReference(), language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), in label.GetPinnableReference(), language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), in label.GetPinnableReference(), in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), in label.GetPinnableReference(), in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), in label.GetPinnableReference(), language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), in label.GetPinnableReference(), language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), label, language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), label, in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), label, in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), label, language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(in url.GetPinnableReference(), label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, in label.GetPinnableReference(), language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, in label.GetPinnableReference(), language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, in label.GetPinnableReference(), in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, in label.GetPinnableReference(), in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, in label.GetPinnableReference(), language, kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, in label.GetPinnableReference(), language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, uint* trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, in language.GetPinnableReference(), kind, isDefault, trackId);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, in language.GetPinnableReference(), kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddDataSourceFromUrl(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string url, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, Silk.NET.Core.Bool32 isDefault, Span<uint> trackId)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddDataSourceFromUrl(url, label, language, kind, isDefault, ref trackId.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack<TI0>(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddTrack(label, language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddTrack(label, in language.GetPinnableReference(), kind, track);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack<TI0>(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddTrack(label, in language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddTrack(label, in language.GetPinnableReference(), kind, ref track);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack<TI0>(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddTrack(label, language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddTrack(in label.GetPinnableReference(), language, kind, track);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack<TI0>(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddTrack(in label, language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddTrack(in label.GetPinnableReference(), language, kind, ref track);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddTrack(in label.GetPinnableReference(), in language.GetPinnableReference(), kind, track);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddTrack<TI0>(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddTrack(in label, in language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddTrack(in label.GetPinnableReference(), in language.GetPinnableReference(), kind, ref track);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddTrack(in label.GetPinnableReference(), language, kind, track);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddTrack<TI0>(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddTrack(in label, language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddTrack(in label.GetPinnableReference(), language, kind, ref track);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack<TI0>(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] char* language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddTrack(label, language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, IMFTimedTextTrack** track)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddTrack(label, in language.GetPinnableReference(), kind, track);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddTrack<TI0>(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] [RequiresLocation] in char language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddTrack(label, in language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static unsafe int AddTrack(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In)] ReadOnlySpan<char> language, TimedTextTrackKind kind, ref IMFTimedTextTrack* track)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->AddTrack(label, in language.GetPinnableReference(), kind, ref track);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int AddTrack<TI0>(this ComPtr<IMFTimedText> thisVtbl, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string label, [Flow(Silk.NET.Core.Native.FlowDirection.In), UnmanagedType(Silk.NET.Core.Native.UnmanagedType.LPWStr)] string language, TimedTextTrackKind kind, ref ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->AddTrack(label, language, kind, (IMFTimedTextTrack**) track.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RemoveTrack<TI0>(this ComPtr<IMFTimedText> thisVtbl, ComPtr<TI0> track) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrack>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->RemoveTrack((IMFTimedTextTrack*) track.Handle);
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int RemoveTrack(this ComPtr<IMFTimedText> thisVtbl, Span<IMFTimedTextTrack> track)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->RemoveTrack(ref track.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetCueTimeOffset(this ComPtr<IMFTimedText> thisVtbl, Span<double> offset)
+    {
+        var @this = thisVtbl.Handle;
+        // SpanOverloader
+        return @this->GetCueTimeOffset(ref offset.GetPinnableReference());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetTracks<TI0>(this ComPtr<IMFTimedText> thisVtbl, ref ComPtr<TI0> tracks) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrackList>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetTracks((IMFTimedTextTrackList**) tracks.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetActiveTracks<TI0>(this ComPtr<IMFTimedText> thisVtbl, ref ComPtr<TI0> activeTracks) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrackList>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetActiveTracks((IMFTimedTextTrackList**) activeTracks.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetTextTracks<TI0>(this ComPtr<IMFTimedText> thisVtbl, ref ComPtr<TI0> textTracks) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrackList>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetTextTracks((IMFTimedTextTrackList**) textTracks.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static int GetMetadataTracks<TI0>(this ComPtr<IMFTimedText> thisVtbl, ref ComPtr<TI0> metadataTracks) where TI0 : unmanaged, IComVtbl<IMFTimedTextTrackList>, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // ComPtrOverloader
+        return @this->GetMetadataTracks((IMFTimedTextTrackList**) metadataTracks.GetAddressOf());
+    }
+
+    /// <summary>To be documented.</summary>
+    public static ComPtr<TI0> QueryInterface<TI0>(this ComPtr<IMFTimedText> thisVtbl) where TI0 : unmanaged, IComVtbl<TI0>
+    {
+        var @this = thisVtbl.Handle;
+        // NonKhrReturnTypeOverloader
+        SilkMarshal.ThrowHResult(@this->QueryInterface(out ComPtr<TI0> silkRet));
+        return silkRet;
+    }
+
+}

--- a/src/Microsoft/Silk.NET.MediaFoundation/Structs/VideoNormalizedRect.gen.cs
+++ b/src/Microsoft/Silk.NET.MediaFoundation/Structs/VideoNormalizedRect.gen.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Silk.NET.Core;
+using Silk.NET.Core.Native;
+using Silk.NET.Core.Attributes;
+using Silk.NET.Core.Contexts;
+using Silk.NET.Core.Loader;
+
+#pragma warning disable 1591
+
+namespace Silk.NET.MediaFoundation
+{
+    [NativeName("Name", "MFVideoNormalizedRect")]
+    public unsafe partial struct VideoNormalizedRect
+    {
+        public VideoNormalizedRect
+        (
+            float? left = null,
+            float? top = null,
+            float? right = null,
+            float? bottom = null
+        ) : this()
+        {
+            if (left is not null)
+            {
+                Left = left.Value;
+            }
+
+            if (top is not null)
+            {
+                Top = top.Value;
+            }
+
+            if (right is not null)
+            {
+                Right = right.Value;
+            }
+
+            if (bottom is not null)
+            {
+                Bottom = bottom.Value;
+            }
+        }
+
+
+        [NativeName("Type", "float")]
+        [NativeName("Type.Name", "float")]
+        [NativeName("Name", "left")]
+        public float Left;
+
+        [NativeName("Type", "float")]
+        [NativeName("Type.Name", "float")]
+        [NativeName("Name", "top")]
+        public float Top;
+
+        [NativeName("Type", "float")]
+        [NativeName("Type.Name", "float")]
+        [NativeName("Name", "right")]
+        public float Right;
+
+        [NativeName("Type", "float")]
+        [NativeName("Type.Name", "float")]
+        [NativeName("Name", "bottom")]
+        public float Bottom;
+    }
+}


### PR DESCRIPTION
# Summary of the PR

Adds support for [MediaFoundation](https://learn.microsoft.com/es-es/windows/win32/medfound/microsoft-media-foundation-sdk) from the Windows SDK, which according to MSDN:

> ...enables the development of applications and components for using digital media on Windows Vista and later.

# Related issues, Discord discussions, or proposals

As discussed in Discord, this is part of the ongoing effort to port the [Stride Game Engine](https://github.com/Stride3d/stride) away from SharpDX and towards Silk.NET.