### PR TITLE
Fix copy-pase typos in Silk.NET.Math that were discovered during the exploration for Math 3.0.

### DIFF
--- a/src/Maths/Silk.NET.Maths/Cube.cs
+++ b/src/Maths/Silk.NET.Maths/Cube.cs
@@ -121,7 +121,7 @@ namespace Silk.NET.Maths
             return Scalar.GreaterThanOrEqual(other.Origin.X, this.Origin.X) && Scalar.GreaterThanOrEqual
                 (other.Origin.Y, this.Origin.Y) && Scalar.GreaterThanOrEqual
                 (other.Origin.Z, this.Origin.Z) && Scalar.LessThanOrEqual(oMax.X, tMax.X) && Scalar.LessThanOrEqual
-                (oMax.Y, tMax.Y) && Scalar.GreaterThanOrEqual(oMax.Y, tMax.Y);
+                (oMax.Y, tMax.Y) && Scalar.LessThanOrEqual(oMax.Y, tMax.Y);
         }
 
         /// <summary>

--- a/src/Maths/Silk.NET.Maths/Matrix2X2.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix2X2.cs
@@ -22,6 +22,7 @@ namespace Silk.NET.Maths
         /// </summary>
         [IgnoreDataMember]
         public Vector2D<T> Row1;
+
         /// <summary>
         /// Row 2 of the matrix.
         /// </summary>
@@ -39,7 +40,6 @@ namespace Silk.NET.Maths
         /// </summary>
         [IgnoreDataMember]
         public Vector2D<T> Column2 => new(M12, M22);
-
 
         /// <summary>Value at row 1, column 1 of the matrix.</summary>
         [DataMember]
@@ -130,8 +130,8 @@ namespace Silk.NET.Maths
             Row2 = new(value.M21, value.M22);
         }
 
-        /// <summary>Constructs a <see cref="Matrix2X2{T}"/> from the given Matrix4x3.</summary>
-        /// <param name="value">The source Matrix4x3.</param>
+        /// <summary>Constructs a <see cref="Matrix2X2{T}"/> from the given <see cref="Matrix4X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X3{T}"/>.</param>
         public Matrix2X2(Matrix4X3<T> value)
         {
             Row1 = new(value.M11, value.M12);
@@ -166,6 +166,7 @@ namespace Silk.NET.Maths
         public static Matrix2X2<T> Identity => _identity;
 
         /// <summary>Returns whether the matrix is the identity matrix.</summary>
+        [IgnoreDataMember]
         public readonly bool IsIdentity
             => Scalar.Equal(M11, Scalar<T>.One) &&
                Scalar.Equal(M22, Scalar<T>.One) && // Check diagonal element first for early out.
@@ -225,7 +226,7 @@ namespace Silk.NET.Maths
         /// <returns>The result of the multiplication.</returns>
         public static unsafe Vector2D<T> operator *(Vector2D<T> value1, Matrix2X2<T> value2)
         {
-            return value1 * value2.Row1 + value1 * value2.Row2;
+            return value1.X * value2.Row1 + value1.Y * value2.Row2;
         }
 
         /// <summary>Multiplies a matrix by a scalar value.</summary>

--- a/src/Maths/Silk.NET.Maths/Matrix2X3.Ops.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix2X3.Ops.cs
@@ -216,7 +216,7 @@ namespace Silk.NET.Maths
         public static unsafe Matrix2X3<T> Lerp<T>(Matrix2X3<T> matrix1, Matrix2X3<T> matrix2, T amount)
             where T : unmanaged, IFormattable, IEquatable<T>, IComparable<T>
         {
-            return new(Vector3D.Lerp(matrix1.Row1, matrix2.Row2, amount), Vector3D.Lerp(matrix1.Row2, matrix2.Row2, amount));
+            return new(Vector3D.Lerp(matrix1.Row1, matrix2.Row1, amount), Vector3D.Lerp(matrix1.Row2, matrix2.Row2, amount));
         }
 
         /// <summary>Transforms the given matrix by applying the given Quaternion rotation.</summary>

--- a/src/Maths/Silk.NET.Maths/Matrix2X3.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix2X3.cs
@@ -78,8 +78,8 @@ namespace Silk.NET.Maths
         [DataMember]
         public T M21
         {
-            readonly get => Row1.X;
-            set => Row1.X = value;
+            readonly get => Row2.X;
+            set => Row2.X = value;
         }
 
         /// <summary>Value at row 2, column 2 of the matrix.</summary>

--- a/src/Maths/Silk.NET.Maths/Matrix2X4.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix2X4.cs
@@ -179,8 +179,8 @@ namespace Silk.NET.Maths
             Row2 = new(value.M21, value.M22, default, default);
         }
 
-        /// <summary>Constructs a <see cref="Matrix2X4{T}"/> from the given Matrix4x3.</summary>
-        /// <param name="value">The source Matrix4x3.</param>
+        /// <summary>Constructs a <see cref="Matrix2X4{T}"/> from the given <see cref="Matrix4X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X3{T}"/>.</param>
         public Matrix2X4(Matrix4X3<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13, default);
@@ -203,7 +203,7 @@ namespace Silk.NET.Maths
             Row2 = new(value.M21, value.M22, value.M23, default);
         }
 
-        /// <summary>Constructs a Matrix2x4 from the given <see cref="Matrix4X2{T}"/>.</summary>
+        /// <summary>Constructs a <see cref="Matrix2X4{T}"/> from the given <see cref="Matrix4X2{T}"/>.</summary>
         /// <param name="value">The source <see cref="Matrix4X2{T}"/>.</param>
         public Matrix2X4(Matrix4X2<T> value)
         {

--- a/src/Maths/Silk.NET.Maths/Matrix3X2.Ops.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix3X2.Ops.cs
@@ -467,7 +467,7 @@ namespace Silk.NET.Maths
         /// <param name="value2">The second source matrix.</param>
         /// <returns>The product matrix.</returns>
         [MethodImpl((MethodImplOptions) 768)]
-        public static Matrix2X3<T> Multiply<T>(Matrix2X3<T> value1, Matrix3X3<T> value2)
+        public static Matrix3X2<T> Multiply<T>(Matrix3X3<T> value1, Matrix3X2<T> value2)
             where T : unmanaged, IFormattable, IEquatable<T>, IComparable<T>
             => value1 * value2;
 

--- a/src/Maths/Silk.NET.Maths/Matrix3X2.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix3X2.cs
@@ -51,7 +51,7 @@ namespace Silk.NET.Maths
         [IgnoreDataMember]
         public Vector3D<T> Column2 => new(Row1.Y, Row2.Y, Row3.Y);
 
-        /// <summary>The first element of the first row</summary>
+        /// <summary>Value at row 1, column 1 of the matrix.</summary>
         [DataMember]
         public T M11
         {
@@ -59,7 +59,7 @@ namespace Silk.NET.Maths
             set => Row1.X = value;
         }
 
-        /// <summary>The second element of the first row</summary>
+        /// <summary>Value at row 1, column 2 of the matrix.</summary>
         [DataMember]
         public T M12
         {
@@ -67,7 +67,7 @@ namespace Silk.NET.Maths
             set => Row1.Y = value;
         }
 
-        /// <summary>The first element of the second row</summary>
+        /// <summary>Value at row 2, column 1 of the matrix.</summary>
         [DataMember]
         public T M21
         {
@@ -75,7 +75,7 @@ namespace Silk.NET.Maths
             set => Row2.X = value;
         }
 
-        /// <summary>The second element of the second row</summary>
+        /// <summary>Value at row 2, column 2 of the matrix.</summary>
         [DataMember]
         public T M22
         {
@@ -83,7 +83,7 @@ namespace Silk.NET.Maths
             set => Row2.Y = value;
         }
 
-        /// <summary>The first element of the third row</summary>
+        /// <summary>Value at row 3, column 1 of the matrix.</summary>
         [DataMember]
         public T M31
         {
@@ -91,7 +91,7 @@ namespace Silk.NET.Maths
             set => Row3.X = value;
         }
 
-        /// <summary>The second element of the third row</summary>
+        /// <summary>Value at row 3, column 2 of the matrix.</summary>
         [DataMember]
         public T M32
         {
@@ -154,8 +154,8 @@ namespace Silk.NET.Maths
             Row3 = row3;
         }
 
-        /// <summary>Constructs a <see cref="Matrix3X2{T}"/> from the given Matrix4x3.</summary>
-        /// <param name="value">The source Matrix4x3.</param>
+        /// <summary>Constructs a <see cref="Matrix3X2{T}"/> from the given <see cref="Matrix4X3{T}"/>.</summary>
+        /// <param name="value">The source <see cref="Matrix4X3{T}"/>.</param>
         public Matrix3X2(Matrix4X3<T> value)
         {
             Row1 = new(value.M11, value.M12);

--- a/src/Maths/Silk.NET.Maths/Matrix3X3.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix3X3.cs
@@ -45,13 +45,11 @@ namespace Silk.NET.Maths
         [IgnoreDataMember]
         public Vector3D<T> Column1 => new(Row1.X, Row2.X, Row3.X);
 
-
         /// <summary>
         /// Column 2 of the matrix.
         /// </summary>
         [IgnoreDataMember]
         public Vector3D<T> Column2 => new(Row1.Y, Row2.Y, Row3.Y);
-
 
         /// <summary>
         /// Column 3 of the matrix.
@@ -205,15 +203,6 @@ namespace Silk.NET.Maths
         /// <summary>Constructs a <see cref="Matrix3X3{T}"/> from the given <see cref="Matrix3X4{T}"/>.</summary>
         /// <param name="value">The source <see cref="Matrix3X4{T}"/>.</param>
         public Matrix3X3(Matrix3X4<T> value)
-        {
-            Row1 = new(value.M11, value.M12, value.M13);
-            Row2 = new(value.M21, value.M22, value.M23);
-            Row3 = new(value.M31, value.M32, value.M33);
-        }
-
-        /// <summary>Constructs a <see cref="Matrix3X3{T}"/> from the given <see cref="Matrix3X3{T}"/>.</summary>
-        /// <param name="value">The source <see cref="Matrix3X3{T}"/>.</param>
-        public Matrix3X3(Matrix3X3<T> value)
         {
             Row1 = new(value.M11, value.M12, value.M13);
             Row2 = new(value.M21, value.M22, value.M23);

--- a/src/Maths/Silk.NET.Maths/Matrix3X4.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix3X4.cs
@@ -194,12 +194,7 @@ namespace Silk.NET.Maths
             }
         }
 
-        /// <summary>
-        /// Constructs a <see cref="Matrix3X4{T}"/> from the given rows.
-        /// </summary>
-        /// <param name="row1"></param>
-        /// <param name="row2"></param>
-        /// <param name="row3"></param>
+        /// <summary>Constructs a <see cref="Matrix3X4{T}"/> from the given rows.</summary>
         public Matrix3X4(Vector4D<T> row1, Vector4D<T> row2, Vector4D<T> row3)
         {
             Row1 = row1;
@@ -231,15 +226,6 @@ namespace Silk.NET.Maths
             Row1 = new(value.M11, value.M12, value.M13, default);
             Row2 = new(value.M21, value.M22, value.M23, default);
             Row3 = new(value.M31, value.M32, value.M33, default);
-        }
-
-        /// <summary>Constructs a <see cref="Matrix3X4{T}"/> from the given <see cref="Matrix3X4{T}"/>.</summary>
-        /// <param name="value">The source <see cref="Matrix3X4{T}"/>.</param>
-        public Matrix3X4(Matrix3X4<T> value)
-        {
-            Row1 = new(value.M11, value.M12, value.M13, value.M14);
-            Row2 = new(value.M21, value.M22, value.M23, value.M24);
-            Row3 = new(value.M31, value.M32, value.M33, value.M34);
         }
 
         /// <summary>Constructs a <see cref="Matrix3X4{T}"/> from the given <see cref="Matrix3X3{T}"/>.</summary>

--- a/src/Maths/Silk.NET.Maths/Matrix4X2.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix4X2.cs
@@ -30,24 +30,22 @@ namespace Silk.NET.Maths
         public Vector2D<T> Row1;
 
         /// <summary>
-        /// Row 2 of the matrix
+        /// Row 2 of the matrix.
         /// </summary>
         [IgnoreDataMember]
         public Vector2D<T> Row2;
 
         /// <summary>
-        /// Row 3 of the matrix
+        /// Row 3 of the matrix.
         /// </summary>
         [IgnoreDataMember]
         public Vector2D<T> Row3;
 
         /// <summary>
-        /// Row 4 of the matrix
+        /// Row 4 of the matrix.
         /// </summary>
         [IgnoreDataMember]
         public Vector2D<T> Row4;
-
-
 
         /// <summary>
         /// Column 1 of the matrix.

--- a/src/Maths/Silk.NET.Maths/Matrix4X3.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix4X3.cs
@@ -29,19 +29,19 @@ namespace Silk.NET.Maths
         public Vector3D<T> Row1;
 
         /// <summary>
-        /// Row 1 of the matrix.
+        /// Row 2 of the matrix.
         /// </summary>
         [IgnoreDataMember]
         public Vector3D<T> Row2;
 
         /// <summary>
-        /// Row 1 of the matrix.
+        /// Row 3 of the matrix.
         /// </summary>
         [IgnoreDataMember]
         public Vector3D<T> Row3;
 
         /// <summary>
-        /// Row 1 of the matrix.
+        /// Row 4 of the matrix.
         /// </summary>
         [IgnoreDataMember]
         public Vector3D<T> Row4;
@@ -223,16 +223,6 @@ namespace Silk.NET.Maths
             Row2 = new(value.M21, value.M22, default);
             Row3 = Vector3D<T>.UnitZ;
             Row4 = new(value.M31, value.M32, default);
-        }
-
-        /// <summary>Constructs a <see cref="Matrix4X3{T}"/> from the given <see cref="Matrix4X3{T}"/>.</summary>
-        /// <param name="value">The source <see cref="Matrix4X3{T}"/>.</param>
-        public Matrix4X3(Matrix4X3<T> value)
-        {
-            Row1 = new(value.M11, value.M12, value.M13);
-            Row2 = new(value.M21, value.M22, value.M23);
-            Row3 = new(value.M31, value.M32, value.M33);
-            Row4 = new(value.M41, value.M42, value.M43);
         }
 
         /// <summary>Constructs a <see cref="Matrix4X3{T}"/> from the given <see cref="Matrix3X4{T}"/>.</summary>

--- a/src/Maths/Silk.NET.Maths/Matrix5X4.cs
+++ b/src/Maths/Silk.NET.Maths/Matrix5X4.cs
@@ -8,7 +8,7 @@ using System.Runtime.Serialization;
 
 namespace Silk.NET.Maths
 {
-    /// <summary>A structure encapsulating a 4x4 matrix.</summary>
+    /// <summary>A structure encapsulating a 5x4 matrix.</summary>
     [Serializable]
     [DataContract]
     public struct Matrix5X4<T> : IEquatable<Matrix5X4<T>>

--- a/src/Maths/Silk.NET.Maths/PublicAPI/net5.0/PublicAPI.Shipped.txt
+++ b/src/Maths/Silk.NET.Maths/PublicAPI/net5.0/PublicAPI.Shipped.txt
@@ -295,7 +295,6 @@ Silk.NET.Maths.Matrix3X3<T>.M33.set -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3() -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix2X4<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X2<T> value) -> void
-Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X3<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix4X2<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix4X3<T> value) -> void
@@ -344,7 +343,6 @@ Silk.NET.Maths.Matrix3X4<T>.Matrix3X4() -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix2X4<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X2<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X3<T> value) -> void
-Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix4X2<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix4X3<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Vector4D<T> row1, Silk.NET.Maths.Vector4D<T> row2, Silk.NET.Maths.Vector4D<T> row3) -> void
@@ -429,7 +427,6 @@ Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X2<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X3<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X2<T> value) -> void
-Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X3<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X4<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Vector3D<T> row1, Silk.NET.Maths.Vector3D<T> row2, Silk.NET.Maths.Vector3D<T> row3, Silk.NET.Maths.Vector3D<T> row4) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(T m11, T m12, T m13, T m21, T m22, T m23, T m31, T m32, T m33, T m41, T m42, T m43) -> void
@@ -838,7 +835,7 @@ static Silk.NET.Maths.Matrix3X2.CreateTranslation<T>(T xPosition, T yPosition) -
 static Silk.NET.Maths.Matrix3X2.Invert<T>(Silk.NET.Maths.Matrix3X2<T> matrix, out Silk.NET.Maths.Matrix3X2<T> result) -> bool
 static Silk.NET.Maths.Matrix3X2.Lerp<T>(Silk.NET.Maths.Matrix3X2<T> matrix1, Silk.NET.Maths.Matrix3X2<T> matrix2, T amount) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix2X3<T> value1, Silk.NET.Maths.Matrix3X2<T> value2) -> Silk.NET.Maths.Matrix2X2<T>
-static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix2X3<T> value1, Silk.NET.Maths.Matrix3X3<T> value2) -> Silk.NET.Maths.Matrix2X3<T>
+static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X3<T> value1, Silk.NET.Maths.Matrix3X2<T> value2) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, Silk.NET.Maths.Matrix2X2<T> value2) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, Silk.NET.Maths.Matrix2X3<T> value2) -> Silk.NET.Maths.Matrix3X3<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, T value2) -> Silk.NET.Maths.Matrix3X2<T>

--- a/src/Maths/Silk.NET.Maths/PublicAPI/net6.0-android/PublicAPI.Shipped.txt
+++ b/src/Maths/Silk.NET.Maths/PublicAPI/net6.0-android/PublicAPI.Shipped.txt
@@ -295,7 +295,6 @@ Silk.NET.Maths.Matrix3X3<T>.M33.set -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3() -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix2X4<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X2<T> value) -> void
-Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X3<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix4X2<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix4X3<T> value) -> void
@@ -344,7 +343,6 @@ Silk.NET.Maths.Matrix3X4<T>.Matrix3X4() -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix2X4<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X2<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X3<T> value) -> void
-Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix4X2<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix4X3<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Vector4D<T> row1, Silk.NET.Maths.Vector4D<T> row2, Silk.NET.Maths.Vector4D<T> row3) -> void
@@ -429,7 +427,6 @@ Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X2<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X3<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X2<T> value) -> void
-Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X3<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X4<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Vector3D<T> row1, Silk.NET.Maths.Vector3D<T> row2, Silk.NET.Maths.Vector3D<T> row3, Silk.NET.Maths.Vector3D<T> row4) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(T m11, T m12, T m13, T m21, T m22, T m23, T m31, T m32, T m33, T m41, T m42, T m43) -> void
@@ -838,7 +835,7 @@ static Silk.NET.Maths.Matrix3X2.CreateTranslation<T>(T xPosition, T yPosition) -
 static Silk.NET.Maths.Matrix3X2.Invert<T>(Silk.NET.Maths.Matrix3X2<T> matrix, out Silk.NET.Maths.Matrix3X2<T> result) -> bool
 static Silk.NET.Maths.Matrix3X2.Lerp<T>(Silk.NET.Maths.Matrix3X2<T> matrix1, Silk.NET.Maths.Matrix3X2<T> matrix2, T amount) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix2X3<T> value1, Silk.NET.Maths.Matrix3X2<T> value2) -> Silk.NET.Maths.Matrix2X2<T>
-static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix2X3<T> value1, Silk.NET.Maths.Matrix3X3<T> value2) -> Silk.NET.Maths.Matrix2X3<T>
+static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X3<T> value1, Silk.NET.Maths.Matrix3X2<T> value2) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, Silk.NET.Maths.Matrix2X2<T> value2) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, Silk.NET.Maths.Matrix2X3<T> value2) -> Silk.NET.Maths.Matrix3X3<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, T value2) -> Silk.NET.Maths.Matrix3X2<T>

--- a/src/Maths/Silk.NET.Maths/PublicAPI/net6.0-ios/PublicAPI.Shipped.txt
+++ b/src/Maths/Silk.NET.Maths/PublicAPI/net6.0-ios/PublicAPI.Shipped.txt
@@ -295,7 +295,6 @@ Silk.NET.Maths.Matrix3X3<T>.M33.set -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3() -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix2X4<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X2<T> value) -> void
-Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X3<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix4X2<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix4X3<T> value) -> void
@@ -344,7 +343,6 @@ Silk.NET.Maths.Matrix3X4<T>.Matrix3X4() -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix2X4<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X2<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X3<T> value) -> void
-Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix4X2<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix4X3<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Vector4D<T> row1, Silk.NET.Maths.Vector4D<T> row2, Silk.NET.Maths.Vector4D<T> row3) -> void
@@ -429,7 +427,6 @@ Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X2<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X3<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X2<T> value) -> void
-Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X3<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X4<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Vector3D<T> row1, Silk.NET.Maths.Vector3D<T> row2, Silk.NET.Maths.Vector3D<T> row3, Silk.NET.Maths.Vector3D<T> row4) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(T m11, T m12, T m13, T m21, T m22, T m23, T m31, T m32, T m33, T m41, T m42, T m43) -> void
@@ -838,7 +835,7 @@ static Silk.NET.Maths.Matrix3X2.CreateTranslation<T>(T xPosition, T yPosition) -
 static Silk.NET.Maths.Matrix3X2.Invert<T>(Silk.NET.Maths.Matrix3X2<T> matrix, out Silk.NET.Maths.Matrix3X2<T> result) -> bool
 static Silk.NET.Maths.Matrix3X2.Lerp<T>(Silk.NET.Maths.Matrix3X2<T> matrix1, Silk.NET.Maths.Matrix3X2<T> matrix2, T amount) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix2X3<T> value1, Silk.NET.Maths.Matrix3X2<T> value2) -> Silk.NET.Maths.Matrix2X2<T>
-static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix2X3<T> value1, Silk.NET.Maths.Matrix3X3<T> value2) -> Silk.NET.Maths.Matrix2X3<T>
+static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X3<T> value1, Silk.NET.Maths.Matrix3X2<T> value2) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, Silk.NET.Maths.Matrix2X2<T> value2) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, Silk.NET.Maths.Matrix2X3<T> value2) -> Silk.NET.Maths.Matrix3X3<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, T value2) -> Silk.NET.Maths.Matrix3X2<T>

--- a/src/Maths/Silk.NET.Maths/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
+++ b/src/Maths/Silk.NET.Maths/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
@@ -295,7 +295,6 @@ Silk.NET.Maths.Matrix3X3<T>.M33.set -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3() -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix2X4<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X2<T> value) -> void
-Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X3<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix4X2<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix4X3<T> value) -> void
@@ -344,7 +343,6 @@ Silk.NET.Maths.Matrix3X4<T>.Matrix3X4() -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix2X4<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X2<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X3<T> value) -> void
-Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix4X2<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix4X3<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Vector4D<T> row1, Silk.NET.Maths.Vector4D<T> row2, Silk.NET.Maths.Vector4D<T> row3) -> void
@@ -429,7 +427,6 @@ Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X2<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X3<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X2<T> value) -> void
-Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X3<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X4<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Vector3D<T> row1, Silk.NET.Maths.Vector3D<T> row2, Silk.NET.Maths.Vector3D<T> row3, Silk.NET.Maths.Vector3D<T> row4) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(T m11, T m12, T m13, T m21, T m22, T m23, T m31, T m32, T m33, T m41, T m42, T m43) -> void
@@ -838,7 +835,7 @@ static Silk.NET.Maths.Matrix3X2.CreateTranslation<T>(T xPosition, T yPosition) -
 static Silk.NET.Maths.Matrix3X2.Invert<T>(Silk.NET.Maths.Matrix3X2<T> matrix, out Silk.NET.Maths.Matrix3X2<T> result) -> bool
 static Silk.NET.Maths.Matrix3X2.Lerp<T>(Silk.NET.Maths.Matrix3X2<T> matrix1, Silk.NET.Maths.Matrix3X2<T> matrix2, T amount) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix2X3<T> value1, Silk.NET.Maths.Matrix3X2<T> value2) -> Silk.NET.Maths.Matrix2X2<T>
-static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix2X3<T> value1, Silk.NET.Maths.Matrix3X3<T> value2) -> Silk.NET.Maths.Matrix2X3<T>
+static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X3<T> value1, Silk.NET.Maths.Matrix3X2<T> value2) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, Silk.NET.Maths.Matrix2X2<T> value2) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, Silk.NET.Maths.Matrix2X3<T> value2) -> Silk.NET.Maths.Matrix3X3<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, T value2) -> Silk.NET.Maths.Matrix3X2<T>

--- a/src/Maths/Silk.NET.Maths/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Maths/Silk.NET.Maths/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -295,7 +295,6 @@ Silk.NET.Maths.Matrix3X3<T>.M33.set -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3() -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix2X4<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X2<T> value) -> void
-Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X3<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix4X2<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix4X3<T> value) -> void
@@ -344,7 +343,6 @@ Silk.NET.Maths.Matrix3X4<T>.Matrix3X4() -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix2X4<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X2<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X3<T> value) -> void
-Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix4X2<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix4X3<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Vector4D<T> row1, Silk.NET.Maths.Vector4D<T> row2, Silk.NET.Maths.Vector4D<T> row3) -> void
@@ -429,7 +427,6 @@ Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X2<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X3<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X2<T> value) -> void
-Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X3<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X4<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Vector3D<T> row1, Silk.NET.Maths.Vector3D<T> row2, Silk.NET.Maths.Vector3D<T> row3, Silk.NET.Maths.Vector3D<T> row4) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(T m11, T m12, T m13, T m21, T m22, T m23, T m31, T m32, T m33, T m41, T m42, T m43) -> void
@@ -838,7 +835,7 @@ static Silk.NET.Maths.Matrix3X2.CreateTranslation<T>(T xPosition, T yPosition) -
 static Silk.NET.Maths.Matrix3X2.Invert<T>(Silk.NET.Maths.Matrix3X2<T> matrix, out Silk.NET.Maths.Matrix3X2<T> result) -> bool
 static Silk.NET.Maths.Matrix3X2.Lerp<T>(Silk.NET.Maths.Matrix3X2<T> matrix1, Silk.NET.Maths.Matrix3X2<T> matrix2, T amount) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix2X3<T> value1, Silk.NET.Maths.Matrix3X2<T> value2) -> Silk.NET.Maths.Matrix2X2<T>
-static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix2X3<T> value1, Silk.NET.Maths.Matrix3X3<T> value2) -> Silk.NET.Maths.Matrix2X3<T>
+static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X3<T> value1, Silk.NET.Maths.Matrix3X2<T> value2) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, Silk.NET.Maths.Matrix2X2<T> value2) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, Silk.NET.Maths.Matrix2X3<T> value2) -> Silk.NET.Maths.Matrix3X3<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, T value2) -> Silk.NET.Maths.Matrix3X2<T>

--- a/src/Maths/Silk.NET.Maths/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/Maths/Silk.NET.Maths/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -295,7 +295,6 @@ Silk.NET.Maths.Matrix3X3<T>.M33.set -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3() -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix2X4<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X2<T> value) -> void
-Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X3<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix4X2<T> value) -> void
 Silk.NET.Maths.Matrix3X3<T>.Matrix3X3(Silk.NET.Maths.Matrix4X3<T> value) -> void
@@ -344,7 +343,6 @@ Silk.NET.Maths.Matrix3X4<T>.Matrix3X4() -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix2X4<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X2<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X3<T> value) -> void
-Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix4X2<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Matrix4X3<T> value) -> void
 Silk.NET.Maths.Matrix3X4<T>.Matrix3X4(Silk.NET.Maths.Vector4D<T> row1, Silk.NET.Maths.Vector4D<T> row2, Silk.NET.Maths.Vector4D<T> row3) -> void
@@ -429,7 +427,6 @@ Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X2<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X3<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix3X4<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X2<T> value) -> void
-Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X3<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Matrix4X4<T> value) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(Silk.NET.Maths.Vector3D<T> row1, Silk.NET.Maths.Vector3D<T> row2, Silk.NET.Maths.Vector3D<T> row3, Silk.NET.Maths.Vector3D<T> row4) -> void
 Silk.NET.Maths.Matrix4X3<T>.Matrix4X3(T m11, T m12, T m13, T m21, T m22, T m23, T m31, T m32, T m33, T m41, T m42, T m43) -> void
@@ -838,7 +835,7 @@ static Silk.NET.Maths.Matrix3X2.CreateTranslation<T>(T xPosition, T yPosition) -
 static Silk.NET.Maths.Matrix3X2.Invert<T>(Silk.NET.Maths.Matrix3X2<T> matrix, out Silk.NET.Maths.Matrix3X2<T> result) -> bool
 static Silk.NET.Maths.Matrix3X2.Lerp<T>(Silk.NET.Maths.Matrix3X2<T> matrix1, Silk.NET.Maths.Matrix3X2<T> matrix2, T amount) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix2X3<T> value1, Silk.NET.Maths.Matrix3X2<T> value2) -> Silk.NET.Maths.Matrix2X2<T>
-static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix2X3<T> value1, Silk.NET.Maths.Matrix3X3<T> value2) -> Silk.NET.Maths.Matrix2X3<T>
+static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X3<T> value1, Silk.NET.Maths.Matrix3X2<T> value2) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, Silk.NET.Maths.Matrix2X2<T> value2) -> Silk.NET.Maths.Matrix3X2<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, Silk.NET.Maths.Matrix2X3<T> value2) -> Silk.NET.Maths.Matrix3X3<T>
 static Silk.NET.Maths.Matrix3X2.Multiply<T>(Silk.NET.Maths.Matrix3X2<T> value1, T value2) -> Silk.NET.Maths.Matrix3X2<T>

--- a/src/Maths/Silk.NET.Maths/Sphere.cs
+++ b/src/Maths/Silk.NET.Maths/Sphere.cs
@@ -69,7 +69,7 @@ namespace Silk.NET.Maths
         /// <remarks>This does consider a point on the edge contained.</remarks>
         public bool Contains(Vector3D<T> point)
         {
-            return Scalar.LessThanOrEqual(Vector3D.DistanceSquared(point, Center), Radius);
+            return Scalar.LessThanOrEqual(Vector3D.DistanceSquared(point, Center), SquaredRadius);
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary of the PR
A few typos / copy-paste errors were identified and fixed.

# Related issues, Discord discussions, or proposals

https://discord.com/channels/521092042781229087/587346162802229298/1390153285842894990
https://discord.com/channels/521092042781229087/587346162802229298/1395540633472729258
