### PR TITLE
Start of Silk.NET.WebGPU.Extensions.ImGui

### DIFF
--- a/Silk.NET.sln
+++ b/Silk.NET.sln
@@ -614,6 +614,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Silk.NET.Assimp.Tests", "sr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Silk.NET.Core.Tests", "src\Core\Silk.NET.Core.Tests\Silk.NET.Core.Tests.csproj", "{4D871493-0B88-477A-99A1-3E05561CFAD9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Silk.NET.WebGPU.Extensions.ImGui", "src\WebGPU\Extensions\Silk.NET.WebGPU.Extensions.ImGui\Silk.NET.WebGPU.Extensions.ImGui.csproj", "{2938BFB2-6795-AF0D-1555-AA05D70B2BCA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -3755,6 +3757,18 @@ Global
 		{4D871493-0B88-477A-99A1-3E05561CFAD9}.Release|x64.Build.0 = Release|Any CPU
 		{4D871493-0B88-477A-99A1-3E05561CFAD9}.Release|x86.ActiveCfg = Release|Any CPU
 		{4D871493-0B88-477A-99A1-3E05561CFAD9}.Release|x86.Build.0 = Release|Any CPU
+		{2938BFB2-6795-AF0D-1555-AA05D70B2BCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2938BFB2-6795-AF0D-1555-AA05D70B2BCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2938BFB2-6795-AF0D-1555-AA05D70B2BCA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2938BFB2-6795-AF0D-1555-AA05D70B2BCA}.Debug|x64.Build.0 = Debug|Any CPU
+		{2938BFB2-6795-AF0D-1555-AA05D70B2BCA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2938BFB2-6795-AF0D-1555-AA05D70B2BCA}.Debug|x86.Build.0 = Debug|Any CPU
+		{2938BFB2-6795-AF0D-1555-AA05D70B2BCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2938BFB2-6795-AF0D-1555-AA05D70B2BCA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2938BFB2-6795-AF0D-1555-AA05D70B2BCA}.Release|x64.ActiveCfg = Release|Any CPU
+		{2938BFB2-6795-AF0D-1555-AA05D70B2BCA}.Release|x64.Build.0 = Release|Any CPU
+		{2938BFB2-6795-AF0D-1555-AA05D70B2BCA}.Release|x86.ActiveCfg = Release|Any CPU
+		{2938BFB2-6795-AF0D-1555-AA05D70B2BCA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -4054,6 +4068,7 @@ Global
 		{01B6FFA0-5B37-44EA-ABDF-7BABD05874C5} = {90471225-AC23-424E-B62E-F6EC4C6ECAC0}
 		{12D0A556-7DDF-4902-8911-1DA3F6331149} = {6EADA376-E83F-40B7-9539-71DD17AEF7A4}
 		{4D871493-0B88-477A-99A1-3E05561CFAD9} = {0651C5EF-50AA-4598-8D9C-8F210ADD8490}
+		{2938BFB2-6795-AF0D-1555-AA05D70B2BCA} = {D218E3C8-44C7-472F-B147-3C9DA8B0C2EC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F5273D7F-3334-48DF-94E3-41AE6816CD4D}

--- a/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/net5.0/PublicAPI.Shipped.txt
+++ b/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/net5.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/net5.0/PublicAPI.Unshipped.txt
+++ b/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/net5.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
+++ b/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/Silk.NET.WebGPU.Extensions.ImGui.csproj
+++ b/src/WebGPU/Extensions/Silk.NET.WebGPU.Extensions.ImGui/Silk.NET.WebGPU.Extensions.ImGui.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <LangVersion>preview</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\Input\Extensions\Silk.NET.Input.Extensions\Silk.NET.Input.Extensions.csproj" />
+        <ProjectReference Include="..\..\..\Input\Silk.NET.Input.Common\Silk.NET.Input.Common.csproj" />
+        <ProjectReference Include="..\..\Silk.NET.WebGPU\Silk.NET.WebGPU.csproj" />
+        <ProjectReference Include="..\..\..\Windowing\Silk.NET.Windowing.Common\Silk.NET.Windowing.Common.csproj" />
+        <PackageReference Include="ImGui.NET" Version="1.91.6.1" />
+    </ItemGroup>
+
+    <Import Project="..\..\..\..\build\props\common.props" />
+
+    <ItemGroup>
+      <PackageReference Update="DotNet.ReproducibleBuilds" Version="1.2.25" />
+      <PackageReference Update="DotNet.ReproducibleBuilds.Isolated" Version="1.2.25" />
+      <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR adds a new package "Silk.NET.WebGPU.Extensions.ImGui" which implements similar experience to the WebGPU API compared with the solutions already present for OpenGL/Vulkan.