### PR TITLE
3.0 - Simple IHandle interface for XYZHandle structs

### DIFF
--- a/sources/Core/Core/Abstractions/IHandle.cs
+++ b/sources/Core/Core/Abstractions/IHandle.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Silk.NET.Core;
+
+public interface IHandle
+{
+    public bool IsNull { get; }
+}

--- a/sources/Core/Core/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/sources/Core/Core/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -125,6 +125,8 @@ Silk.NET.Core.IGLContext.VSync.get -> bool
 Silk.NET.Core.IGLContext.VSync.set -> void
 Silk.NET.Core.IGLContextSource
 Silk.NET.Core.IGLContextSource.GLContext.get -> Silk.NET.Core.IGLContext?
+Silk.NET.Core.IHandle
+Silk.NET.Core.IHandle.IsNull.get -> bool
 Silk.NET.Core.INativeWindow
 Silk.NET.Core.INativeWindow.TryGetPlatformInfo<TPlatformInfo>(out TPlatformInfo? info) -> bool
 Silk.NET.Core.Loader.DefaultNativeContext

--- a/sources/SilkTouch/SilkTouch/Mods/TransformHandles.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/TransformHandles.cs
@@ -513,6 +513,11 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
                         Token(SyntaxKind.UnsafeKeyword),
                         Token(SyntaxKind.PartialKeyword)
                     )
+                )
+                .WithBaseList(
+                    BaseList(
+                        [SimpleBaseType(ParseTypeName("IHandle"))]
+                    )
                 );
         }
 
@@ -696,6 +701,23 @@ public class TransformHandles(IOptionsSnapshot<TransformHandles.Config> config, 
                                         SingletonSeparatedList(Argument(IdentifierName("right")))
                                     )
                                 )
+                        )
+                    )
+                )
+                .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
+
+            // IHandle.IsNull
+            yield return PropertyDeclaration(
+                    PredefinedType(Token(SyntaxKind.BoolKeyword)),
+                    Identifier("IsNull")
+                )
+                .WithModifiers(TokenList(Token(SyntaxKind.PublicKeyword)))
+                .WithExpressionBody(
+                    ArrowExpressionClause(
+                        BinaryExpression(
+                            SyntaxKind.EqualsExpression,
+                            CastExpression(IdentifierName("IntPtr"), IdentifierName("Handle")),
+                            LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0))
                         )
                     )
                 )


### PR DESCRIPTION
# Summary of the PR
Adds a simple IHandle struct for XYZHandle structs, and implements an `IsNull` property.

# Related issues, Discord discussions, or proposals
https://discord.com/channels/521092042781229087/587346162802229298/1443561471245291592

# Further Comments
Only tested locally with SDL.