### PR TITLE
[3.0] Fix EnumGroupRegression test case

### DIFF
--- a/sources/SilkTouch/SilkTouch/Mods/MixKhronosData.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/MixKhronosData.cs
@@ -2278,7 +2278,7 @@ public partial class MixKhronosData(
             }
 
             // Some enum groups don't have members, meaning that the code above won't catch them
-            if (groupName != null && !data.Groups.ContainsKey(groupName))
+            if (groupName != null && !IsUngroupable(groupName) && !data.Groups.ContainsKey(groupName))
             {
                 data.Groups[groupName] = new EnumGroup(
                     groupName,

--- a/tests/SilkTouch/SilkTouch/Khronos/MixKhronosDataTests.EnumGroupRegression.cl.xml.verified.txt
+++ b/tests/SilkTouch/SilkTouch/Khronos/MixKhronosDataTests.EnumGroupRegression.cl.xml.verified.txt
@@ -15,6 +15,8 @@ Added Group: cl_arm_svm_alloc_flags
 Existing Group: cl_command_queue_properties
     Added: CL_QUEUE_RESERVED_QCOM
 
+Added Group: cl_compiler_mode_altera
+
 Added Group: cl_device_command_buffer_capabilities_khr 
     Added: CL_COMMAND_BUFFER_CAPABILITY_DEVICE_SIDE_ENQUEUE_KHR
     Added: CL_COMMAND_BUFFER_CAPABILITY_KERNEL_PRINTF_KHR


### PR DESCRIPTION
# Summary of the PR
This prevents the `Constants_*` and `enums_*` groups from being output for the OpenCL XML spec in the EnumGroupRegression test case. The change to `cl_compiler_mode_altera` is justifiable since it is an empty enum.

Note that empty enums still contain important information, such as whether they are `[Flags]` types or not.
These notably affect the generation of the Vulkan bindings where ignoring these empty enums causes some enums to turn into non-Flags types.

# Related issues, Discord discussions, or proposals
Discord discussion: https://discord.com/channels/521092042781229087/587346162802229298/1454577375063970045

# Further Comments
