### PR TITLE
docs: fix incomplete XML documentation for CreateInput method

### DIFF
--- a/src/Input/Silk.NET.Input.Common/InputWindowExtensions.cs
+++ b/src/Input/Silk.NET.Input.Common/InputWindowExtensions.cs
@@ -58,7 +58,7 @@ namespace Silk.NET.Input
         /// </exception>
         /// <exception cref="NotSupportedException">
         /// Couldn't find a suitable input platform for this view. This occurs when you've created a window/view using
-        /// a window platform, but haven't installed
+        /// a window platform, but haven't installed the corresponding input backend package.
         /// </exception>
         public static IInputContext CreateInput(this IView view)
         {


### PR DESCRIPTION
The documentation for the NotSupportedException trailed off mid-sentence.
Completed the text to clarify that this error usually occurs when the corresponding input backend package is missing.

**Changes**

- Updated the tag text for clarity.
- No functional code changes.