### PR TITLE
[3.0] Fix coverage report check

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -100,7 +100,7 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                 name: coverage-${{ matrix.name }}
-                path: ./coverage/**/coverage.cobertura.xml
+                path: ./coverage/**/*.cobertura.xml
     Report-Coverage:
         name: "Report Coverage"
         runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -101,6 +101,7 @@ jobs:
               with:
                 name: coverage-${{ matrix.name }}
                 path: ./coverage/**/*.cobertura.xml
+                if-no-files-found: error
     Report-Coverage:
         name: "Report Coverage"
         runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -119,7 +119,7 @@ jobs:
             - name: Generate Report
               uses: danielpalme/ReportGenerator-GitHub-Action@5.1.9
               with:
-                reports: './coverage/**/**/coverage.cobertura.xml'
+                reports: './coverage/**/*.cobertura.xml'
                 targetdir: './coveragereport'
                 reporttypes: 'Cobertura'
                 verbosity: 'Info'


### PR DESCRIPTION
# Summary of the PR
Technically a duplicate of https://github.com/dotnet/Silk.NET/pull/2543, but this is to test if the coverage report comment works for PRs coming from branches from the dotnet/Silk.NET repo. It currently does not work for forks (known issue), but the comment does work for the main repo.

This fixes the coverage report check, making it so that all checks pass.

# Related issues, Discord discussions, or proposals
N/A

# Further Comments
The last time coverage reports ran was during https://github.com/dotnet/Silk.NET/pull/2494.
In that PR we had 3% coverage, now we have 14%! :tada: