### PR TITLE
[3.0] Improve generator performance

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <!-- Analyzers -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.12.0-beta1.25218.8" />
     <!-- SilkTouch -->
-    <PackageVersion Include="ClangSharp.PInvokeGenerator" Version="20.1.2.4" />
+    <PackageVersion Include="ClangSharp.PInvokeGenerator" Version="21.1.8.3" />
     <PackageVersion Include="CSharpier.Core" Version="0.30.2" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <!-- Analyzers -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.12.0-beta1.25218.8" />
     <!-- SilkTouch -->
-    <PackageVersion Include="ClangSharp.PInvokeGenerator" Version="21.1.8.3" />
+    <PackageVersion Include="ClangSharp.PInvokeGenerator" Version="20.1.2.4" />
     <PackageVersion Include="CSharpier.Core" Version="0.30.2" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.1" />

--- a/sources/SilkTouch/SilkTouch/Mods/AddApiProfiles.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/AddApiProfiles.cs
@@ -265,9 +265,7 @@ public class AddApiProfiles(
                 logger.LogDebug("No profile identified for {}", path);
             }
 
-            ctx.SourceProject = doc.WithSyntaxRoot(
-                rewriter.Visit(root).NormalizeWhitespace()
-            ).Project;
+            ctx.SourceProject = doc.WithSyntaxRoot(rewriter.Visit(root)).Project;
             rewriter.Profile = null;
         }
     }

--- a/sources/SilkTouch/SilkTouch/Mods/AddOpaqueStructs.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/AddOpaqueStructs.cs
@@ -72,11 +72,10 @@ public class AddOpaqueStructs(
         {
             var qualified = name.LastIndexOf('.');
             var ns =
-                qualified != -1
-                    ? ModUtils.NamespaceIntoIdentifierName(name.AsSpan()[..qualified])
-                    : _defaultNamespaces.TryGetValue(ctx.JobKey, out var def)
-                        ? ModUtils.NamespaceIntoIdentifierName(def)
-                        : null;
+                qualified != -1 ? ModUtils.NamespaceIntoIdentifierName(name.AsSpan()[..qualified])
+                : _defaultNamespaces.TryGetValue(ctx.JobKey, out var def)
+                    ? ModUtils.NamespaceIntoIdentifierName(def)
+                : null;
             if (ns is null)
             {
                 logger.LogWarning(
@@ -107,8 +106,7 @@ public class AddOpaqueStructs(
                                     )
                                 )
                         )
-                    )
-                    .NormalizeWhitespace(),
+                    ),
                 filePath: proj.FullPath(fname)
             ).Project;
         }

--- a/sources/SilkTouch/SilkTouch/Mods/AddVTables.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/AddVTables.cs
@@ -1454,8 +1454,7 @@ public class AddVTables(IOptionsSnapshot<AddVTables.Configuration> config) : IMo
 
             rw.Reset();
             proj = doc.WithSyntaxRoot(
-                rw.Visit(node)?.NormalizeWhitespace()
-                    ?? throw new InvalidOperationException("Visit returned null")
+                rw.Visit(node) ?? throw new InvalidOperationException("Visit returned null")
             ).Project;
             if (rw.InterfacePartials.Count == 0)
             {
@@ -1515,11 +1514,7 @@ public class AddVTables(IOptionsSnapshot<AddVTables.Configuration> config) : IMo
         )
         {
             proj = proj
-                ?.AddDocument(
-                    Path.GetFileName(fname),
-                    root.NormalizeWhitespace(),
-                    filePath: proj.FullPath(fname)
-                )
+                ?.AddDocument(Path.GetFileName(fname), root, filePath: proj.FullPath(fname))
                 .Project;
         }
 

--- a/sources/SilkTouch/SilkTouch/Mods/BakeSourceSets.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/BakeSourceSets.cs
@@ -391,7 +391,7 @@ public class BakeSourceSets(
         {
             proj = proj.AddDocument(
                 Path.GetFileName(bakedPath),
-                bakedRoot.NormalizeWhitespace(),
+                bakedRoot,
                 // we can forgive the below nulls because RelativePath checks them, and returns null if they're null.
                 filePath: proj.FullPath(bakedPath)
             ).Project;

--- a/sources/SilkTouch/SilkTouch/Mods/ChangeNamespace.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/ChangeNamespace.cs
@@ -59,7 +59,8 @@ public class ChangeNamespace(IOptionsSnapshot<ChangeNamespace.Configuration> con
 
             rsps[i] = rsp with
             {
-                GeneratorConfiguration = rsp.GeneratorConfiguration.ToWrapper() with {
+                GeneratorConfiguration = rsp.GeneratorConfiguration.ToWrapper() with
+                {
                     DefaultNamespace = def,
                     WithNamespaces = with,
                 },
@@ -91,7 +92,7 @@ public class ChangeNamespace(IOptionsSnapshot<ChangeNamespace.Configuration> con
             var doc =
                 proj!.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             proj = doc.WithSyntaxRoot(
-                rewriter.Visit(await doc.GetSyntaxRootAsync(ct))?.NormalizeWhitespace()
+                rewriter.Visit(await doc.GetSyntaxRootAsync(ct))
                     ?? throw new InvalidOperationException("Visit returned null.")
             ).Project;
         }
@@ -116,17 +117,16 @@ public class ChangeNamespace(IOptionsSnapshot<ChangeNamespace.Configuration> con
             _usingsToAdd.Clear();
             return base.VisitCompilationUnit(node) switch
             {
-                CompilationUnitSyntax syntax
-                    => syntax.AddUsings(
-                        _usingsToAdd
-                            .Select(x => UsingDirective(ModUtils.NamespaceIntoIdentifierName(x)))
-                            .Where(x =>
-                                syntax.Usings.All(y => x.Name?.ToString() != y.Name?.ToString())
-                            )
-                            .ToArray()
-                    ),
+                CompilationUnitSyntax syntax => syntax.AddUsings(
+                    _usingsToAdd
+                        .Select(x => UsingDirective(ModUtils.NamespaceIntoIdentifierName(x)))
+                        .Where(x =>
+                            syntax.Usings.All(y => x.Name?.ToString() != y.Name?.ToString())
+                        )
+                        .ToArray()
+                ),
                 { } ret => ret,
-                null => null
+                null => null,
             };
         }
 
@@ -140,10 +140,11 @@ public class ChangeNamespace(IOptionsSnapshot<ChangeNamespace.Configuration> con
             }
             return base.VisitNamespaceDeclaration(node) switch
             {
-                NamespaceDeclarationSyntax syntax
-                    => syntax.WithName(ModUtils.NamespaceIntoIdentifierName(newNs)),
+                NamespaceDeclarationSyntax syntax => syntax.WithName(
+                    ModUtils.NamespaceIntoIdentifierName(newNs)
+                ),
                 { } ret => ret,
-                null => null
+                null => null,
             };
         }
 
@@ -159,10 +160,11 @@ public class ChangeNamespace(IOptionsSnapshot<ChangeNamespace.Configuration> con
             }
             return base.VisitFileScopedNamespaceDeclaration(node) switch
             {
-                FileScopedNamespaceDeclarationSyntax syntax
-                    => syntax.WithName(ModUtils.NamespaceIntoIdentifierName(newNs)),
+                FileScopedNamespaceDeclarationSyntax syntax => syntax.WithName(
+                    ModUtils.NamespaceIntoIdentifierName(newNs)
+                ),
                 { } ret => ret,
-                null => null
+                null => null,
             };
         }
     }

--- a/sources/SilkTouch/SilkTouch/Mods/Common/MSBuildModContext.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/Common/MSBuildModContext.cs
@@ -308,13 +308,8 @@ internal class MSBuildModContext(
         CancellationToken ct = default
     )
     {
-        var result = await CodeFormatter.FormatAsync(
-            root.NormalizeWhitespace().SyntaxTree,
-            _opts,
-            ct
-        );
-        return !result.CompilationErrors.Any()
-            ? result.Code
-            : root.NormalizeWhitespace(eol: "\n").ToFullString();
+        var normalizedRoot = root.NormalizeWhitespace();
+        var result = await CodeFormatter.FormatAsync(normalizedRoot.SyntaxTree, _opts, ct);
+        return !result.CompilationErrors.Any() ? result.Code : normalizedRoot.ToFullString();
     }
 }

--- a/sources/SilkTouch/SilkTouch/Mods/Common/MSBuildModContext.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/Common/MSBuildModContext.cs
@@ -308,7 +308,7 @@ internal class MSBuildModContext(
         CancellationToken ct = default
     )
     {
-        var normalizedRoot = root.NormalizeWhitespace();
+        var normalizedRoot = root.NormalizeWhitespace(eol: "\n");
         var result = await CodeFormatter.FormatAsync(normalizedRoot.SyntaxTree, _opts, ct);
         return !result.CompilationErrors.Any() ? result.Code : normalizedRoot.ToFullString();
     }

--- a/sources/SilkTouch/SilkTouch/Mods/Common/MSBuildModContext.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/Common/MSBuildModContext.cs
@@ -308,7 +308,7 @@ internal class MSBuildModContext(
         CancellationToken ct = default
     )
     {
-        var normalizedRoot = root.NormalizeWhitespace(eol: "\n");
+        var normalizedRoot = root.NormalizeWhitespace();
         var result = await CodeFormatter.FormatAsync(normalizedRoot.SyntaxTree, _opts, ct);
         return !result.CompilationErrors.Any() ? result.Code : normalizedRoot.ToFullString();
     }

--- a/sources/SilkTouch/SilkTouch/Mods/ExtractHandles.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/ExtractHandles.cs
@@ -51,7 +51,7 @@ public class ExtractHandles(ILogger<ExtractHandles> logger) : Mod
             project = project
                 .AddDocument(
                     Path.GetFileName(relativePath),
-                    node.NormalizeWhitespace(),
+                    node,
                     filePath: project.FullPath(relativePath)
                 )
                 .Project;

--- a/sources/SilkTouch/SilkTouch/Mods/ExtractNestedTyping.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/ExtractNestedTyping.cs
@@ -86,7 +86,7 @@ public partial class ExtractNestedTyping(ILogger<ExtractNestedTyping> logger) : 
             // This is also where extracted enums are processed.
             rewriter.File = fname;
             project = doc.WithSyntaxRoot(
-                rewriter.Visit(node)?.NormalizeWhitespace()
+                rewriter.Visit(node)
                     ?? throw new InvalidOperationException("Rewriter returned null")
             ).Project;
 
@@ -110,8 +110,7 @@ public partial class ExtractNestedTyping(ILogger<ExtractNestedTyping> logger) : 
                                             )
                                     )
                                     : SingletonList<MemberDeclarationSyntax>(newStruct)
-                            )
-                            .NormalizeWhitespace(),
+                            ),
                         filePath: project.FullPath(
                             $"{fname.AsSpan()[..fname.LastIndexOf('/')]}/{newStruct.Identifier}.gen.cs"
                         )
@@ -174,8 +173,7 @@ public partial class ExtractNestedTyping(ILogger<ExtractNestedTyping> logger) : 
                                         .WithMembers(SingletonList(typeDecl))
                                 )
                                 : SingletonList(typeDecl)
-                        )
-                        .NormalizeWhitespace(),
+                        ),
                     filePath: project.FullPath($"{dir}/{identifier}.gen.cs")
                 )
                 .Project;

--- a/sources/SilkTouch/SilkTouch/Mods/InterceptNativeFunctions.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/InterceptNativeFunctions.cs
@@ -48,7 +48,7 @@ public class InterceptNativeFunctions(
             var doc =
                 proj!.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             proj = doc.WithSyntaxRoot(
-                rewriter.Visit(await doc.GetSyntaxRootAsync(ct))?.NormalizeWhitespace()
+                rewriter.Visit(await doc.GetSyntaxRootAsync(ct))
                     ?? throw new InvalidOperationException("Visit returned null.")
             ).Project;
         }

--- a/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/IdentifierRenamingTransformer.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/IdentifierRenamingTransformer.cs
@@ -14,19 +14,25 @@ public class IdentifierRenamingTransformer : LocationTransformer
 {
     private ISymbol symbol = null!;
 
-    private readonly IReadOnlyDictionary<string, List<(ISymbol Symbol, string NewName)>> newNameLookup;
+    private readonly IReadOnlyDictionary<
+        string,
+        List<(ISymbol Symbol, string NewName)>
+    > newNameLookup;
 
     /// <summary>
     /// Creates a new IdentifierRenamingTransformer.
     /// </summary>
     /// <param name="newNames">The new names for each symbol</param>
-    public IdentifierRenamingTransformer(IEnumerable<(ISymbol Symbol, string NewName)> newNames) : this(CreateNameLookup(newNames)) {}
+    public IdentifierRenamingTransformer(IEnumerable<(ISymbol Symbol, string NewName)> newNames)
+        : this(CreateNameLookup(newNames)) { }
 
     /// <summary>
     /// Creates a new IdentifierRenamingTransformer.
     /// </summary>
     /// <param name="newNameLookup">The new names for each symbol grouped by symbol name.</param>
-    public IdentifierRenamingTransformer(IReadOnlyDictionary<string, List<(ISymbol Symbol, string NewName)>> newNameLookup)
+    public IdentifierRenamingTransformer(
+        IReadOnlyDictionary<string, List<(ISymbol Symbol, string NewName)>> newNameLookup
+    )
     {
         this.newNameLookup = newNameLookup;
     }
@@ -34,9 +40,14 @@ public class IdentifierRenamingTransformer : LocationTransformer
     /// <summary>
     /// Creates a name lookup dictionary designed for <see cref="IdentifierRenamingTransformer"/>.
     /// </summary>
-    public static IReadOnlyDictionary<string, List<(ISymbol Symbol, string NewName)>> CreateNameLookup(IEnumerable<(ISymbol Symbol, string NewName)> names)
+    public static IReadOnlyDictionary<
+        string,
+        List<(ISymbol Symbol, string NewName)>
+    > CreateNameLookup(IEnumerable<(ISymbol Symbol, string NewName)> names)
     {
-        return names.GroupBy(t => t.Symbol.Name).ToDictionary(group => group.Key, group => group.ToList());
+        return names
+            .GroupBy(t => t.Symbol.Name)
+            .ToDictionary(group => group.Key, group => group.ToList());
     }
 
     /// <inheritdoc />
@@ -68,7 +79,7 @@ public class IdentifierRenamingTransformer : LocationTransformer
         return currentNameIdentifier;
     }
 
-     // ----- Types -----
+    // ----- Types -----
 
     /// <inheritdoc />
     public override SyntaxNode VisitClassDeclaration(ClassDeclarationSyntax node)

--- a/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationRewriter.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationRewriter.cs
@@ -283,4 +283,9 @@ public class LocationTransformationRewriter : CSharpSyntaxRewriter
 
         return base.VisitVariableDeclarator(node)!;
     }
+
+    // ----- Skipped nodes -----
+
+    /// <inheritdoc />
+    public override SyntaxNode VisitUsingDirective(UsingDirectiveSyntax node) => node;
 }

--- a/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationRewriter.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationRewriter.cs
@@ -51,13 +51,37 @@ public class LocationTransformationRewriter : CSharpSyntaxRewriter
 
         // Used to skip symbol lookups
         // Does not handle the omission of the "-Attribute" suffix, but generally, we don't need to transform attributes
-        _relevantIdentifiers = _symbols.Select(s => s.Name).ToHashSet();
+        _relevantIdentifiers = new HashSet<string>(_symbols.Count);
+        foreach (var symbol in _symbols)
+        {
+            _relevantIdentifiers.Add(symbol.Name);
+        }
+    }
+
+    private LocationTransformationRewriter(
+        HashSet<ISymbol> symbols,
+        List<LocationTransformer> transformers,
+        HashSet<string> relevantIdentifiers
+    )
+    {
+        _symbols = symbols;
+        _transformers = transformers;
+        _relevantIdentifiers = relevantIdentifiers;
     }
 
     /// <summary>
     /// Initializes the renamer to work for a new document. Must be called before visiting any nodes.
     /// </summary>
     public void Initialize(SemanticModel semanticModel) => _semanticModel = semanticModel;
+
+    /// <summary>
+    /// Clone this rewriter for purposes of thread safety.
+    /// </summary>
+    /// <remarks>
+    /// This is allowed to return the current instance and share data.
+    /// </remarks>
+    public LocationTransformationRewriter GetThreadSafeCopy() =>
+        new(_symbols, [.. _transformers.Select(t => t.GetThreadSafeCopy())], _relevantIdentifiers);
 
     /// <inheritdoc />
     [return: NotNullIfNotNull("unmodifiedNode")]

--- a/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationRewriter.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationRewriter.cs
@@ -255,8 +255,7 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
     {
-        var symbol =
-            semanticModel.GetSymbolInfo(node).Symbol ?? semanticModel.GetTypeInfo(node).Type;
+        var symbol = semanticModel.GetSymbolInfo(node).Symbol;
         ReportSymbol(node, symbol);
 
         return base.VisitIdentifierName(node)!;

--- a/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationRewriter.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationRewriter.cs
@@ -14,39 +14,47 @@ namespace Silk.NET.SilkTouch.Mods.LocationTransformation;
 /// and modifies the nodes only when coming back up.
 /// <br/>
 /// Modifying nodes cause them to be detached from the semantic model (meaning no symbol information),
-/// so this ensures that we gather all of the data we need before making changes.
+/// so this ensures that we gather all the data we need before making changes.
 /// </remarks>
-/// <param name="symbols">Symbols to search for.</param>
-/// <param name="transformers">Transformers to use on each found symbol reference.</param>
-public class LocationTransformationRewriter(
-    HashSet<ISymbol> symbols,
-    List<LocationTransformer> transformers
-) : CSharpSyntaxRewriter
+public class LocationTransformationRewriter : CSharpSyntaxRewriter
 {
     // Symbols can also be referenced within XML doc, which are trivia nodes.
     /// <inheritdoc />
     public override bool VisitIntoStructuredTrivia => true;
 
-    private readonly Dictionary<SyntaxNode, QueuedTransformation> queuedTransformations = new();
+    private readonly Dictionary<SyntaxNode, QueuedTransformation> _queuedTransformations = new();
 
     /// <param name="Symbol">The symbol for the node.</param>
     /// <param name="TransformerIndex">The index of the transformer that should be used when continuing the transformation process.</param>
     private record struct QueuedTransformation(ISymbol Symbol, int TransformerIndex);
 
-    private readonly List<SyntaxNode> tempNodeList = new();
+    private readonly List<SyntaxNode> _tempNodeList = new();
 
     /// <summary>
     /// The semantic model of the currently processed document.
     /// </summary>
-    private SemanticModel semanticModel = null!;
+    private SemanticModel _semanticModel = null!;
+
+    private readonly HashSet<ISymbol> _symbols;
+    private readonly List<LocationTransformer> _transformers;
+    private readonly HashSet<string> _relevantIdentifiers;
+
+    /// <param name="symbols">Symbols to search for.</param>
+    /// <param name="transformers">Transformers to use on each found symbol reference.</param>
+    public LocationTransformationRewriter(
+        HashSet<ISymbol> symbols,
+        List<LocationTransformer> transformers
+    )
+    {
+        _symbols = symbols;
+        _transformers = transformers;
+        _relevantIdentifiers = _symbols.Select(s => s.Name).ToHashSet();
+    }
 
     /// <summary>
     /// Initializes the renamer to work for a new document. Must be called before visiting any nodes.
     /// </summary>
-    public void Initialize(SemanticModel semanticModel)
-    {
-        this.semanticModel = semanticModel;
-    }
+    public void Initialize(SemanticModel semanticModel) => _semanticModel = semanticModel;
 
     /// <inheritdoc />
     [return: NotNullIfNotNull("unmodifiedNode")]
@@ -63,12 +71,12 @@ public class LocationTransformationRewriter(
         // Check for queued transformation
         // To apply a transformation, we must be in the same level in the hierarchy as the selected node
         // We also must apply transformations when going back up in the hierarchy so we don't overwrite previous transformations
-        if (queuedTransformations.Remove(unmodifiedNode, out var transformation))
+        if (_queuedTransformations.Remove(unmodifiedNode, out var transformation))
         {
             if (transformation.TransformerIndex >= 0)
             {
                 // Apply deferred transformer
-                var deferredTransformer = transformers[transformation.TransformerIndex];
+                var deferredTransformer = _transformers[transformation.TransformerIndex];
                 modifiedNode = deferredTransformer
                     .Visit(modifiedNode)
                     .WithLeadingTrivia(unmodifiedNode.GetLeadingTrivia().Select(VisitTrivia))
@@ -76,12 +84,12 @@ public class LocationTransformationRewriter(
             }
 
             // Continue applying remaining transformers
-            for (var i = transformation.TransformerIndex + 1; i < transformers.Count; i++)
+            for (var i = transformation.TransformerIndex + 1; i < _transformers.Count; i++)
             {
-                var transformer = transformers[i];
+                var transformer = _transformers[i];
 
                 // Calculate hierarchy
-                var hierarchy = tempNodeList;
+                var hierarchy = _tempNodeList;
                 {
                     hierarchy.Clear();
 
@@ -109,7 +117,7 @@ public class LocationTransformationRewriter(
                 {
                     // We can't directly transform the node since we are at the wrong place in the hierarchy
                     // Defer it so it is processed later
-                    queuedTransformations.Add(
+                    _queuedTransformations.Add(
                         selectedNode,
                         new QueuedTransformation(transformation.Symbol, i)
                     );
@@ -130,12 +138,12 @@ public class LocationTransformationRewriter(
 
     private void ReportSymbol(SyntaxNode node, ISymbol? symbol)
     {
-        if (symbol == null || !symbols.Contains(symbol))
+        if (symbol == null || !_symbols.Contains(symbol))
         {
             return;
         }
 
-        queuedTransformations.Add(node, new QueuedTransformation(symbol, -1));
+        _queuedTransformations.Add(node, new QueuedTransformation(symbol, -1));
     }
 
     // ----- Types -----
@@ -143,7 +151,7 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitClassDeclaration(ClassDeclarationSyntax node)
     {
-        var symbol = semanticModel.GetDeclaredSymbol(node);
+        var symbol = _semanticModel.GetDeclaredSymbol(node);
         ReportSymbol(node, symbol);
 
         return base.VisitClassDeclaration(node)!;
@@ -152,7 +160,7 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitStructDeclaration(StructDeclarationSyntax node)
     {
-        var symbol = semanticModel.GetDeclaredSymbol(node);
+        var symbol = _semanticModel.GetDeclaredSymbol(node);
         ReportSymbol(node, symbol);
 
         return base.VisitStructDeclaration(node)!;
@@ -161,7 +169,7 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
     {
-        var symbol = semanticModel.GetDeclaredSymbol(node);
+        var symbol = _semanticModel.GetDeclaredSymbol(node);
         ReportSymbol(node, symbol);
 
         return base.VisitInterfaceDeclaration(node)!;
@@ -170,7 +178,7 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitRecordDeclaration(RecordDeclarationSyntax node)
     {
-        var symbol = semanticModel.GetDeclaredSymbol(node);
+        var symbol = _semanticModel.GetDeclaredSymbol(node);
         ReportSymbol(node, symbol);
 
         return base.VisitRecordDeclaration(node)!;
@@ -179,7 +187,7 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitDelegateDeclaration(DelegateDeclarationSyntax node)
     {
-        var symbol = semanticModel.GetDeclaredSymbol(node);
+        var symbol = _semanticModel.GetDeclaredSymbol(node);
         ReportSymbol(node, symbol);
 
         return base.VisitDelegateDeclaration(node)!;
@@ -188,7 +196,7 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitEnumDeclaration(EnumDeclarationSyntax node)
     {
-        var symbol = semanticModel.GetDeclaredSymbol(node);
+        var symbol = _semanticModel.GetDeclaredSymbol(node);
         ReportSymbol(node, symbol);
 
         return base.VisitEnumDeclaration(node)!;
@@ -199,7 +207,7 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitEnumMemberDeclaration(EnumMemberDeclarationSyntax node)
     {
-        var symbol = semanticModel.GetDeclaredSymbol(node);
+        var symbol = _semanticModel.GetDeclaredSymbol(node);
         ReportSymbol(node, symbol);
 
         return base.VisitEnumMemberDeclaration(node)!;
@@ -208,7 +216,7 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitPropertyDeclaration(PropertyDeclarationSyntax node)
     {
-        var symbol = semanticModel.GetDeclaredSymbol(node);
+        var symbol = _semanticModel.GetDeclaredSymbol(node);
         ReportSymbol(node, symbol);
 
         return base.VisitPropertyDeclaration(node)!;
@@ -217,7 +225,7 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitEventDeclaration(EventDeclarationSyntax node)
     {
-        var symbol = semanticModel.GetDeclaredSymbol(node);
+        var symbol = _semanticModel.GetDeclaredSymbol(node);
         ReportSymbol(node, symbol);
 
         return base.VisitEventDeclaration(node)!;
@@ -226,7 +234,7 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
     {
-        var symbol = semanticModel.GetDeclaredSymbol(node);
+        var symbol = _semanticModel.GetDeclaredSymbol(node);
         ReportSymbol(node, symbol);
 
         return base.VisitMethodDeclaration(node)!;
@@ -235,7 +243,7 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
     {
-        var symbol = semanticModel.GetDeclaredSymbol(node);
+        var symbol = _semanticModel.GetDeclaredSymbol(node);
         ReportSymbol(node, symbol);
 
         return base.VisitConstructorDeclaration(node)!;
@@ -244,7 +252,7 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitDestructorDeclaration(DestructorDeclarationSyntax node)
     {
-        var symbol = semanticModel.GetDeclaredSymbol(node);
+        var symbol = _semanticModel.GetDeclaredSymbol(node);
         ReportSymbol(node, symbol);
 
         return base.VisitDestructorDeclaration(node)!;
@@ -255,7 +263,12 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
     {
-        var symbol = semanticModel.GetSymbolInfo(node).Symbol;
+        if (!_relevantIdentifiers.Contains(node.Identifier.Text))
+        {
+            return node;
+        }
+
+        var symbol = _semanticModel.GetSymbolInfo(node).Symbol;
         ReportSymbol(node, symbol);
 
         return base.VisitIdentifierName(node)!;
@@ -265,7 +278,7 @@ public class LocationTransformationRewriter(
     /// <inheritdoc />
     public override SyntaxNode VisitVariableDeclarator(VariableDeclaratorSyntax node)
     {
-        var symbol = semanticModel.GetDeclaredSymbol(node);
+        var symbol = _semanticModel.GetDeclaredSymbol(node);
         ReportSymbol(node, symbol);
 
         return base.VisitVariableDeclarator(node)!;

--- a/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationRewriter.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationRewriter.cs
@@ -18,7 +18,10 @@ namespace Silk.NET.SilkTouch.Mods.LocationTransformation;
 /// </remarks>
 /// <param name="symbols">Symbols to search for.</param>
 /// <param name="transformers">Transformers to use on each found symbol reference.</param>
-public class LocationTransformationRewriter(HashSet<ISymbol> symbols, List<LocationTransformer> transformers) : CSharpSyntaxRewriter
+public class LocationTransformationRewriter(
+    HashSet<ISymbol> symbols,
+    List<LocationTransformer> transformers
+) : CSharpSyntaxRewriter
 {
     // Symbols can also be referenced within XML doc, which are trivia nodes.
     /// <inheritdoc />
@@ -66,7 +69,8 @@ public class LocationTransformationRewriter(HashSet<ISymbol> symbols, List<Locat
             {
                 // Apply deferred transformer
                 var deferredTransformer = transformers[transformation.TransformerIndex];
-                modifiedNode = deferredTransformer.Visit(modifiedNode)
+                modifiedNode = deferredTransformer
+                    .Visit(modifiedNode)
                     .WithLeadingTrivia(unmodifiedNode.GetLeadingTrivia().Select(VisitTrivia))
                     .WithTrailingTrivia(unmodifiedNode.GetTrailingTrivia());
             }
@@ -105,13 +109,17 @@ public class LocationTransformationRewriter(HashSet<ISymbol> symbols, List<Locat
                 {
                     // We can't directly transform the node since we are at the wrong place in the hierarchy
                     // Defer it so it is processed later
-                    queuedTransformations.Add(selectedNode, new QueuedTransformation(transformation.Symbol, i));
+                    queuedTransformations.Add(
+                        selectedNode,
+                        new QueuedTransformation(transformation.Symbol, i)
+                    );
 
                     break;
                 }
 
                 // Transform the node
-                modifiedNode = transformer.Visit(modifiedNode)
+                modifiedNode = transformer
+                    .Visit(modifiedNode)
                     .WithLeadingTrivia(unmodifiedNode.GetLeadingTrivia().Select(VisitTrivia))
                     .WithTrailingTrivia(unmodifiedNode.GetTrailingTrivia());
             }
@@ -247,7 +255,8 @@ public class LocationTransformationRewriter(HashSet<ISymbol> symbols, List<Locat
     /// <inheritdoc />
     public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
     {
-        var symbol = semanticModel.GetSymbolInfo(node).Symbol ?? semanticModel.GetTypeInfo(node).Type;
+        var symbol =
+            semanticModel.GetSymbolInfo(node).Symbol ?? semanticModel.GetTypeInfo(node).Type;
         ReportSymbol(node, symbol);
 
         return base.VisitIdentifierName(node)!;

--- a/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationRewriter.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationRewriter.cs
@@ -313,6 +313,7 @@ public class LocationTransformationRewriter : CSharpSyntaxRewriter
 
     // ----- Skipped nodes -----
 
+    // Using statements contain a lot of identifier nodes, but never any symbol references that we care about.
     /// <inheritdoc />
     public override SyntaxNode VisitUsingDirective(UsingDirectiveSyntax node) => node;
 }

--- a/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationRewriter.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationRewriter.cs
@@ -48,6 +48,9 @@ public class LocationTransformationRewriter : CSharpSyntaxRewriter
     {
         _symbols = symbols;
         _transformers = transformers;
+
+        // Used to skip symbol lookups
+        // Does not handle the omission of the "-Attribute" suffix, but generally, we don't need to transform attributes
         _relevantIdentifiers = _symbols.Select(s => s.Name).ToHashSet();
     }
 

--- a/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationUtils.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationUtils.cs
@@ -53,6 +53,7 @@ public static class LocationTransformationUtils
 
         var newDocuments = new ConcurrentDictionary<DocumentId, SyntaxNode>();
         var symbolSet = new HashSet<ISymbol>(symbols, SymbolEqualityComparer.Default);
+        var baseRewriter = new LocationTransformationRewriter(symbolSet, transformers.ToList());
         await Parallel.ForEachAsync(
             documentIds,
             ct,
@@ -73,10 +74,7 @@ public static class LocationTransformationUtils
                 var semanticModel = compilation.GetSemanticModel(originalRoot.SyntaxTree);
 
                 // Since this is multithreaded, each thread needs their own copy of the rewriter and transformers
-                var rewriter = new LocationTransformationRewriter(
-                    symbolSet,
-                    [.. transformers.Select(t => t.GetThreadSafeCopy())]
-                );
+                var rewriter = baseRewriter.GetThreadSafeCopy();
 
                 rewriter.Initialize(semanticModel);
                 var newRoot = rewriter.Visit(originalRoot);

--- a/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationUtils.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationUtils.cs
@@ -45,6 +45,12 @@ public static class LocationTransformationUtils
         ];
 
         var originalSolution = sourceProject.Solution;
+        var compilation = await sourceProject.GetCompilationAsync(ct);
+        if (compilation == null)
+        {
+            return;
+        }
+
         var newDocuments = new ConcurrentDictionary<DocumentId, SyntaxNode>();
         var symbolSet = new HashSet<ISymbol>(symbols, SymbolEqualityComparer.Default);
         await Parallel.ForEachAsync(
@@ -59,12 +65,12 @@ public static class LocationTransformationUtils
                 }
 
                 var originalRoot = await originalDocument.GetSyntaxRootAsync(ct);
-                var semanticModel = await originalDocument.GetSemanticModelAsync(ct);
-
-                if (originalRoot == null || semanticModel == null)
+                if (originalRoot == null)
                 {
                     return;
                 }
+
+                var semanticModel = compilation.GetSemanticModel(originalRoot.SyntaxTree);
 
                 // Since this is multithreaded, each thread needs their own copy of the rewriter and transformers
                 var rewriter = new LocationTransformationRewriter(

--- a/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationUtils.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationUtils.cs
@@ -45,12 +45,6 @@ public static class LocationTransformationUtils
         ];
 
         var originalSolution = sourceProject.Solution;
-        var compilation = await sourceProject.GetCompilationAsync(ct);
-        if (compilation == null)
-        {
-            return;
-        }
-
         var newDocuments = new ConcurrentDictionary<DocumentId, SyntaxNode>();
         var symbolSet = new HashSet<ISymbol>(symbols, SymbolEqualityComparer.Default);
         var baseRewriter = new LocationTransformationRewriter(symbolSet, transformers.ToList());
@@ -66,12 +60,11 @@ public static class LocationTransformationUtils
                 }
 
                 var originalRoot = await originalDocument.GetSyntaxRootAsync(ct);
-                if (originalRoot == null)
+                var semanticModel = await originalDocument.GetSemanticModelAsync(ct);
+                if (originalRoot == null || semanticModel == null)
                 {
                     return;
                 }
-
-                var semanticModel = compilation.GetSemanticModel(originalRoot.SyntaxTree);
 
                 // Since this is multithreaded, each thread needs their own copy of the rewriter and transformers
                 var rewriter = baseRewriter.GetThreadSafeCopy();

--- a/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationUtils.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformationUtils.cs
@@ -26,7 +26,8 @@ public static class LocationTransformationUtils
         IEnumerable<ISymbol> symbols,
         IEnumerable<LocationTransformer> transformers,
         ILogger? logger = null,
-        CancellationToken ct = default)
+        CancellationToken ct = default
+    )
     {
         var sourceProject = ctx.SourceProject;
         if (sourceProject == null)
@@ -37,33 +38,45 @@ public static class LocationTransformationUtils
         // We need to track both the original solution and modified solution
         // The original is where we retrieve documents and semantic models
         // The modified solution is where we place the results
-        IReadOnlyList<DocumentId> documentIds = [.. sourceProject.DocumentIds, .. ctx.TestProject?.DocumentIds ?? []];
+        IReadOnlyList<DocumentId> documentIds =
+        [
+            .. sourceProject.DocumentIds,
+            .. ctx.TestProject?.DocumentIds ?? [],
+        ];
 
         var originalSolution = sourceProject.Solution;
         var newDocuments = new ConcurrentDictionary<DocumentId, SyntaxNode>();
         var symbolSet = new HashSet<ISymbol>(symbols, SymbolEqualityComparer.Default);
-        await Parallel.ForEachAsync(documentIds, ct, async (documentId, _) => {
-            var originalDocument = originalSolution.GetDocument(documentId);
-            if (originalDocument == null)
+        await Parallel.ForEachAsync(
+            documentIds,
+            ct,
+            async (documentId, _) =>
             {
-                return;
+                var originalDocument = originalSolution.GetDocument(documentId);
+                if (originalDocument == null)
+                {
+                    return;
+                }
+
+                var originalRoot = await originalDocument.GetSyntaxRootAsync(ct);
+                var semanticModel = await originalDocument.GetSemanticModelAsync(ct);
+
+                if (originalRoot == null || semanticModel == null)
+                {
+                    return;
+                }
+
+                // Since this is multithreaded, each thread needs their own copy of the rewriter and transformers
+                var rewriter = new LocationTransformationRewriter(
+                    symbolSet,
+                    [.. transformers.Select(t => t.GetThreadSafeCopy())]
+                );
+
+                rewriter.Initialize(semanticModel);
+                var newRoot = rewriter.Visit(originalRoot);
+                newDocuments.TryAdd(documentId, newRoot);
             }
-
-            var originalRoot = await originalDocument.GetSyntaxRootAsync(ct);
-            var semanticModel = await originalDocument.GetSemanticModelAsync(ct);
-
-            if (originalRoot == null || semanticModel == null)
-            {
-                return;
-            }
-
-            // Since this is multithreaded, each thread needs their own copy of the rewriter and transformers
-            var rewriter = new LocationTransformationRewriter(symbolSet, [..transformers.Select(t => t.GetThreadSafeCopy())]);
-            rewriter.Initialize(semanticModel);
-
-            var newRoot = rewriter.Visit(originalRoot);
-            newDocuments.TryAdd(documentId, newRoot);
-        });
+        );
 
         var modifiedSolution = sourceProject.Solution;
         foreach (var (documentId, newRoot) in newDocuments)

--- a/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformer.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformer.cs
@@ -31,8 +31,9 @@ public abstract class LocationTransformer : CSharpSyntaxRewriter
 
     /// <summary>
     /// Clone this location transformer for purposes of thread safety.
-    /// If the location transformer is already thread safe, the location transformer
-    /// does not need to be cloned.
     /// </summary>
+    /// <remarks>
+    /// This is allowed to return the current instance and share data.
+    /// </remarks>
     public abstract LocationTransformer GetThreadSafeCopy();
 }

--- a/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformer.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/LocationTransformation/LocationTransformer.cs
@@ -24,7 +24,10 @@ public abstract class LocationTransformer : CSharpSyntaxRewriter
     /// <param name="hierarchy">The node hierarchy as a reversed stack. Index 0 is the current node. Index 1 is its parent and so on.</param>
     /// <param name="symbol">The symbol that is associated with this node.</param>
     /// <returns>The given node, another node, or null.</returns>
-    public abstract SyntaxNode? GetNodeToModify(IReadOnlyList<SyntaxNode> hierarchy, ISymbol symbol);
+    public abstract SyntaxNode? GetNodeToModify(
+        IReadOnlyList<SyntaxNode> hierarchy,
+        ISymbol symbol
+    );
 
     /// <summary>
     /// Clone this location transformer for purposes of thread safety.

--- a/sources/SilkTouch/SilkTouch/Mods/MarkNativeNames.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/MarkNativeNames.cs
@@ -37,7 +37,7 @@ public class MarkNativeNames : IMod
             var doc =
                 proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             proj = doc.WithSyntaxRoot(
-                rewriter.Visit(await doc.GetSyntaxRootAsync(ct))?.NormalizeWhitespace()
+                rewriter.Visit(await doc.GetSyntaxRootAsync(ct))
                     ?? throw new InvalidOperationException("Visit returned null.")
             ).Project;
         }

--- a/sources/SilkTouch/SilkTouch/Mods/MixKhronosData.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/MixKhronosData.cs
@@ -363,7 +363,7 @@ public partial class MixKhronosData(
             var doc =
                 proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             proj = doc.WithSyntaxRoot(
-                rewriter1.Visit(await doc.GetSyntaxRootAsync(ct))?.NormalizeWhitespace()
+                rewriter1.Visit(await doc.GetSyntaxRootAsync(ct))
                     ?? throw new InvalidOperationException("Visit returned null.")
             ).Project;
         }
@@ -373,7 +373,7 @@ public partial class MixKhronosData(
         {
             proj = proj.AddDocument(
                 Path.GetFileName(filePath),
-                node.NormalizeWhitespace(),
+                node,
                 filePath: proj.FullPath(filePath)
             ).Project;
         }
@@ -385,7 +385,7 @@ public partial class MixKhronosData(
             var doc =
                 proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             proj = doc.WithSyntaxRoot(
-                rewriter2.Visit(await doc.GetSyntaxRootAsync(ct))?.NormalizeWhitespace()
+                rewriter2.Visit(await doc.GetSyntaxRootAsync(ct))
                     ?? throw new InvalidOperationException("Visit returned null.")
             ).Project;
         }
@@ -397,7 +397,7 @@ public partial class MixKhronosData(
             var doc =
                 proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             proj = doc.WithSyntaxRoot(
-                rewriter3.Visit(await doc.GetSyntaxRootAsync(ct))?.NormalizeWhitespace()
+                rewriter3.Visit(await doc.GetSyntaxRootAsync(ct))
                     ?? throw new InvalidOperationException("Visit returned null.")
             ).Project;
         }

--- a/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
@@ -200,7 +200,7 @@ public class PrettifyNames(
         var typeNamesLongestFirst = typeNames.OrderByDescending(x => x.Key.Length).ToArray();
 
         var documentPaths = proj
-            .Documents.Select(d => d.FilePath)
+            .Documents.Select(d => d.RelativePath())
             .Where(d => d != null)
             .ToHashSet();
 
@@ -223,12 +223,13 @@ public class PrettifyNames(
 
             // Rename doc and update path
             var originalName = doc.Name;
-            var originalPath = doc.FilePath;
+            var originalPath = doc.RelativePath();
             doc = doc.ReplaceNameAndPath(oldName, newName);
+            var newPath = doc.RelativePath();
 
             // Check for path conflict
             documentPaths.Remove(originalPath);
-            if (!documentPaths.Add(doc.FilePath!))
+            if (!documentPaths.Add(newPath))
             {
                 logger.LogError(
                     $"{originalName} -> {doc.Name} failed to rename file as a file already exists at {doc.FilePath}"

--- a/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
@@ -221,11 +221,23 @@ public class PrettifyNames(
                 continue;
             }
 
+            // Save syntax tree so we can restore it later
+            // Modifying the document can cause it to be reparsed
+            // C# discord: https://discord.com/channels/143867839282020352/598678594750775301/1494176147351535687
+            var syntaxRoot = await doc.GetSyntaxRootAsync(ct);
+            if (syntaxRoot == null)
+            {
+                continue;
+            }
+
             // Rename doc and update path
             var originalName = doc.Name;
             var originalPath = doc.RelativePath();
             doc = doc.ReplaceNameAndPath(oldName, newName);
             var newPath = doc.RelativePath();
+
+            // Restore syntax tree
+            doc = doc.WithSyntaxRoot(syntaxRoot);
 
             // Check for path conflict
             documentPaths.Remove(originalPath);

--- a/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
@@ -195,8 +195,14 @@ public class PrettifyNames(
 
         // Change the filenames where appropriate.
         proj = ctx.SourceProject;
+
         var typeNames = newNames.GetValueOrDefault("", []);
         var typeNamesLongestFirst = typeNames.OrderByDescending(x => x.Key.Length).ToArray();
+
+        var documentPaths = proj
+            .Documents.Select(d => d.FilePath)
+            .Where(d => d != null)
+            .ToHashSet();
 
         foreach (var docId in proj.DocumentIds)
         {
@@ -206,6 +212,7 @@ public class PrettifyNames(
                 continue;
             }
 
+            // Find best matching document for renamed types
             var firstMatch = typeNamesLongestFirst.FirstOrDefault(x =>
                 doc.FilePath.Contains(x.Key) || doc.Name.Contains(x.Key)
             );
@@ -214,43 +221,23 @@ public class PrettifyNames(
                 continue;
             }
 
+            // Rename doc and update path
             var originalName = doc.Name;
+            var originalPath = doc.FilePath;
             doc = doc.ReplaceNameAndPath(oldName, newName);
 
-            var found = false;
-            if (doc.FilePath is not null)
-            {
-                foreach (var checkDocId in proj.DocumentIds)
-                {
-                    if (checkDocId == docId)
-                    {
-                        continue;
-                    }
-
-                    var checkDoc = proj.GetDocument(checkDocId);
-                    if (checkDoc?.FilePath is null)
-                    {
-                        continue;
-                    }
-
-                    if (checkDoc.FilePath == doc.FilePath)
-                    {
-                        found = true;
-                        break;
-                    }
-                }
-            }
-
-            if (found)
+            // Check for path conflict
+            documentPaths.Remove(originalPath);
+            if (!documentPaths.Add(doc.FilePath!))
             {
                 logger.LogError(
                     $"{originalName} -> {doc.Name} failed to rename file as a file already exists at {doc.FilePath}"
                 );
+
+                continue;
             }
-            else
-            {
-                proj = doc.Project;
-            }
+
+            proj = doc.Project;
         }
 
         ctx.SourceProject = proj;

--- a/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
@@ -1132,17 +1132,6 @@ public class PrettifyNames(
                 }
             }
 
-            // These collections are used later.
-            // These keep track of method discriminators to determine whether we have incompatible overloads.
-            // We keep track of the first original name so that we can add it to conflictingOriginalNames when we
-            // do discover a conflict (along with the original name of the actual conflict).
-            var methodDiscriminators =
-                new Dictionary<
-                    string,
-                    (string? FirstOriginalName, List<MethodDeclarationSyntax> Methods)
-                >();
-            var conflictingOriginalNames = new HashSet<string>();
-
             // This loop cannot be part of the loop below because it modifies the primaries
             foreach (var (scope, members) in context.Names)
             {
@@ -1207,6 +1196,17 @@ public class PrettifyNames(
                     }
                 }
             }
+
+            // These collections are used later.
+            // These keep track of method discriminators to determine whether we have incompatible overloads.
+            // We keep track of the first original name so that we can add it to conflictingOriginalNames when we
+            // do discover a conflict (along with the original name of the actual conflict).
+            var methodDiscriminators =
+                new Dictionary<
+                    string,
+                    (string? FirstOriginalName, List<MethodDeclarationSyntax> Methods)
+                >();
+            var conflictingOriginalNames = new HashSet<string>();
 
             foreach (var (scope, members) in context.Names)
             {

--- a/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/PrettifyNames.cs
@@ -222,7 +222,7 @@ public class PrettifyNames(
             }
 
             // Save syntax tree so we can restore it later
-            // Modifying the document can cause it to be reparsed
+            // This is because modifying the document can cause it to be reparsed
             // C# discord: https://discord.com/channels/143867839282020352/598678594750775301/1494176147351535687
             var syntaxRoot = await doc.GetSyntaxRootAsync(ct);
             if (syntaxRoot == null)
@@ -244,7 +244,7 @@ public class PrettifyNames(
             if (!documentPaths.Add(newPath))
             {
                 logger.LogError(
-                    $"{originalName} -> {doc.Name} failed to rename file as a file already exists at {doc.FilePath}"
+                    $"{originalName} -> {doc.Name} failed to rename file as a file already exists at {newPath}"
                 );
 
                 continue;

--- a/sources/SilkTouch/SilkTouch/Mods/StripAttributes.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/StripAttributes.cs
@@ -48,7 +48,7 @@ public class StripAttributes(IOptionsSnapshot<StripAttributes.Configuration> cfg
             var doc =
                 proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             proj = doc.WithSyntaxRoot(
-                rewriter.Visit(await doc.GetSyntaxRootAsync(ct))?.NormalizeWhitespace()
+                rewriter.Visit(await doc.GetSyntaxRootAsync(ct))
                     ?? throw new InvalidOperationException("Visit returned null.")
             ).Project;
         }

--- a/sources/SilkTouch/SilkTouch/Mods/TransformEnums.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/TransformEnums.cs
@@ -190,7 +190,7 @@ public class TransformEnums(IOptionsSnapshot<TransformEnums.Configuration> cfg) 
             var doc =
                 proj.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             proj = doc.WithSyntaxRoot(
-                rewriter.Visit(await doc.GetSyntaxRootAsync(ct))?.NormalizeWhitespace()
+                rewriter.Visit(await doc.GetSyntaxRootAsync(ct))
                     ?? throw new InvalidOperationException("Visit returned null.")
             ).Project;
         }

--- a/sources/SilkTouch/SilkTouch/Mods/TransformFunctions.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/TransformFunctions.cs
@@ -60,7 +60,7 @@ public class TransformFunctions(FunctionTransformer ft) : ModCSharpSyntaxRewrite
                 proj!.GetDocument(docId) ?? throw new InvalidOperationException("Document missing");
             if (await doc.GetSyntaxRootAsync(ct) is { } root)
             {
-                proj = doc.WithSyntaxRoot(Visit(root).NormalizeWhitespace()).Project;
+                proj = doc.WithSyntaxRoot(Visit(root)).Project;
             }
         }
 

--- a/sources/SilkTouch/SilkTouch/Mods/TransformHandles.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/TransformHandles.cs
@@ -86,8 +86,8 @@ public class TransformHandles(
             }
         }
 
-        // Do the two following transformation to all references of the handle types:
-        // 2. Reduce pointer dimensions
+        // Reduce pointer dimensions
+        // The -Handle suffix will be applied later by PrettifyNames if the user configures it to do so
         ctx.SourceProject = project;
         await LocationTransformationUtils.ModifyAllReferencesAsync(
             ctx,

--- a/sources/SilkTouch/SilkTouch/Mods/TransformHandles.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/TransformHandles.cs
@@ -115,9 +115,7 @@ public class TransformHandles(
             var syntaxRoot = await syntaxTree.GetRootAsync(ct);
 
             // Rewrite handle struct to include handle members
-            document = document.WithSyntaxRoot(
-                handleTypeRewriter.Visit(syntaxRoot).NormalizeWhitespace()
-            );
+            document = document.WithSyntaxRoot(handleTypeRewriter.Visit(syntaxRoot));
 
             project = document.Project;
         }

--- a/sources/SilkTouch/SilkTouch/Mods/TransformProperties.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/TransformProperties.cs
@@ -58,7 +58,7 @@ public class TransformProperties : IMod
                 && lit.IsKind(SyntaxKind.Utf8StringLiteralExpression)
             )
             {
-                node = node.WithType(IdentifierName("Utf8String")).NormalizeWhitespace();
+                node = node.WithType(IdentifierName("Utf8String"));
             }
 
             return base.VisitPropertyDeclaration(node);

--- a/sources/SilkTouch/SilkTouch/Mods/Transformation/FunctionTransformer.cs
+++ b/sources/SilkTouch/SilkTouch/Mods/Transformation/FunctionTransformer.cs
@@ -117,7 +117,6 @@ public class FunctionTransformer(
                         .WithBody(null)
                         .WithExpressionBody(null)
                         .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
-                        .NormalizeWhitespace(eol: "\n")
                         .ToFullString()
                 );
                 continue;

--- a/sources/SilkTouch/SilkTouch/Profiling/ProfilingScope.cs
+++ b/sources/SilkTouch/SilkTouch/Profiling/ProfilingScope.cs
@@ -10,21 +10,21 @@ namespace Silk.NET.SilkTouch.Profiling;
 /// </summary>
 internal readonly struct ProfilingScope : IDisposable
 {
-    private readonly string name;
-    private readonly long timestamp;
+    private readonly string _name;
+    private readonly long _timestamp;
 
     public ProfilingScope(string name)
     {
-        this.name = name;
-        timestamp = Stopwatch.GetTimestamp();
+        _name = name;
+        _timestamp = Stopwatch.GetTimestamp();
     }
 
     public void Dispose()
     {
-        var elapsed = Stopwatch.GetElapsedTime(timestamp);
+        var elapsed = Stopwatch.GetElapsedTime(_timestamp);
         Console.WriteLine(
             "Elapsed time for scope \"{0}\": {1:F3} ms",
-            name,
+            _name,
             elapsed.TotalMilliseconds
         );
     }

--- a/sources/SilkTouch/SilkTouch/Profiling/ProfilingScope.cs
+++ b/sources/SilkTouch/SilkTouch/Profiling/ProfilingScope.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Silk.NET.SilkTouch.Profiling;
+
+/// <summary>
+/// Lightweight way to profile a section of code.
+/// </summary>
+internal readonly struct ProfilingScope : IDisposable
+{
+    private readonly string name;
+    private readonly long timestamp;
+
+    public ProfilingScope(string name)
+    {
+        this.name = name;
+        timestamp = Stopwatch.GetTimestamp();
+    }
+
+    public void Dispose()
+    {
+        var elapsed = Stopwatch.GetElapsedTime(timestamp);
+        Console.WriteLine(
+            "Elapsed time for scope \"{0}\": {1:F3} ms",
+            name,
+            elapsed.TotalMilliseconds
+        );
+    }
+}


### PR DESCRIPTION
# Summary of the PR

This branch will be where I investigate performance improvements to the Silk 3.0 bindings generator.

# Related issues, Discord discussions, or proposals

Discord thread for discussing development: https://discord.com/channels/521092042781229087/1493337581805371432

# Further Comments

## Tasks

- ~~Update ClangSharp~~
   - Decision: Going to move this to https://github.com/dotnet/Silk.NET/pull/2570
   - This is because updating ClangSharp required updating SDL... and that caused further build problems
- [x] Optimize renamer
   - [x] Track relevant identifiers and only resolve symbols for relevant identifiers instead of for all identifiers
- [x] Optimize PrettifyNames
   - [x] Optimize document rename path conflict detection
- [x] Consider removing `NormalizeWhitespace` calls where possible
- [x] Investigate `ContainsAny` calls, particularly when called by `TryParseNativeTypeName`. This shows up as a hotspot during profiling.
   - Not worth optimizing (will improve only by ~100 ms and worsens code maintainability)
   - Also likely to not affect the Microsoft bindings 
- ~~Consider removing `ModCSharpSyntaxRewriter`~~
    - Moved to backlog (https://github.com/orgs/dotnet/projects/64/views/16?pane=issue&itemId=168550672)
- [x] Regenerate all bindings on Windows to ensure no changes