### PR TITLE
Fix SdlGamepad/SdlJoystick state going stale with no event subscribers

### DIFF
--- a/src/Input/Silk.NET.Input.Sdl/SdlGamepad.cs
+++ b/src/Input/Silk.NET.Input.Sdl/SdlGamepad.cs
@@ -128,14 +128,14 @@ namespace Silk.NET.Input.Sdl
                         }
                         case GameControllerAxis.ControllerAxisTriggerleft:
                         {
-                            TriggerMoved?.Invoke
-                                (this, _triggers[0] = new Trigger(0, (float) @event.Caxis.Value / short.MaxValue));
+                            var trigger0 = _triggers[0] = new Trigger(0, (float) @event.Caxis.Value / short.MaxValue);
+                            TriggerMoved?.Invoke(this, trigger0);
                             break;
                         }
                         case GameControllerAxis.ControllerAxisTriggerright:
                         {
-                            TriggerMoved?.Invoke
-                                (this, _triggers[1] = new Trigger(1, (float) @event.Caxis.Value / short.MaxValue));
+                            var trigger1 = _triggers[1] = new Trigger(1, (float) @event.Caxis.Value / short.MaxValue);
+                            TriggerMoved?.Invoke(this, trigger1);
                             break;
                         }
                     }
@@ -145,15 +145,15 @@ namespace Silk.NET.Input.Sdl
                 case EventType.Controllerbuttondown:
                 {
                     var ogBtn = _buttons[@event.Cbutton.Button];
-                    ButtonDown?.Invoke
-                        (this, _buttons[@event.Cbutton.Button] = new Button(ogBtn.Name, ogBtn.Index, true));
+                    var newBtn = _buttons[@event.Cbutton.Button] = new Button(ogBtn.Name, ogBtn.Index, true);
+                    ButtonDown?.Invoke(this, newBtn);
                     break;
                 }
                 case EventType.Controllerbuttonup:
                 {
                     var ogBtn = _buttons[@event.Cbutton.Button];
-                    ButtonUp?.Invoke
-                        (this, _buttons[@event.Cbutton.Button] = new Button(ogBtn.Name, ogBtn.Index, false));
+                    var newBtn = _buttons[@event.Cbutton.Button] = new Button(ogBtn.Name, ogBtn.Index, false);
+                    ButtonUp?.Invoke(this, newBtn);
                     break;
                 }
                 case EventType.Controllerdeviceadded:

--- a/src/Input/Silk.NET.Input.Sdl/SdlGamepad.cs
+++ b/src/Input/Silk.NET.Input.Sdl/SdlGamepad.cs
@@ -128,14 +128,14 @@ namespace Silk.NET.Input.Sdl
                         }
                         case GameControllerAxis.ControllerAxisTriggerleft:
                         {
-                            var trigger0 = _triggers[0] = new Trigger(0, (float) @event.Caxis.Value / short.MaxValue);
-                            TriggerMoved?.Invoke(this, trigger0);
+                            _triggers[0] = new Trigger(0, (float) @event.Caxis.Value / short.MaxValue);
+                            TriggerMoved?.Invoke(this, _triggers[0]);
                             break;
                         }
                         case GameControllerAxis.ControllerAxisTriggerright:
                         {
-                            var trigger1 = _triggers[1] = new Trigger(1, (float) @event.Caxis.Value / short.MaxValue);
-                            TriggerMoved?.Invoke(this, trigger1);
+                            _triggers[1] = new Trigger(1, (float) @event.Caxis.Value / short.MaxValue);
+                            TriggerMoved?.Invoke(this, _triggers[1]);
                             break;
                         }
                     }
@@ -145,15 +145,15 @@ namespace Silk.NET.Input.Sdl
                 case EventType.Controllerbuttondown:
                 {
                     var ogBtn = _buttons[@event.Cbutton.Button];
-                    var newBtn = _buttons[@event.Cbutton.Button] = new Button(ogBtn.Name, ogBtn.Index, true);
-                    ButtonDown?.Invoke(this, newBtn);
+                    _buttons[@event.Cbutton.Button] = new Button(ogBtn.Name, ogBtn.Index, true);
+                    ButtonDown?.Invoke(this, _buttons[@event.Cbutton.Button]);
                     break;
                 }
                 case EventType.Controllerbuttonup:
                 {
                     var ogBtn = _buttons[@event.Cbutton.Button];
-                    var newBtn = _buttons[@event.Cbutton.Button] = new Button(ogBtn.Name, ogBtn.Index, false);
-                    ButtonUp?.Invoke(this, newBtn);
+                    _buttons[@event.Cbutton.Button] = new Button(ogBtn.Name, ogBtn.Index, false);
+                    ButtonUp?.Invoke(this, _buttons[@event.Cbutton.Button]);
                     break;
                 }
                 case EventType.Controllerdeviceadded:

--- a/src/Input/Silk.NET.Input.Sdl/SdlJoystick.cs
+++ b/src/Input/Silk.NET.Input.Sdl/SdlJoystick.cs
@@ -52,12 +52,9 @@ namespace Silk.NET.Input.Sdl
                         Array.Resize(ref _axes, @event.Jaxis.Axis + 1);
                     }
 
-                    AxisMoved?.Invoke
-                    (
-                        this,
-                        _axes[@event.Jaxis.Axis] = new Axis
-                            (@event.Jaxis.Axis, (float) @event.Jaxis.Value / short.MaxValue)
-                    );
+                    _axes[@event.Jaxis.Axis] = new Axis
+                        (@event.Jaxis.Axis, (float) @event.Jaxis.Value / short.MaxValue);
+                    AxisMoved?.Invoke(this, _axes[@event.Jaxis.Axis]);
                     break;
                 }
                 case EventType.Joyballmotion:
@@ -73,17 +70,14 @@ namespace Silk.NET.Input.Sdl
                     }
 
                     var val = @event.Jhat.Value;
-                    HatMoved?.Invoke
+                    _hats[@event.Jhat.Hat] = new Hat
                     (
-                        this,
-                        _hats[@event.Jhat.Hat] = new Hat
-                        (
-                            @event.Jhat.Hat, (Position2D) ((val & 0x01) * (int) Position2D.Up +
-                                                           (val & 0x02) * (int) Position2D.Right +
-                                                           (val & 0x04) * (int) Position2D.Down +
-                                                           (val & 0x08) * (int) Position2D.Left)
-                        )
+                        @event.Jhat.Hat, (Position2D) ((val & 0x01) * (int) Position2D.Up +
+                                                       (val & 0x02) * (int) Position2D.Right +
+                                                       (val & 0x04) * (int) Position2D.Down +
+                                                       (val & 0x08) * (int) Position2D.Left)
                     );
+                    HatMoved?.Invoke(this, _hats[@event.Jhat.Hat]);
                     break;
                 }
                 case EventType.Joybuttondown:
@@ -93,12 +87,9 @@ namespace Silk.NET.Input.Sdl
                         Array.Resize(ref _buttons, @event.Jbutton.Button + 1);
                     }
 
-                    ButtonDown?.Invoke
-                    (
-                        this,
-                        _buttons[@event.Jbutton.Button] = new Button
-                            ((ButtonName) @event.Jbutton.Button, @event.Jbutton.Button, true)
-                    );
+                    _buttons[@event.Jbutton.Button] = new Button
+                        ((ButtonName) @event.Jbutton.Button, @event.Jbutton.Button, true);
+                    ButtonDown?.Invoke(this, _buttons[@event.Jbutton.Button]);
                     break;
                 }
                 case EventType.Joybuttonup:
@@ -108,12 +99,9 @@ namespace Silk.NET.Input.Sdl
                         Array.Resize(ref _buttons, @event.Jbutton.Button + 1);
                     }
 
-                    ButtonUp?.Invoke
-                    (
-                        this,
-                        _buttons[@event.Jbutton.Button] = new Button
-                            ((ButtonName) @event.Jbutton.Button, @event.Jbutton.Button, false)
-                    );
+                    _buttons[@event.Jbutton.Button] = new Button
+                        ((ButtonName) @event.Jbutton.Button, @event.Jbutton.Button, false);
+                    ButtonUp?.Invoke(this, _buttons[@event.Jbutton.Button]);
                     break;
                 }
                 case EventType.Joydeviceadded:


### PR DESCRIPTION
Fixes #2604

SdlGamepad and SdlJoystick's button/axis/trigger/hat handlers wrote the internal state array update as a side effect inside the argument list of the `?.Invoke(...)` call for their change events (`ButtonDown`, `ButtonUp`, `TriggerMoved` on SdlGamepad; `AxisMoved`, `HatMoved`, `ButtonDown`, `ButtonUp` on SdlJoystick). C#'s null-conditional operator short-circuits the whole call, including evaluating the arguments, when the event has no subscribers. So if nobody's subscribed to those events, the array never actually gets updated, and polling the corresponding state (`Buttons`, `Triggers`, `Axes`, `Hats`) reads permanently stale data even with real input on the device.

ThumbstickMoved on SdlGamepad already did this correctly (array assignment as its own statement before the event fires), so this brings the rest in line with that same shape.

Full writeup, repro steps, and confirmation this affects the latest release/main (but not GlfwGamepad, which rewrites state unconditionally every frame) are in #2604.
